### PR TITLE
Fix the repeat nni_pipe in reap_pipe_list.

### DIFF
--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -157,6 +157,7 @@ nni_pipe_close(nni_pipe *p)
 	}
 	//MQTT Session reserved
 	if (p->cache) {
+		nni_atomic_swap_bool(&p->p_closed, false);
 		return;
 	}
 	nni_reap(&pipe_reap_list, p);

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -820,7 +820,7 @@ nano_pipe_close(void *arg)
 	log_trace(" ############## nano_pipe_close ############## ");
 	if (npipe->cache == true) {
 		// not first time we trying to close stored session pipe
-		nni_atomic_swap_bool(&npipe->p_closed, false);
+		//nni_atomic_swap_bool(&npipe->p_closed, false);
 		return;
 	}
 	nni_mtx_lock(&s->lk);
@@ -838,7 +838,7 @@ nano_pipe_close(void *arg)
 		p->event                   = false;
 		npipe->cache               = true;
 		p->conn_param->clean_start = 1;
-		nni_atomic_swap_bool(&npipe->p_closed, false);
+		//nni_atomic_swap_bool(&npipe->p_closed, false);
 		if (nni_list_active(&s->recvpipes, p)) {
 			nni_list_remove(&s->recvpipes, p);
 		}


### PR DESCRIPTION
It's an error in handling clean-session. The cache flag was set to false
because the second pipe with the same clientid was starting while the process of
closing first pipe is unfinished yet.

Which makes NanoMQ not crash when running the fuzz in https://github.com/emqx/nanomq/issues/1411. But memory leakage may happen. 