### PR TITLE
Fix the data race in pipe and qos msg in mqtt quic proto layer

### DIFF
--- a/src/mqtt/protocol/mqtt/mqtt_quic.c
+++ b/src/mqtt/protocol/mqtt/mqtt_quic.c
@@ -580,13 +580,14 @@ mqtt_quic_send_cb(void *arg)
 {
 	mqtt_pipe_t *p   = arg;
 	mqtt_sock_t *s   = p->mqtt_sock;
-	nni_msg *    msg = NULL;
-	nni_aio * aio;
+	nni_msg     *msg = NULL;
+	nni_aio     *aio;
+	int          rv;
 
 	if (nni_aio_result(&p->send_aio) != 0) {
 		// We failed to send... clean up and deal with it.
 		log_warn("fail to send on aio");
-		nni_msg_free(nni_aio_get_msg(&p->send_aio));
+		// msg is already be freed in QUIC transport
 		nni_aio_set_msg(&p->send_aio, NULL);
 		return;
 	}

--- a/src/mqtt/protocol/mqtt/mqtt_quic.c
+++ b/src/mqtt/protocol/mqtt/mqtt_quic.c
@@ -1158,12 +1158,14 @@ static void
 mqtt_timer_cb(void *arg)
 {
 	mqtt_sock_t *s = arg;
-	mqtt_pipe_t *p = s->pipe;
+	mqtt_pipe_t *p;
 
 	if (nng_aio_result(&s->time_aio) != 0) {
 		return;
 	}
 	nni_mtx_lock(&s->mtx);
+
+	p = s->pipe;
 
 	if (NULL == p || nni_atomic_get_bool(&p->closed)) {
 		// QUIC connection has been shut down

--- a/src/mqtt/protocol/mqtt/mqtt_quic.c
+++ b/src/mqtt/protocol/mqtt/mqtt_quic.c
@@ -539,7 +539,7 @@ mqtt_quic_data_strm_send_cb(void *arg)
 	if (nni_aio_result(&p->send_aio) != 0) {
 		// We failed to send... clean up and deal with it.
 		p->busy = false;
-		nni_msg_free(nni_aio_get_msg(&p->send_aio));
+		// nni_msg_free(nni_aio_get_msg(&p->send_aio));
 		nni_aio_set_msg(&p->send_aio, NULL);
 		return;
 	}

--- a/src/mqtt/protocol/mqtt/mqtt_quic.c
+++ b/src/mqtt/protocol/mqtt/mqtt_quic.c
@@ -1736,7 +1736,7 @@ mqtt_quic_ctx_send(void *arg, nni_aio *aio)
 {
 	mqtt_quic_ctx *ctx = arg;
 	mqtt_sock_t   *s   = ctx->mqtt_sock;
-	mqtt_pipe_t   *p   = s->pipe;
+	mqtt_pipe_t   *p;
 	nni_msg       *msg;
 	uint16_t       packet_id;
 	uint8_t        qos;
@@ -1747,6 +1747,7 @@ mqtt_quic_ctx_send(void *arg, nni_aio *aio)
 	}
 
 	nni_mtx_lock(&s->mtx);
+	p = s->pipe;
 
 	msg = nni_aio_get_msg(aio);
 	if (msg == NULL) {
@@ -1849,15 +1850,16 @@ static void
 mqtt_quic_ctx_recv(void *arg, nni_aio *aio)
 {
 	mqtt_quic_ctx *ctx = arg;
-	mqtt_sock_t *s   = ctx->mqtt_sock;
-	mqtt_pipe_t *p   = s->pipe;
-	nni_msg     *msg = NULL;
+	mqtt_sock_t   *s   = ctx->mqtt_sock;
+	mqtt_pipe_t   *p;
+	nni_msg       *msg = NULL;
 
 	if (nni_aio_begin(aio) != 0) {
 		return;
 	}
 
 	nni_mtx_lock(&s->mtx);
+	p = s->pipe;
 	// TODO Should socket is closed be check first?
 	if (p == NULL) {
 		goto wait;

--- a/src/mqtt/protocol/mqtt/mqttv5_quic.c
+++ b/src/mqtt/protocol/mqtt/mqttv5_quic.c
@@ -1730,7 +1730,7 @@ mqtt_quic_ctx_send(void *arg, nni_aio *aio)
 {
 	mqtt_quic_ctx *ctx = arg;
 	mqtt_sock_t   *s   = ctx->mqtt_sock;
-	mqtt_pipe_t   *p   = s->pipe;
+	mqtt_pipe_t   *p;
 	nni_msg       *msg;
 	uint16_t       packet_id;
 	uint8_t        qos;
@@ -1741,6 +1741,7 @@ mqtt_quic_ctx_send(void *arg, nni_aio *aio)
 	}
 
 	nni_mtx_lock(&s->mtx);
+	p = s->pipe;
 
 	msg = nni_aio_get_msg(aio);
 	if (msg == NULL) {
@@ -1843,8 +1844,8 @@ static void
 mqtt_quic_ctx_recv(void *arg, nni_aio *aio)
 {
 	mqtt_quic_ctx *ctx = arg;
-	mqtt_sock_t *s   = ctx->mqtt_sock;
-	mqtt_pipe_t *p   = s->pipe;
+	mqtt_sock_t *s     = ctx->mqtt_sock;
+	mqtt_pipe_t *p;
 	nni_msg     *msg = NULL;
 
 	if (nni_aio_begin(aio) != 0) {
@@ -1852,6 +1853,7 @@ mqtt_quic_ctx_recv(void *arg, nni_aio *aio)
 	}
 
 	nni_mtx_lock(&s->mtx);
+	p = s->pipe;
 	// TODO Should socket is closed be check first?
 	if (p == NULL) {
 		goto wait;

--- a/src/mqtt/protocol/mqtt/mqttv5_quic.c
+++ b/src/mqtt/protocol/mqtt/mqttv5_quic.c
@@ -1163,13 +1163,14 @@ static void
 mqtt_timer_cb(void *arg)
 {
 	mqtt_sock_t *s = arg;
-	mqtt_pipe_t *p = s->pipe;
+	mqtt_pipe_t *p;
 
 	if (nng_aio_result(&s->time_aio) != 0) {
 		return;
 	}
 	nni_mtx_lock(&s->mtx);
 
+	p = s->pipe;
 	if (NULL == p || nni_atomic_get_bool(&p->closed)) {
 		// QUIC connection has been shut down
 		nni_mtx_unlock(&s->mtx);

--- a/src/mqtt/protocol/mqtt/mqttv5_quic.c
+++ b/src/mqtt/protocol/mqtt/mqttv5_quic.c
@@ -542,7 +542,7 @@ mqtt_quic_data_strm_send_cb(void *arg)
 	if (nni_aio_result(&p->send_aio) != 0) {
 		// We failed to send... clean up and deal with it.
 		p->busy = false;
-		nni_msg_free(nni_aio_get_msg(&p->send_aio));
+		// nni_msg_free(nni_aio_get_msg(&p->send_aio));
 		nni_aio_set_msg(&p->send_aio, NULL);
 		return;
 	}

--- a/src/mqtt/protocol/mqtt/mqttv5_quic.c
+++ b/src/mqtt/protocol/mqtt/mqttv5_quic.c
@@ -583,13 +583,14 @@ mqtt_quic_send_cb(void *arg)
 {
 	mqtt_pipe_t *p   = arg;
 	mqtt_sock_t *s   = p->mqtt_sock;
-	nni_msg *    msg = NULL;
-	nni_aio * aio;
+	nni_msg     *msg = NULL;
+	nni_aio     *aio;
+	int          rv;
 
-	if (nni_aio_result(&p->send_aio) != 0) {
+	if ((rv = nni_aio_result(&p->send_aio)) != 0) {
 		// We failed to send... clean up and deal with it.
-		log_warn("fail to send on aio");
-		nni_msg_free(nni_aio_get_msg(&p->send_aio));
+		log_warn("fail to send msg %d", rv);
+		// msg is already be freed in QUIC transport
 		nni_aio_set_msg(&p->send_aio, NULL);
 		return;
 	}

--- a/src/supplemental/quic/quic_api.c
+++ b/src/supplemental/quic/quic_api.c
@@ -990,6 +990,7 @@ quic_pipe_send_start(quic_strm_t *qstrm)
 			nni_list_remove(&qstrm->sendq, aio);
 			msg = nni_aio_get_msg(aio);
 			nni_msg_free(msg);
+			nni_aio_set_msg(aio, NULL);
 			nni_aio_finish_error(aio, NNG_ECLOSED);
 		}
 		return;
@@ -1421,6 +1422,7 @@ quic_pipe_close(void *qpipe, uint8_t *code)
 		nni_list_remove(&qstrm->sendq, aio);
 		nni_msg *msg = nni_aio_get_msg(aio);
 		nni_msg_free(msg);
+		nni_aio_set_msg(aio, NULL);
 		nni_aio_finish_error(aio, NNG_ECLOSED);
 	}
 	while ((aio = nni_list_first(&qstrm->recvq)) != NULL) {


### PR DESCRIPTION
* Fix https://github.com/nanomq/NanoNNG/issues/601
* Fix the data race in socket->pipe in mqtt quic proto layer.
* Fix the double free in qos msg for mqtt over quic.

