### PR TITLE
Fix QUIC

### DIFF
--- a/src/mqtt/protocol/mqtt/mqtt_quic_client.c
+++ b/src/mqtt/protocol/mqtt/mqtt_quic_client.c
@@ -1612,6 +1612,13 @@ quic_mqtt_pipe_fini(void *arg)
 		// there should be no msg waiting
 		count++;
 	}
+	if (count == 0) {
+		log_warn("disconnect msg of bridging is lost due to no ctx "
+		            "on receving");
+		nni_msg_free(tmsg);
+		conn_param_free(p->cparam);
+	}
+
 	while ((aio = nni_list_first(&s->send_queue)) != NULL) {
 		nni_list_remove(&s->send_queue, aio);
 		msg = nni_aio_get_msg(aio);

--- a/src/mqtt/protocol/mqtt/mqtt_quic_client.c
+++ b/src/mqtt/protocol/mqtt/mqtt_quic_client.c
@@ -332,6 +332,7 @@ mqtt_send_msg(nni_aio *aio, nni_msg *msg, mqtt_sock_t *s)
 	ptype = nni_mqtt_msg_get_packet_type(msg);
 	switch (ptype) {
 	case NNG_MQTT_CONNECT:
+	case NNG_MQTT_DISCONNECT:
 		// impossible to reach here
 	case NNG_MQTT_PUBACK:
 	case NNG_MQTT_PUBREC:
@@ -386,6 +387,7 @@ mqtt_send_msg(nni_aio *aio, nni_msg *msg, mqtt_sock_t *s)
 		}
 		break;
 	default:
+		log_error("Undefined type");
 		return NNG_EPROTO;
 	}
 	if (s->qos_first)

--- a/src/mqtt/protocol/mqtt/mqtt_quic_client.c
+++ b/src/mqtt/protocol/mqtt/mqtt_quic_client.c
@@ -1683,15 +1683,12 @@ quic_mqtt_pipe_stop(void *arg)
 
 	log_info("Stopping MQTT over QUIC Stream");
 	if (!nni_atomic_get_bool(&p->closed)) {
-		// if (quic_pipe_close(p->qpipe, &p->reason_code) == 0) {
 			nni_aio_stop(&p->send_aio);
 			nni_aio_stop(&p->recv_aio);
 			nni_aio_abort(&p->rep_aio, NNG_ECANCELED);
 			nni_aio_finish_error(&p->rep_aio, NNG_ECANCELED);
 			nni_aio_stop(&p->rep_aio);
-			// nni_aio_stop(&s->time_aio);
-		// }
-		}
+	}
 	if (p != s->pipe) {
 		// close & finit data stream
 		log_warn("close data stream of topic");

--- a/src/mqtt/protocol/mqtt/mqtt_quic_client.c
+++ b/src/mqtt/protocol/mqtt/mqtt_quic_client.c
@@ -1384,7 +1384,6 @@ mqtt_quic_sock_close(void *arg)
 
 	nni_mtx_lock(&s->mtx);
 	nni_sock_hold(s->nsock);
-	nni_aio_stop(&s->time_aio);
 	nni_aio_close(&s->time_aio);
 	nni_atomic_set_bool(&s->closed, true);
 
@@ -1683,11 +1682,12 @@ quic_mqtt_pipe_stop(void *arg)
 
 	log_info("Stopping MQTT over QUIC Stream");
 	if (!nni_atomic_get_bool(&p->closed)) {
-			nni_aio_stop(&p->send_aio);
-			nni_aio_stop(&p->recv_aio);
-			nni_aio_abort(&p->rep_aio, NNG_ECANCELED);
-			nni_aio_finish_error(&p->rep_aio, NNG_ECANCELED);
-			nni_aio_stop(&p->rep_aio);
+		nni_aio_stop(&p->send_aio);
+		nni_aio_stop(&p->recv_aio);
+		nni_aio_abort(&p->rep_aio, NNG_ECANCELED);
+		nni_aio_finish_error(&p->rep_aio, NNG_ECANCELED);
+		nni_aio_stop(&p->rep_aio);
+		nni_aio_stop(&s->time_aio);
 	}
 	if (p != s->pipe) {
 		// close & finit data stream

--- a/src/mqtt/protocol/mqtt/mqtt_quic_client.c
+++ b/src/mqtt/protocol/mqtt/mqtt_quic_client.c
@@ -332,8 +332,9 @@ mqtt_send_msg(nni_aio *aio, nni_msg *msg, mqtt_sock_t *s)
 	ptype = nni_mqtt_msg_get_packet_type(msg);
 	switch (ptype) {
 	case NNG_MQTT_CONNECT:
-	case NNG_MQTT_DISCONNECT:
 		// impossible to reach here
+
+	case NNG_MQTT_DISCONNECT:
 	case NNG_MQTT_PUBACK:
 	case NNG_MQTT_PUBREC:
 	case NNG_MQTT_PUBREL:

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -330,6 +330,11 @@ mqtt_msg_content_free(nni_mqtt_proto_data *mqtt)
 		if (mqtt->payload.connect.will_properties) {
 			property_free(mqtt->payload.connect.will_properties);
 		}
+		mqtt_buf_free(&mqtt->payload.connect.client_id);
+		mqtt_buf_free(&mqtt->payload.connect.password);
+		mqtt_buf_free(&mqtt->payload.connect.user_name);
+		mqtt_buf_free(&mqtt->payload.connect.will_msg);
+		mqtt_buf_free(&mqtt->payload.connect.will_topic);
 		break;
 	case NNG_MQTT_CONNACK:
 		if (mqtt->var_header.connack.properties) {

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -167,7 +167,6 @@ nni_mqtt_msg_encode(nni_msg *msg)
 				mqtt->initialized = true;
 				mqtt->is_copied   = true;
 			}
-			mqtt->is_copied  = true;
 			mqtt->is_decoded = false;
 			return codec_handler[i].encode(msg);
 		}
@@ -193,7 +192,6 @@ nni_mqttv5_msg_encode(nni_msg *msg)
 				mqtt->is_copied   = true;
 			}
 			mqtt->is_copied  = true;
-			mqtt->is_decoded = false;
 			return codec_v5_handler[i].encode(msg);
 		}
 	}

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -167,6 +167,7 @@ nni_mqtt_msg_encode(nni_msg *msg)
 				mqtt->initialized = true;
 				mqtt->is_copied   = true;
 			}
+			mqtt->is_copied  = true;
 			mqtt->is_decoded = false;
 			return codec_handler[i].encode(msg);
 		}
@@ -192,6 +193,7 @@ nni_mqttv5_msg_encode(nni_msg *msg)
 				mqtt->is_copied   = true;
 			}
 			mqtt->is_copied  = true;
+			mqtt->is_decoded = false;
 			return codec_v5_handler[i].encode(msg);
 		}
 	}
@@ -330,11 +332,6 @@ mqtt_msg_content_free(nni_mqtt_proto_data *mqtt)
 		if (mqtt->payload.connect.will_properties) {
 			property_free(mqtt->payload.connect.will_properties);
 		}
-		mqtt_buf_free(&mqtt->payload.connect.client_id);
-		mqtt_buf_free(&mqtt->payload.connect.password);
-		mqtt_buf_free(&mqtt->payload.connect.user_name);
-		mqtt_buf_free(&mqtt->payload.connect.will_msg);
-		mqtt_buf_free(&mqtt->payload.connect.will_topic);
 		break;
 	case NNG_MQTT_CONNACK:
 		if (mqtt->var_header.connack.properties) {

--- a/src/supplemental/quic/msquic_dial.c
+++ b/src/supplemental/quic/msquic_dial.c
@@ -362,7 +362,7 @@ nni_quic_dialer_close(void *arg)
 				c->dial_aio = NULL;
 				nni_aio_set_prov_data(aio, NULL);
 				nng_stream_close(&c->stream);
-				nng_stream_free(&c->stream);
+				// nng_stream_free(&c->stream);
 			}
 			nni_aio_finish_error(aio, NNG_ECLOSED);
 		}
@@ -448,11 +448,11 @@ quic_cb(int events, void *arg)
 
 		nni_mtx_unlock(&d->mtx);
 		break;
-	case QUIC_STREAM_EVENT_RECEIVE: // get a fin from stream
+	// case QUIC_STREAM_EVENT_RECEIVE: // get a fin from stream
 	// TODO Need more talk about those cases
 	// case QUIC_STREAM_EVENT_PEER_SEND_ABORTED:
 	// case QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN:
-	case QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE:
+	// case QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE:
 	case QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE:
 	// case QUIC_STREAM_EVENT_PEER_RECEIVE_ABORTED:
 		quic_error(arg, NNG_ECONNSHUT);
@@ -473,7 +473,7 @@ quic_fini(void *arg)
 		nni_msquic_quic_dialer_rele(c->dialer);
 	}
 	// have to wait msquic cb
-	NNI_FREE_STRUCT(c);
+	// NNI_FREE_STRUCT(c);
 }
 
 static nni_reap_list quic_reap_list = {
@@ -484,7 +484,8 @@ static void
 quic_free(void *arg)
 {
 	nni_quic_conn *c = arg;
-	nni_reap(&quic_reap_list, c);
+	NNI_FREE_STRUCT(c);
+	// nni_reap(&quic_reap_list, c);
 }
 
 // Notify upper layer that something happened.
@@ -994,7 +995,7 @@ msquic_strm_cb(_In_ HQUIC stream, _In_opt_ void *Context,
 	case QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE:
 		log_warn("[strm][%p] QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE.", stream);
 
-		quic_cb(QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE, c);
+		// quic_cb(QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE, c);
 		break;
 
 	case QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE:

--- a/src/supplemental/quic/msquic_dial.c
+++ b/src/supplemental/quic/msquic_dial.c
@@ -472,7 +472,7 @@ quic_fini(void *arg)
 		nni_msquic_quic_dialer_rele(c->dialer);
 	}
 	// have to wait msquic cb
-	// NNI_FREE_STRUCT(c);
+	NNI_FREE_STRUCT(c);
 }
 
 static nni_reap_list quic_reap_list = {
@@ -483,8 +483,7 @@ static void
 quic_stream_free(void *arg)
 {
 	nni_quic_conn *c = arg;
-	NNI_FREE_STRUCT(c);
-	// nni_reap(&quic_reap_list, c);
+	quic_fini(c);
 }
 
 // Notify upper layer that something happened.

--- a/src/supplemental/quic/msquic_dial.c
+++ b/src/supplemental/quic/msquic_dial.c
@@ -458,11 +458,10 @@ quic_stream_cb(int events, void *arg)
 	// case QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE:
 	case QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE:
 	// case QUIC_STREAM_EVENT_PEER_RECEIVE_ABORTED:
-		if (c->closed != true) {
-			msquic_strm_fini(c->qstrm);
-			// Marked it as closed, prevent explicit shutdown
-			c->closed = true;
-		}
+		// Marked it as closed, prevent explicit shutdown
+		c->closed = true;
+		// It's the only place to free msquic stream
+		msquic_strm_fini(c->qstrm);
 		quic_stream_error(arg, NNG_ECONNSHUT);
 		break;
 	default:

--- a/src/supplemental/quic/msquic_dial.c
+++ b/src/supplemental/quic/msquic_dial.c
@@ -431,6 +431,8 @@ quic_stream_cb(int events, void *arg)
 		nni_aio_list_remove(aio);
 		QUIC_BUFFER *buf = nni_aio_get_input(aio, 0);
 		free(buf);
+		nni_msg *msg = nni_aio_get_msg(aio);
+		nni_msg_free(msg);
 		nni_aio_finish(aio, 0, nni_aio_count(aio));
 
 		// Start next send only after finished the last send
@@ -458,13 +460,11 @@ quic_stream_cb(int events, void *arg)
 	// case QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE:
 	case QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE:
 	// case QUIC_STREAM_EVENT_PEER_RECEIVE_ABORTED:
-		nni_mtx_lock(&c->mtx);
 		if (c->closed != true) {
 			msquic_strm_fini(c->qstrm);
 			// Marked it as closed, prevent explicit shutdown
 			c->closed = true;
 		}
-		nni_mtx_unlock(&c->mtx);
 		quic_stream_error(arg, NNG_ECONNSHUT);
 		break;
 	default:
@@ -893,6 +893,8 @@ msquic_strm_cb(_In_ HQUIC stream, _In_opt_ void *Context,
 			QUIC_BUFFER *buf = nni_aio_get_input(aio, 0);
 			free(buf);
 			Event->SEND_COMPLETE.ClientContext = NULL;
+			nni_msg *msg = nni_aio_get_msg(aio);
+			nni_msg_free(msg);
 			nni_aio_finish(aio, 0, nni_aio_count(aio));
 			break;
 		}

--- a/src/supplemental/quic/msquic_dial.c
+++ b/src/supplemental/quic/msquic_dial.c
@@ -431,8 +431,6 @@ quic_stream_cb(int events, void *arg)
 		nni_aio_list_remove(aio);
 		QUIC_BUFFER *buf = nni_aio_get_input(aio, 0);
 		free(buf);
-		nni_msg *msg = nni_aio_get_msg(aio);
-		nni_msg_free(msg);
 		nni_aio_finish(aio, 0, nni_aio_count(aio));
 
 		// Start next send only after finished the last send
@@ -893,8 +891,9 @@ msquic_strm_cb(_In_ HQUIC stream, _In_opt_ void *Context,
 			QUIC_BUFFER *buf = nni_aio_get_input(aio, 0);
 			free(buf);
 			Event->SEND_COMPLETE.ClientContext = NULL;
-			nni_msg *msg = nni_aio_get_msg(aio);
-			nni_msg_free(msg);
+			// TODO free by user cb or msquic layer???
+			// nni_msg *msg = nni_aio_get_msg(aio);
+			// nni_msg_free(msg);
 			nni_aio_finish(aio, 0, nni_aio_count(aio));
 			break;
 		}

--- a/src/supplemental/quic/msquic_dial.c
+++ b/src/supplemental/quic/msquic_dial.c
@@ -361,7 +361,7 @@ nni_quic_dialer_close(void *arg)
 				c->dial_aio = NULL;
 				nni_aio_set_prov_data(aio, NULL);
 				nng_stream_close(&c->stream);
-				// nng_stream_free(&c->stream);
+				nng_stream_free(&c->stream);
 			}
 			nni_aio_finish_error(aio, NNG_ECLOSED);
 		}


### PR DESCRIPTION
Fix the conflict between msquic and nng close.
Fix some memory leakages in quic.
Fix deadlock in quic stream.
Fix the missing decrement of refcnt of dialer.
Fix the wrong nng_stream_free in quic_dialer_close.
