### PR TITLE
User-defined operation types are supported when rb is full

### DIFF
--- a/include/nng/exchange/exchange.h
+++ b/include/nng/exchange/exchange.h
@@ -25,7 +25,7 @@ NNG_DECL int exchange_client_get_msgs_by_key(void *arg, uint64_t key, uint32_t c
 NNG_DECL int exchange_client_get_msgs_fuzz(void *arg, uint64_t start, uint64_t end, uint32_t *count, nng_msg ***list);
 
 NNG_DECL int exchange_init(exchange_t **ex, char *name, char *topic,
- 				  unsigned int *rbsCaps, char **rbsName, unsigned int rbsCount);
+				  unsigned int *rbsCaps, char **rbsName, uint8_t *rbsFullOp, unsigned int rbsCount);
 NNG_DECL int exchange_add_rb(exchange_t *ex, ringBuffer_t *rb);
 NNG_DECL int exchange_release(exchange_t *ex);
 NNG_DECL int exchange_handle_msg(exchange_t *ex, uint64_t key, void *msg, nng_aio *aio);

--- a/include/nng/supplemental/nanolib/conf.h
+++ b/include/nng/supplemental/nanolib/conf.h
@@ -290,7 +290,7 @@ typedef struct ringBuffer_node ringBuffer_node;
 struct ringBuffer_node {
 	char    *name;
 	uint32_t cap;
-	uint32_t overWrite;
+	uint32_t fullOp;
 };
 
 typedef struct conf_exchange_node conf_exchange_node;

--- a/include/nng/supplemental/nanolib/ringbuffer.h
+++ b/include/nng/supplemental/nanolib/ringbuffer.h
@@ -100,7 +100,7 @@ int ringBuffer_add_rule(ringBuffer_t *rb,
 
 int ringBuffer_init(ringBuffer_t **rb,
 					unsigned int cap,
-					unsigned int overWrite,
+					enum fullOption fullOp,
 					unsigned long long expiredAt);
 int ringBuffer_enqueue(ringBuffer_t *rb,
 					   uint64_t key,

--- a/src/mqtt/protocol/exchange/exchange.c
+++ b/src/mqtt/protocol/exchange/exchange.c
@@ -3,7 +3,7 @@
 
 int
 exchange_init(exchange_t **ex, char *name, char *topic,
-			  unsigned int *rbsCaps, char **rbsName, unsigned int rbsCount)
+			  unsigned int *rbsCaps, char **rbsName, uint8_t *rbsFullOp, unsigned int rbsCount)
 {
 	int ret = 0;
 	exchange_t *newEx = NULL;
@@ -58,7 +58,7 @@ exchange_init(exchange_t **ex, char *name, char *topic,
 
 	for (unsigned int i = 0; i < rbsCount; i++) {
 		ringBuffer_t *rb = NULL;
-		ret = ringBuffer_init(&rb, rbsCaps[i], 1, -1);
+		ret = ringBuffer_init(&rb, rbsCaps[i], rbsFullOp[i], -1);
 		if (rb == NULL || ret != 0) {
 			for (unsigned int j = 0; j < newEx->rb_count; j++) {
 				ringBuffer_release(newEx->rbs[j]);

--- a/src/mqtt/protocol/exchange/exchange_server.c
+++ b/src/mqtt/protocol/exchange/exchange_server.c
@@ -423,17 +423,20 @@ exchange_sock_bind_exchange(void *arg, const void *v, size_t sz, nni_opt_type t)
 
 	char    **rbsName = NULL;
 	uint32_t *rbsCap = NULL;
+	uint8_t  *rbsFullOp = NULL;
 	for (int i=0; i<(int)node->rbufs_sz; ++i) {
 		cvector_push_back(rbsName, node->rbufs[i]->name);
 		cvector_push_back(rbsCap, node->rbufs[i]->cap);
+		cvector_push_back(rbsFullOp, node->rbufs[i]->fullOp);
 	}
 
 	exchange_t *ex = NULL;
 	rv = exchange_init(&ex, node->name, node->topic,
-			rbsCap, rbsName, cvector_size(rbsName));
+			rbsCap, rbsName, rbsFullOp, cvector_size(rbsName));
 
 	cvector_free(rbsName);
 	cvector_free(rbsCap);
+	cvector_free(rbsFullOp);
 	if (rv != 0) {
 		log_error("Failed to exchange_init %d", rv);
 		return rv;

--- a/src/mqtt/protocol/exchange/exchange_server_test.c
+++ b/src/mqtt/protocol/exchange/exchange_server_test.c
@@ -122,7 +122,7 @@ test_exchange_client(void)
 	NUTS_TRUE(rb_node != NULL);
 	rb_node->name = "ringBuffer1";
 	rb_node->cap = 10;
-	rb_node->overWrite = 0;
+	rb_node->fullOp = RB_FULL_NONE;
 
 	conf->rbufs = NULL;
 

--- a/src/mqtt/protocol/exchange/exchange_test.c
+++ b/src/mqtt/protocol/exchange/exchange_test.c
@@ -43,6 +43,7 @@ void test_exchange_init(void)
 	exchange_t *ex = NULL;
 	char **ringBufferName;
 	unsigned int caps = 10000;
+	uint8_t fullOps = RB_FULL_NONE;
 
 	ringBufferName = nng_alloc(1 * sizeof(char *));
 	for (int i = 0; i < 1; i++) {
@@ -51,10 +52,10 @@ void test_exchange_init(void)
 
 	strcpy(ringBufferName[0], "ringBuffer1");
 
-	NUTS_TRUE(exchange_init(NULL, NULL, "topic1", &caps, ringBufferName, 1) != 0);
-	NUTS_TRUE(exchange_init(&ex, NULL, "topic1", &caps, ringBufferName, 1) != 0);
+	NUTS_TRUE(exchange_init(NULL, NULL, "topic1", &caps, ringBufferName, &fullOps, 1) != 0);
+	NUTS_TRUE(exchange_init(&ex, NULL, "topic1", &caps, ringBufferName, &fullOps, 1) != 0);
 
-	NUTS_TRUE(exchange_init(&ex, EX_NAME, "topic1", &caps, ringBufferName, 1) == 0);
+	NUTS_TRUE(exchange_init(&ex, EX_NAME, "topic1", &caps, ringBufferName, &fullOps, 1) == 0);
 	NUTS_TRUE(ex != NULL);
 	NUTS_TRUE(ex->rb_count != 0);
 	NUTS_TRUE(exchange_release(ex) == 0);
@@ -87,7 +88,8 @@ void test_exchange_ringBuffer(void)
 	strcpy(ringBufferName[0], "ringBuffer1");
 
 	char topic[100] = "topic1";
-	NUTS_TRUE(exchange_init(&ex, EX_NAME, "topic1", &caps, ringBufferName, 1) == 0);
+	uint8_t fullOps = RB_FULL_RETURN;
+	NUTS_TRUE(exchange_init(&ex, EX_NAME, "topic1", &caps, ringBufferName, &fullOps, 1) == 0);
 	NUTS_TRUE(ex != NULL);
 	NUTS_TRUE(ex->rb_count == 1);
 

--- a/src/supplemental/nanolib/conf.c
+++ b/src/supplemental/nanolib/conf.c
@@ -1157,6 +1157,7 @@ print_exchange_conf(conf_exchange *exchange)
 			ringBuffer_node *r = n->rbufs[j];
 			log_info("exchange ringbus name      %s", r->name);
 			log_info("exchange ringbus cap       %d", r->cap);
+			log_info("exchange ringbus fullOp    %d", r->fullOp);
 		}
 	}
 }

--- a/src/supplemental/nanolib/conf_ver2.c
+++ b/src/supplemental/nanolib/conf_ver2.c
@@ -1079,9 +1079,13 @@ conf_exchange_node_parse(conf_exchange_node *node, cJSON *obj)
 	if (rb_node == NULL) {
 		return;
 	}
+
+	rb_node->cap = 0;
+	rb_node->fullOp = 0;
+
 	hocon_read_str(rb_node, name, rb);
 	hocon_read_num(rb_node, cap, rb);
-	hocon_read_num(rb_node, overWrite, rb);
+	hocon_read_num(rb_node, fullOp, rb);
 
 	if (rb_node->name == NULL || rb_node->cap == 0) {
 		log_error("exchange: ringbuffer: name/cap not found");

--- a/src/supplemental/nanolib/ringbuffer/ringbuffer.c
+++ b/src/supplemental/nanolib/ringbuffer/ringbuffer.c
@@ -91,13 +91,18 @@ static inline int ringBuffer_get_and_clean_msgs(ringBuffer_t *rb, unsigned int c
 
 int ringBuffer_init(ringBuffer_t **rb,
 					unsigned int cap,
-					unsigned int overWrite,
+					enum fullOption fullOp,
 					unsigned long long expiredAt)
 {
 	ringBuffer_t *newRB;
 
 	if (cap >= RINGBUFFER_MAX_SIZE) {
 		log_error("Want to init a ring buffer which is greater than MAX_SIZE: %u\n", RINGBUFFER_MAX_SIZE);
+		return -1;
+	}
+
+	if (fullOp >= RB_FULL_MAX) {
+		log_error("fullOp is not valid: %d\n", fullOp);
 		return -1;
 	}
 
@@ -120,7 +125,8 @@ int ringBuffer_init(ringBuffer_t **rb,
 	newRB->cap = cap;
 
 	newRB->expiredAt = expiredAt;
-	newRB->overWrite = overWrite;
+	newRB->fullOp = fullOp;
+	newRB->files = NULL;
 
 	newRB->enqinRuleList[0] = NULL;
 	newRB->enqoutRuleList[0] = NULL;

--- a/src/supplemental/nanolib/ringbuffer/ringbuffer.c
+++ b/src/supplemental/nanolib/ringbuffer/ringbuffer.c
@@ -369,6 +369,15 @@ int ringBuffer_release(ringBuffer_t *rb)
 		nng_free(rb->msgs, sizeof(*rb->msgs));
 	}
 
+	if (rb->files != NULL) {
+		for (int i = 0; i < cvector_size(rb->files); i++) {
+			nng_free(rb->files[i]->keys, sizeof(uint64_t) * rb->cap);
+			nng_free(rb->files[i]->path, sizeof(char) * 256);
+			nng_free(rb->files[i], sizeof(ringBufferFile_t));
+		}
+		cvector_free(rb->files);
+	}
+
 	ringBufferRuleList_release(rb->enqinRuleList, rb->enqinRuleListLen);
 	ringBufferRuleList_release(rb->deqinRuleList, rb->deqinRuleListLen);
 	ringBufferRuleList_release(rb->enqoutRuleList, rb->enqoutRuleListLen);


### PR DESCRIPTION
Support four ops when ring bus is full
```
 0 RB_FULL_NONE,       // do nothing, and return enqueue failed                                                                                                                                                         
 1 RB_FULL_DROP,        // drop all msgs in ring bus, and enqueue new msg                                                                                                                                                        
 2 RB_FULL_RETURN,   // Get and clean up all msgs from ring bus and return in aio                                                                                                                                                            
 3 RB_FULL_FILE,          // Get and clean up all msgs from ring bus and write them to file
```

User can specify which type of operation to use like
```
exchange_client.name {
     exchange {
         topic = "topic1",
         name = "exchange1",
         ringbus = {
             name = "ringbuffer1",
             cap = 100,
             #  0: RB_FULL_NONE
             #  1: RB_FULL_DROP
             #  2: RB_FULL_RETURN
             #  3: RB_FULL_FILE
             fullOp = 3
         }
     }
}
```

TODO: Parquet part is not supported now