### PR TITLE
* FIX [mqtt_parser] Error return is not performed when the username o…

### DIFF
--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -700,7 +700,7 @@ conn_handler(uint8_t *packet, conn_param *cparam, size_t max)
 		cparam->username.body =
 		    (char *) copyn_utf8_str(packet, &pos, &len_of_str, max-pos);
 		cparam->username.len = len_of_str;
-		rv                   = len_of_str <= 0 ? PAYLOAD_FORMAT_INVALID : 0;
+		rv                   = len_of_str < 0 ? PAYLOAD_FORMAT_INVALID : 0;
 		if (rv != 0) {
 			return rv;
 		}
@@ -713,7 +713,7 @@ conn_handler(uint8_t *packet, conn_param *cparam, size_t max)
 		cparam->password.body =
 		    copyn_utf8_str(packet, &pos, &len_of_str, max-pos);
 		cparam->password.len = len_of_str;
-		rv                   = len_of_str <= 0 ? PAYLOAD_FORMAT_INVALID : 0;
+		rv                   = len_of_str < 0 ? PAYLOAD_FORMAT_INVALID : 0;
 		if (rv != 0) {
 			log_warn("MQTT Packet parsing error!");
 			return rv;


### PR DESCRIPTION
EMQX websocket client set 0x80 and 0x40 in conn_flag, but no username or password is seted. Which will cause emqx show connected then disconnected soon.

fixes https://github.com/emqx/nanomq/issues/1420
