### PR TITLE
Wangha/fix

### DIFF
--- a/src/supplemental/mqtt/mqtt_msg.c
+++ b/src/supplemental/mqtt/mqtt_msg.c
@@ -829,8 +829,7 @@ void
 nni_mqtt_topic_qos_array_set(nni_mqtt_topic_qos *topic_qos, size_t index,
     const char *topic_name, uint32_t len, uint8_t qos, uint8_t nl, uint8_t rap, uint8_t rh)
 {
-	topic_qos[index].topic.buf       = (uint8_t *) nni_alloc(len * sizeof(uint8_t));
-	memcpy(topic_qos[index].topic.buf, topic_name, len);
+	topic_qos[index].topic.buf       = strdup(topic_name);
 	topic_qos[index].topic.length    = len;
 	topic_qos[index].qos             = qos;
 	topic_qos[index].nolocal         = nl;

--- a/src/supplemental/nanolib/log.c
+++ b/src/supplemental/nanolib/log.c
@@ -202,10 +202,12 @@ file_rotation(FILE *fp, conf_log *config)
 		char * index_data = NULL;
 		size_t size       = 0;
 		size_t index      = 1;
+		char   buf[4]     = { 0 };
 
 		if ((rv = nni_plat_file_get(
 		         index_file, (void **) &index_data, &size)) == 0) {
-			if (1 != sscanf(index_data, "%zu", &index)) {
+			memcpy(buf, index_data, size);
+			if (1 != sscanf(buf, "%zu", &index)) {
 				index = 1;
 			}
 			nni_free(index_data, size);


### PR DESCRIPTION
The error is as follows.

```
(lldb) r
Process 16519 launched: '/Users/wangha/Documents/Git/nanomq/build/nanomq/nanomq' (arm64)
2023-04-03 18:30:03.174759+0800 nanomq[16519:9542415] [si_destination_compare] send failed: Invalid argument
2023-04-03 18:30:03.174978+0800 nanomq[16519:9542415] [si_destination_compare] send failed: Undefined error: 0
2023-04-03 18:30:46 [16519] WARN  /Users/wangha/Documents/Git/nanomq/nng/src/sp/transport/mqtt/broker_tcp.c:609  tcptran_pipe_recv_cb: nni aio recv error!! Connection shutdown

=================================================================
==16519==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x00010300fdf1 at pc 0x0001007b8088 bp 0x0001701cd930 sp 0x0001701cd0f0
READ of size 2 at 0x00010300fdf1 thread T7
    #0 0x1007b8084 in wrap_strlen+0x164 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x18084) (BuildId: 112043985f03370ebc205328b62c210a32000000200000000100000000000b00)
    #1 0x186443b8c in vsscanf_l+0xa0 (libsystem_c.dylib:arm64e+0xab8c) (BuildId: 14cd841b0c7b34a2a342cc6796ef925932000000200000000100000000020d00)
    #2 0x1007c0778 in wrap_sscanf+0x7c (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x20778) (BuildId: 112043985f03370ebc205328b62c210a32000000200000000100000000000b00)
    #3 0x1002619c8 in file_rotation log.c:208
    #4 0x1002601fc in file_callback log.c:88
    #5 0x1002610b0 in log_log log.c:288
    #6 0x10014ac1c in tcptran_pipe_recv_cb broker_tcp.c:609
    #7 0x1000a2d00 in nni_taskq_thread taskq.c:50
    #8 0x1000a77c0 in nni_thr_wrap thread.c:94
    #9 0x1000c93bc in nni_plat_thr_main posix_thread.c:266
    #10 0x18657a068 in _pthread_start+0x90 (libsystem_pthread.dylib:arm64e+0x7068) (BuildId: 9f3b729aed043e65adacd75ad06ebbdc32000000200000000100000000020d00)
    #11 0x186574e28 in thread_start+0x4 (libsystem_pthread.dylib:arm64e+0x1e28) (BuildId: 9f3b729aed043e65adacd75ad06ebbdc32000000200000000100000000020d00)

0x00010300fdf1 is located 0 bytes to the right of 1-byte region [0x00010300fdf0,0x00010300fdf1)
allocated by thread T7 here:
    #0 0x1007e2e68 in wrap_malloc+0x94 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x42e68) (BuildId: 112043985f03370ebc205328b62c210a32000000200000000100000000000b00)
    #1 0x1000ae1f4 in nni_alloc posix_alloc.c:20
    #2 0x1000b0768 in nni_plat_file_get posix_file.c:119
    #3 0x100261960 in file_rotation log.c:206
    #4 0x1002601fc in file_callback log.c:88
    #5 0x1002610b0 in log_log log.c:288
    #6 0x10014ac1c in tcptran_pipe_recv_cb broker_tcp.c:609
    #7 0x1000a2d00 in nni_taskq_thread taskq.c:50
    #8 0x1000a77c0 in nni_thr_wrap thread.c:94
    #9 0x1000c93bc in nni_plat_thr_main posix_thread.c:266
    #10 0x18657a068 in _pthread_start+0x90 (libsystem_pthread.dylib:arm64e+0x7068) (BuildId: 9f3b729aed043e65adacd75ad06ebbdc32000000200000000100000000020d00)
    #11 0x186574e28 in thread_start+0x4 (libsystem_pthread.dylib:arm64e+0x1e28) (BuildId: 9f3b729aed043e65adacd75ad06ebbdc32000000200000000100000000020d00)

Thread T7 created by T0 here:
    #0 0x1007dcd2c in wrap_pthread_create+0x54 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x3cd2c) (BuildId: 112043985f03370ebc205328b62c210a32000000200000000100000000000b00)
    #1 0x1000c90a0 in nni_plat_thr_init posix_thread.c:279
    #2 0x1000a7438 in nni_thr_init thread.c:121
    #3 0x1000a2968 in nni_taskq_init taskq.c:95
    #4 0x1000a4180 in nni_taskq_sys_init taskq.c:294
    #5 0x10007a860 in nni_init_helper init.c:35
    #6 0x1000c9884 in nni_plat_init posix_thread.c:422
    #7 0x10007a848 in nni_init init.c:58
    #8 0x100182fd8 in nng_mtx_alloc platform.c:93
    #9 0x100003bf4 in log_init mqtt_api.c:223
    #10 0x10004b1dc in broker_start broker.c:1592
    #11 0x100004640 in main nanomq.c:142
    #12 0x18624fe4c  (<unknown module>)

SUMMARY: AddressSanitizer: heap-buffer-overflow (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x18084) (BuildId: 112043985f03370ebc205328b62c210a32000000200000000100000000000b00) in wrap_strlen+0x164
Shadow bytes around the buggy address:
  0x007020621f60: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x007020621f70: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x007020621f80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x007020621f90: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x007020621fa0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x007020621fb0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa[01]fa
  0x007020621fc0: fa fa 00 03 fa fa fd fa fa fa fd fd fa fa fd fa
  0x007020621fd0: fa fa fd fa fa fa 00 fa fa fa 00 fa fa fa 00 fa
  0x007020621fe0: fa fa 00 fa fa fa 04 fa fa fa 00 fa fa fa 00 03
  0x007020621ff0: fa fa 00 00 fa fa 05 fa fa fa fa fa fa fa fa fa
  0x007020622000: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
```
