### PR TITLE
Make quic_api works better on communicating with MsQuic

### DIFF
--- a/src/mqtt/protocol/mqtt/mqtt_quic.c
+++ b/src/mqtt/protocol/mqtt/mqtt_quic.c
@@ -802,6 +802,7 @@ mqtt_quic_sock_recv(void *arg, nni_aio *aio)
 static int
 quic_mqtt_stream_init(void *arg,nni_pipe *qstrm, void *sock)
 {
+	nni_plat_printf("quic_mqtt_stream_init.\n");
 	mqtt_pipe_t *p = arg;
 	p->qstream = qstrm;
 	p->mqtt_sock = sock;

--- a/src/mqtt/protocol/mqtt/mqtt_quic.c
+++ b/src/mqtt/protocol/mqtt/mqtt_quic.c
@@ -802,7 +802,6 @@ mqtt_quic_sock_recv(void *arg, nni_aio *aio)
 static int
 quic_mqtt_stream_init(void *arg,nni_pipe *qstrm, void *sock)
 {
-	nni_plat_printf("quic_mqtt_stream_init.\n");
 	mqtt_pipe_t *p = arg;
 	p->qstream = qstrm;
 	p->mqtt_sock = sock;

--- a/src/supplemental/quic/quic_api.c
+++ b/src/supplemental/quic/quic_api.c
@@ -892,13 +892,14 @@ quic_strm_recv(void *arg, nni_aio *raio)
 	int                rv;
 
 	if (nni_aio_begin(raio) != 0) {
-		return;
+		return -1;
 	}
 	nni_mtx_lock(&qstrm->mtx);
 	if ((rv = nni_aio_schedule(raio, mqtt_quic_strm_recv_cancel, qstrm)) !=
 	    0) {
+		nni_mtx_unlock(&qstrm->mtx);
 		nni_aio_finish_error(raio, rv);
-		return;
+		return 0;
 	}
 
 	nni_list_append(&qstrm->recvq, raio);

--- a/src/supplemental/quic/quic_api.c
+++ b/src/supplemental/quic/quic_api.c
@@ -14,8 +14,8 @@
 #include <time.h>
 #include <unistd.h>
 
-#define QUIC_API_C_DEBUG 1
-#define QUIC_API_C_INFO 1
+#define QUIC_API_C_DEBUG 0
+#define QUIC_API_C_INFO 0
 
 #if QUIC_API_C_DEBUG
 #define qdebug(fmt, ...)                                                 \
@@ -403,6 +403,8 @@ quic_strm_start(HQUIC Connection, void *Context, HQUIC *Streamp, bool active)
 {
 	HQUIC       Stream = NULL;
 	QUIC_STATUS Status;
+
+	NNI_ARG_UNUSED(active);
 
 	// Create/allocate a new bidirectional stream. The stream is just
 	// allocated and no QUIC stream identifier is assigned until it's
@@ -969,8 +971,8 @@ quic_strm_send(void *arg, nni_aio *aio)
 	quic_strm_t *qstrm = arg;
 	int          rv;
 
-	if (nni_aio_begin(aio) != 0) {
-		return;
+	if ((rv = nni_aio_begin(aio)) != 0) {
+		return rv;
 	}
 	nni_mtx_lock(&qstrm->mtx);
 	if ((rv = nni_aio_schedule(aio, quic_strm_send_cancel, qstrm)) != 0) {
@@ -997,11 +999,15 @@ quic_alloc()
 int
 nni_msquic_dialer_alloc(nng_stream_dialer **dp, const nng_url *url)
 {
+	NNI_ARG_UNUSED(dp);
+	NNI_ARG_UNUSED(url);
 	return 0;
 }
 
 int
 nni_msquic_listener_alloc(nng_stream_listener **lp, const nng_url *url)
 {
+	NNI_ARG_UNUSED(lp);
+	NNI_ARG_UNUSED(url);
 	return 0;
 }

--- a/src/supplemental/quic/quic_api.c
+++ b/src/supplemental/quic/quic_api.c
@@ -14,7 +14,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#define QUIC_API_C_DEBUG 1
+#define QUIC_API_C_DEBUG 0
 #define QUIC_API_C_INFO 0
 
 #if QUIC_API_C_DEBUG
@@ -720,7 +720,8 @@ quic_strm_recv_cb(void *arg)
 	nni_aio *aio = NULL;
 
 	qdebug("before rxlen %d rwlen %d.\n", qstrm->rxlen, qstrm->rwlen);
-	qdebug("rrpos %d rrlen %d rrbuf %x %x.\n", qstrm->rrpos, qstrm->rrlen, qstrm->rrbuf[qstrm->rrpos], qstrm->rrbuf[qstrm->rrpos + 1]);
+	qdebug("rrpos %d rrlen %d rrbuf %x %x.\n", qstrm->rrpos, qstrm->rrlen,
+	    qstrm->rrbuf[qstrm->rrpos], qstrm->rrbuf[qstrm->rrpos + 1]);
 
 	uint8_t  usedbytes;
 	uint8_t *rbuf = qstrm->rrbuf + qstrm->rrpos;


### PR DESCRIPTION
1. Fix the pending error in quic_api when communicating with MsQuic.
2. Using an extra buffer to store remaining Event->RECEIVE.Buffer in MsQuic.
3. Better mode to receive data (recv_start and recv_cb)