### PR TITLE
Fix a dead lock in dbtree_delete_retain in mqtt_db.c

### DIFF
--- a/src/supplemental/nanolib/mqtt_db.c
+++ b/src/supplemental/nanolib/mqtt_db.c
@@ -1303,13 +1303,12 @@ dbtree_delete_retain(dbtree *db, char *topic)
 		// dbtree_print(dbtree);
 	}
 
-	nni_rwlock_unlock(&(db->rwlock));
-
 mem_free:
 	cvector_free(node_buf);
 	topic_queue_free(for_free);
 	cvector_free(vec);
-
+	nni_rwlock_unlock(&(db->rwlock));
+	
 	return ret;
 }
 


### PR DESCRIPTION
To prevent the dead lock in dbtree_delete_retain, call nni_rwlock_unlock after mem_free instead of before mem_free (referring to the correct implementation in dbtree_delete_client).

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
