### PR TITLE
* Fix [conf_ver2.c] Clean up the log callback when the configuration …

### DIFF
--- a/src/supplemental/nanolib/conf_ver2.c
+++ b/src/supplemental/nanolib/conf_ver2.c
@@ -1205,6 +1205,7 @@ conf_parse_ver2(conf *config)
 			log_error("Configure file [%s] or [%s] not found or "
 			          "unreadable",
 			    conf_path, CONF_PATH_NAME);
+			log_clear_callback();
 			return;
 		} else {
 			conf_path = CONF_PATH_NAME;


### PR DESCRIPTION
Fixes #596 

Normally, nanomq starts with a log_callback with log_level warning and executes log_clear_callback after parsing the configuration file. Clean up the callback with log_level warning and add a new log_callback.

But when a log_level parameter is passed(like --log_level=trace) and the configuration file is not found, it does not clean up the log_callback, which leads to duplicate log_callbacks, and eventually duplicate printing problems.
