### PR TITLE
Fix bugs on multi stream and do optimization on quic stream.

### DIFF
--- a/src/mqtt/protocol/mqtt/mqtt_client.c
+++ b/src/mqtt/protocol/mqtt/mqtt_client.c
@@ -994,6 +994,7 @@ mqtt_ctx_send(void *arg, nni_aio *aio)
 		if (qos == 0) {
 			break;
 		}
+		// fall through
 	case NNG_MQTT_SUBSCRIBE:
 	case NNG_MQTT_UNSUBSCRIBE:
 		packet_id = mqtt_sock_get_next_packet_id(s);

--- a/src/mqtt/protocol/mqtt/mqtt_quic_client.c
+++ b/src/mqtt/protocol/mqtt/mqtt_quic_client.c
@@ -205,6 +205,7 @@ mqtt_send_msg(nni_aio *aio, nni_msg *msg, mqtt_sock_t *s)
 		if (qos == 0) {
 			break; // QoS 0 need no packet id
 		}
+		// fall through
 	case NNG_MQTT_SUBSCRIBE:
 	case NNG_MQTT_UNSUBSCRIBE:
 		packet_id = nni_mqtt_msg_get_packet_id(msg);
@@ -329,6 +330,7 @@ mqtt_pipe_send_msg(nni_aio *aio, nni_msg *msg, mqtt_pipe_t *p, uint16_t packet_i
 		if (qos == 0) {
 			break; // QoS 0 need no packet id
 		}
+		// fall through
 	case NNG_MQTT_SUBSCRIBE:
 	case NNG_MQTT_UNSUBSCRIBE:
 		packet_id = nni_mqtt_msg_get_packet_id(msg);
@@ -1667,6 +1669,7 @@ mqtt_quic_ctx_send(void *arg, nni_aio *aio)
 		if (nni_mqtt_msg_get_publish_qos(msg) == 0) {
 			break;
 		}
+		// fall through
 	case NNG_MQTT_SUBSCRIBE:
 	case NNG_MQTT_UNSUBSCRIBE:
 		packet_id = mqtt_pipe_get_next_packet_id(s);

--- a/src/mqtt/protocol/mqtt/mqtt_quic_client.c
+++ b/src/mqtt/protocol/mqtt/mqtt_quic_client.c
@@ -1811,7 +1811,6 @@ mqtt_quic_ctx_send(void *arg, nni_aio *aio)
 				} else {
 					nni_id_set(s->topic_map, hash, (void *)(num_ptr + 1));
 				}
->>>>>>> e7f708c6 (* FIX [quic/proto] Add error handler when alloc a quic stream failed.)
 			} else {
 				if ((rv = mqtt_pipe_send_msg(aio, msg, pub_pipe, 0)) >= 0) {
 					nni_mtx_unlock(&s->mtx);

--- a/src/mqtt/protocol/mqtt/mqttv5_client.c
+++ b/src/mqtt/protocol/mqtt/mqttv5_client.c
@@ -995,6 +995,7 @@ mqtt_ctx_send(void *arg, nni_aio *aio)
 		if (qos == 0) {
 			break;
 		}
+		// fall through
 	case NNG_MQTT_SUBSCRIBE:
 	case NNG_MQTT_UNSUBSCRIBE:
 		packet_id = mqtt_sock_get_next_packet_id(s);

--- a/src/mqtt/protocol/mqtt/mqttv5_quic_client.c
+++ b/src/mqtt/protocol/mqtt/mqttv5_quic_client.c
@@ -205,6 +205,7 @@ mqtt_send_msg(nni_aio *aio, nni_msg *msg, mqtt_sock_t *s)
 		if (qos == 0) {
 			break; // QoS 0 need no packet id
 		}
+		// fall through
 	case NNG_MQTT_SUBSCRIBE:
 	case NNG_MQTT_UNSUBSCRIBE:
 		packet_id = nni_mqtt_msg_get_packet_id(msg);
@@ -329,6 +330,7 @@ mqtt_pipe_send_msg(nni_aio *aio, nni_msg *msg, mqtt_pipe_t *p, uint16_t packet_i
 		if (qos == 0) {
 			break; // QoS 0 need no packet id
 		}
+		// fall through
 	case NNG_MQTT_SUBSCRIBE:
 	case NNG_MQTT_UNSUBSCRIBE:
 		packet_id = nni_mqtt_msg_get_packet_id(msg);
@@ -1694,6 +1696,7 @@ mqtt_quic_ctx_send(void *arg, nni_aio *aio)
 		if (nni_mqtt_msg_get_publish_qos(msg) == 0) {
 			break;
 		}
+		// fall through
 	case NNG_MQTT_SUBSCRIBE:
 	case NNG_MQTT_UNSUBSCRIBE:
 		packet_id = mqtt_pipe_get_next_packet_id(s);

--- a/src/supplemental/quic/msquic_dial.c
+++ b/src/supplemental/quic/msquic_dial.c
@@ -404,7 +404,7 @@ nni_msquic_quic_dialer_rele(nni_quic_dialer *d)
 /**************************** MsQuic Connection ****************************/
 
 static void
-quic_stream_cb(int events, void *arg)
+quic_stream_cb(int events, void *arg, int rc)
 {
 	log_debug("[quic cb] start %d\n", events);
 	nni_quic_conn   *c = arg;
@@ -427,7 +427,10 @@ quic_stream_cb(int events, void *arg)
 		nni_aio_list_remove(aio);
 		QUIC_BUFFER *buf = nni_aio_get_input(aio, 0);
 		free(buf);
-		nni_aio_finish(aio, 0, nni_aio_count(aio));
+		if (rc != 0)
+			nni_aio_finish_error(aio, rc);
+		else
+			nni_aio_finish(aio, 0, nni_aio_count(aio));
 
 		// Start next send only after finished the last send
 		quic_stream_dowrite(c);
@@ -592,6 +595,7 @@ quic_stream_dowrite_prior(nni_quic_conn *c, nni_aio *aio)
 	                naiov, QUIC_SEND_FLAG_NONE, aio))) {
 		log_error("Failed in StreamSend, 0x%x!", rv);
 		free(buf);
+		nni_aio_finish_error(aio, NNG_ECANCELED);
 		return;
 	}
 
@@ -880,14 +884,17 @@ msquic_strm_cb(_In_ HQUIC stream, _In_opt_ void *Context,
 	uint32_t       rlen, rlen2, rpos;
 	uint8_t       *rbuf;
 	uint32_t       count;
+	bool           canceled;
 
 	log_debug("quic_strm_cb triggered! %d conn %p strm %p", Event->Type, c, stream);
 	switch (Event->Type) {
 	case QUIC_STREAM_EVENT_SEND_COMPLETE:
 		log_debug("QUIC_STREAM_EVENT_SEND_COMPLETE!");
+		canceled = false;
 		if (Event->SEND_COMPLETE.Canceled) {
 			log_warn("[strm][%p] Data sent Canceled: %d",
 			    stream, Event->SEND_COMPLETE.Canceled);
+			canceled = true;
 		}
 		// Priority msg send
 		if ((aio = Event->SEND_COMPLETE.ClientContext) != NULL) {
@@ -897,11 +904,17 @@ msquic_strm_cb(_In_ HQUIC stream, _In_opt_ void *Context,
 			// TODO free by user cb or msquic layer???
 			// nni_msg *msg = nni_aio_get_msg(aio);
 			// nni_msg_free(msg);
-			nni_aio_finish(aio, 0, nni_aio_count(aio));
+			if (canceled)
+				nni_aio_finish_error(aio, NNG_ECANCELED);
+			else
+				nni_aio_finish(aio, 0, nni_aio_count(aio));
 			break;
 		}
 		// Ordinary send
-		quic_stream_cb(QUIC_STREAM_EVENT_SEND_COMPLETE, c);
+		if (canceled)
+			quic_stream_cb(QUIC_STREAM_EVENT_SEND_COMPLETE, c, NNG_ECANCELED);
+		else
+			quic_stream_cb(QUIC_STREAM_EVENT_SEND_COMPLETE, c, 0);
 		break;
 	case QUIC_STREAM_EVENT_RECEIVE:
 		// Data was received from the peer on the stream.
@@ -976,13 +989,13 @@ msquic_strm_cb(_In_ HQUIC stream, _In_opt_ void *Context,
 		if (c->reason_code == 0)
 			c->reason_code = SERVER_SHUTTING_DOWN;
 
-		quic_stream_cb(QUIC_STREAM_EVENT_PEER_SEND_ABORTED, c);
+		quic_stream_cb(QUIC_STREAM_EVENT_PEER_SEND_ABORTED, c, 0);
 		break;
 	case QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN:
 		// The peer aborted its send direction of the stream.
 		log_warn("[strm][%p] Peer send shut down\n", stream);
 		MsQuic->StreamShutdown(stream, QUIC_STREAM_SHUTDOWN_FLAG_GRACEFUL, 0);
-		quic_stream_cb(QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN, c);
+		quic_stream_cb(QUIC_STREAM_EVENT_PEER_SEND_SHUTDOWN, c, 0);
 		break;
 	case QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE:
 		log_warn("[strm][%p] QUIC_STREAM_EVENT_SEND_SHUTDOWN_COMPLETE.", stream);
@@ -996,7 +1009,7 @@ msquic_strm_cb(_In_ HQUIC stream, _In_opt_ void *Context,
 		log_info("close stream with Error Code: %llu",
 		    (unsigned long long)
 		        Event->SHUTDOWN_COMPLETE.ConnectionErrorCode);
-		quic_stream_cb(QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE, c);
+		quic_stream_cb(QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE, c, 0);
 		break;
 	case QUIC_STREAM_EVENT_START_COMPLETE:
 		log_info(
@@ -1005,11 +1018,11 @@ msquic_strm_cb(_In_ HQUIC stream, _In_opt_ void *Context,
 		    Event->START_COMPLETE.Status);
 		if (!Event->START_COMPLETE.PeerAccepted) {
 			log_warn("Peer refused");
-			quic_stream_cb(QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE, c);
+			quic_stream_cb(QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE, c, 0);
 			break;
 		}
 
-		quic_stream_cb(QUIC_STREAM_EVENT_START_COMPLETE, c);
+		quic_stream_cb(QUIC_STREAM_EVENT_START_COMPLETE, c, 0);
 		break;
 	case QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE:
 		log_info("QUIC_STREAM_EVENT_IDEAL_SEND_BUFFER_SIZE");
@@ -1023,7 +1036,7 @@ msquic_strm_cb(_In_ HQUIC stream, _In_opt_ void *Context,
 		log_warn("QUIC_STREAM_EVENT_PEER_RECEIVE_ABORTED Error Code: %llu",
 		    (unsigned long long) Event->PEER_RECEIVE_ABORTED.ErrorCode);
 
-		quic_stream_cb(QUIC_STREAM_EVENT_PEER_RECEIVE_ABORTED, c);
+		quic_stream_cb(QUIC_STREAM_EVENT_PEER_RECEIVE_ABORTED, c, 0);
 		break;
 
 	default:


### PR DESCRIPTION
* Cancel prior aio on stream layer.
* Add error handler when dial failed.
* A  efficient way (less memory cost) to manage the caches msgs (topic_lmq) when multistream is enabled.

Hi. after those commits. The multistream feature is more stable. Although it still could crash under benchmark.