### PR TITLE
* FIX [exchange_server] Initial alloc memory as 0, otherwise ASAN will coredump when strlen

### DIFF
--- a/src/mqtt/protocol/exchange/exchange_server.c
+++ b/src/mqtt/protocol/exchange/exchange_server.c
@@ -716,7 +716,7 @@ fuzz_search_result_cat(nng_msg **msgList, uint32_t count, cJSON *obj)
 			((uintptr_t)nng_msg_payload_ptr(msgList[i]) - (uintptr_t)nng_msg_body(msgList[i]));
 		if (sz >= pos + diff) {
 			mqdata[i] = nng_alloc(diff * 2 + 1);
-			memset(mqdata[i], 0, diff * 2 + 1);
+			memset(mqdata[i], '\0', diff * 2 + 1);
 			if (mqdata[i] == NULL) {
 				log_warn("Failed to allocate memory for file payload\n");
 				return -1;

--- a/src/mqtt/protocol/exchange/exchange_server.c
+++ b/src/mqtt/protocol/exchange/exchange_server.c
@@ -710,11 +710,13 @@ fuzz_search_result_cat(nng_msg **msgList, uint32_t count, cJSON *obj)
 	}
 
 	char **mqdata = nng_alloc(sizeof(char *) * count);
+	memset(mqdata, 0, sizeof(char *) * count);
 	for (uint32_t i = 0; i < count; i++) {
 		diff = nng_msg_len(msgList[i]) -
 			((uintptr_t)nng_msg_payload_ptr(msgList[i]) - (uintptr_t)nng_msg_body(msgList[i]));
 		if (sz >= pos + diff) {
 			mqdata[i] = nng_alloc(diff * 2 + 1);
+			memset(mqdata[i], 0, diff * 2 + 1);
 			if (mqdata[i] == NULL) {
 				log_warn("Failed to allocate memory for file payload\n");
 				return -1;


### PR DESCRIPTION
```
==263070==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200001e397 at pc 0x7f288ca3daa7 bp 0x7f28790df700 sp 0x7f28790deea8
READ of size 8 at 0x60200001e397 thread T32
    #0 0x7f288ca3daa6 in __interceptor_strlen ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:389
    #1 0x55cffc0c2bff in cJSON_strdup /home/maoyi/github/emqx/nanomq/nng/src/supplemental/nanolib/cJSON.c:204
    #2 0x55cffc0cc2fe in cJSON_CreateString /home/maoyi/github/emqx/nanomq/nng/src/supplemental/nanolib/cJSON.c:2369
    #3 0x55cffc0cccba in cJSON_CreateStringArray /home/maoyi/github/emqx/nanomq/nng/src/supplemental/nanolib/cJSON.c:2567
    #4 0x55cffc06e5b8 in fuzz_search_result_cat /home/maoyi/github/emqx/nanomq/nng/src/mqtt/protocol/exchange/exchange_server.c:740
    #5 0x55cffc06f0ac in ex_query_recv_cb /home/maoyi/github/emqx/nanomq/nng/src/mqtt/protocol/exchange/exchange_server.c:866
    #6 0x55cffc057717 in nni_task_exec /home/maoyi/github/emqx/nanomq/nng/src/core/taskq.c:144
    #7 0x55cffc03989b in nni_aio_finish_impl /home/maoyi/github/emqx/nanomq/nng/src/core/aio.c:469
    #8 0x55cffc03991d in nni_aio_finish_sync /home/maoyi/github/emqx/nanomq/nng/src/core/aio.c:484
    #9 0x55cffc175a78 in tcptran_pipe_recv_cb /home/maoyi/github/emqx/nanomq/nng/src/sp/transport/tcp/tcp.c:421
    #10 0x55cffc056f1f in nni_taskq_thread /home/maoyi/github/emqx/nanomq/nng/src/core/taskq.c:50
    #11 0x55cffc058240 in nni_thr_wrap /home/maoyi/github/emqx/nanomq/nng/src/core/thread.c:94
    #12 0x55cffc060bc7 in nni_plat_thr_main /home/maoyi/github/emqx/nanomq/nng/src/platform/posix/posix_thread.c:266
    #13 0x7f288bc94ac2 in start_thread nptl/pthread_create.c:442
    #14 0x7f288bd2684f  (/lib/x86_64-linux-gnu/libc.so.6+0x12684f)
```