### PR TITLE
Bump NNG version to 1.7.1 & add new hash64 API

### DIFF
--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -60,7 +60,7 @@ extern "C" {
 #define NNG_MINOR_VERSION 7
 #define NNG_PATCH_VERSION 1
 #define NNG_RELEASE_SUFFIX \
-	"pre" // if non-empty (i.e. "pre"), this is a pre-release
+	"" // if non-empty (i.e. "pre"), this is a pre-release
 
 // Maximum length of a socket address. This includes the terminating NUL.
 // This limit is built into other implementations, so do not change it.

--- a/include/nng/protocol/mqtt/mqtt_parser.h
+++ b/include/nng/protocol/mqtt/mqtt_parser.h
@@ -78,11 +78,12 @@ NNG_DECL uint16_t get_variable_binary(uint8_t **dest, const uint8_t *src);
 
 NNG_DECL uint32_t DJBHash(char *str);
 NNG_DECL uint32_t DJBHashn(char *str, uint16_t len);
+NNG_DECL uint64_t DJBHash64(char *str);
+NNG_DECL uint64_t DJBHash64n(uint8_t* str, uint32_t len);
 NNG_DECL uint32_t fnv1a_hashn(char *str, size_t n);
 NNG_DECL uint8_t  crc_hashn(char *str, size_t n);
 NNG_DECL uint32_t crc32_hashn(char *str, size_t n);
 NNG_DECL uint32_t crc32c_hashn(char *str, size_t n);
-NNG_DECL uint64_t nano_hash(char *str);
 NNG_DECL uint8_t  verify_connect(conn_param *cparam, conf *conf);
 
 // repack

--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2018 Devolutions <info@devolutions.net>
 //
@@ -447,7 +447,7 @@ extern int nni_plat_udp_sockname(nni_plat_udp *, nni_sockaddr *);
 // in APIs to transport file descriptors, or across a fork/exec boundary (so
 // that child processes may use these with socket to inherit a socket that is
 // connected to the parent.)
-extern int nni_socket_pair(int *);
+extern int nni_socket_pair(int [2]);
 
 //
 // File/Store Support

--- a/src/platform/posix/posix_socketpair.c
+++ b/src/platform/posix/posix_socketpair.c
@@ -36,7 +36,7 @@ nni_socket_pair(int fds[2])
 }
 #else
 int
-nni_socket_pair(int *fds)
+nni_socket_pair(int fds[2])
 {
 	return (NNG_ENOTSUP);
 }

--- a/src/platform/windows/win_socketpair.c
+++ b/src/platform/windows/win_socketpair.c
@@ -18,7 +18,7 @@
 #include <sys/socket.h>
 
 int
-nni_socket_pair(int *fds)
+nni_socket_pair(int fds[2])
 {
 	int rv;
 	rv = socketpair(PF_UNIX, SOCK_STREAM, 0, fds);

--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -900,6 +900,31 @@ DJBHashn(char *str, uint16_t len)
 	return hash;
 }
 
+uint64_t
+DJBHash64n(uint8_t* str, uint32_t len)
+{
+    uint64_t hash = 5381;
+    uint64_t i    = 0;
+
+    for(i = 0; i < len; str++, i++) {
+        hash = ((hash << 5) + hash) + (*str);
+    }
+
+    return hash;
+}
+
+uint64_t
+DJBHash64(char *str)
+{
+	uint64_t hash = 5381;
+	int      c;
+
+	while ((c = *str++))
+		hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+	                                         // hash = hash * 33 + c;
+	return hash;
+}
+
 /* Fowler/Noll/Vo (FNV) hash function, variant 1a */
 uint32_t
 fnv1a_hashn(char *str, size_t n)
@@ -1084,18 +1109,6 @@ crc32c_hashn(char *str, size_t n)
 	}
 
 	return crc32c_sw(0, (void *)str, n);
-}
-
-uint64_t
-nano_hash(char *str)
-{
-	uint64_t hash = 5381;
-	int      c;
-
-	while ((c = *str++))
-		hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
-	                                         // hash = hash * 33 + c;
-	return hash;
 }
 
 inline void

--- a/src/sp/protocol/mqtt/mqtt_parser_test.c
+++ b/src/sp/protocol/mqtt/mqtt_parser_test.c
@@ -137,7 +137,8 @@ test_hash()
 	NUTS_ASSERT(DJBHashn(str, strlen(str)) == 2090756197);
 	NUTS_ASSERT(fnv1a_hashn(str, strlen(str)) == (uint32_t)-1345293851); 
 	NUTS_ASSERT(crc_hashn(str, strlen(str)) == 191);
-	NUTS_ASSERT(nano_hash(str) == 6385723493);
+	NUTS_ASSERT(DJBHash64(str) == 6385723493);
+	NUTS_ASSERT(DJBHash64n(str, strlen(str)) == 6385723493);
 
 	NUTS_ASSERT(crc32_hashn(str2, strlen(str2)) == (uint32_t)-620996987);
 	NUTS_ASSERT(crc32c_hashn(str2, strlen(str2)) == 788723578);

--- a/src/supplemental/util/platform.c
+++ b/src/supplemental/util/platform.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -179,7 +179,7 @@ nng_random(void)
 }
 
 int
-nng_socket_pair(int *fds)
+nng_socket_pair(int fds[2])
 {
 	return (nni_socket_pair(fds));
 }

--- a/tests/compat_testutil.c
+++ b/tests/compat_testutil.c
@@ -2,7 +2,7 @@
     Copyright (c) 2013 Insollo Entertainment, LLC. All rights reserved.
     Copyright 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
     Copyright 2018 Capitar IT Group BV <info@capitar.com>
-	Copyright 2022 Staysail Systems, Inc. <info@staysail.tech>
+    Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -27,13 +27,13 @@
 // it for validating the compatibility features of nanomsg.   As much as
 // possible we want to run tests from the nanomsg test suite unmodified.
 
-#include <assert.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <nng/compat/nanomsg/nn.h>
 #include "compat_testutil.h"
+#include <nng/compat/nanomsg/nn.h>
 
 int  test_socket_impl(char *file, int line, int family, int protocol);
 int  test_connect_impl(char *file, int line, int sock, char *address);
@@ -143,7 +143,7 @@ test_recv_impl(char *file, int line, int sock, char *data)
 {
 	size_t data_len;
 	int    rc;
-	char * buf;
+	char  *buf;
 
 	data_len = strlen(data);
 	/*  We allocate plus one byte so that we are sure that message received
@@ -226,4 +226,15 @@ void
 nn_sleep(int ms)
 {
 	nng_msleep(ms);
+}
+
+void
+nn_assert_impl(bool b, const char *expression, const char *file, int line)
+{
+	if (b) {
+		return;
+	}
+	fprintf(
+	    stderr, "%s:%d: Assertion failed: %s\n", file, line, expression);
+	abort();
 }

--- a/tests/compat_testutil.h
+++ b/tests/compat_testutil.h
@@ -3,7 +3,7 @@
     Copyright 2017 Garrett D'Amore <garrett@damore.org>
     Copyright 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
     Copyright 2018 Capitar IT Group BV <info@capitar.com>
-    Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
+    Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -31,23 +31,24 @@
 #ifndef COMPAT_TESTUTIL_H_INCLUDED
 #define COMPAT_TESTUTIL_H_INCLUDED
 
-#include <assert.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #define nn_err_strerror nn_strerror
 #define nn_err_abort abort
-#define nn_assert assert
-#define errno_assert assert
-#define wsa_assert assert
-#define alloc_assert(x) assert((x) != NULL)
+#define errno_assert nn_assert
+#define wsa_assert nn_assert
+#define alloc_assert(x) nn_assert((x) != NULL)
 
 #if defined __GNUC__ || defined __llvm__ || defined __clang__
 #define NN_UNUSED __attribute__((unused))
 #else
 #define NN_UNUSED
 #endif
+
+#define nn_assert(x) nn_assert_impl(x, #x, __FILE__, __LINE__)
 
 extern int  test_socket_impl(char *file, int line, int family, int protocol);
 extern int  test_connect_impl(char *file, int line, int sock, char *address);
@@ -57,11 +58,13 @@ extern void test_send_impl(char *file, int line, int sock, char *data);
 extern void test_recv_impl(char *file, int line, int sock, char *data);
 extern void test_drop_impl(char *file, int line, int sock, int err);
 extern int  test_setsockopt_impl(char *file, int line, int sock, int level,
-	int option, const void *optval, size_t optlen);
-extern int get_test_port(int argc, const char *argv[]);
-extern void test_addr_from(char *out, const char *proto, const char *ip,
-	int port);
+     int option, const void *optval, size_t optlen);
+extern int  get_test_port(int argc, const char *argv[]);
+extern void test_addr_from(
+    char *out, const char *proto, const char *ip, int port);
 extern void nn_sleep(int);
+extern void nn_assert_impl(
+    bool b, const char *expression, const char *file, int line);
 
 #define test_socket(f, p) test_socket_impl(__FILE__, __LINE__, (f), (p))
 #define test_connect(s, a) test_connect_impl(__FILE__, __LINE__, (s), (a))
@@ -77,7 +80,7 @@ struct nn_thread {
 	void *thr;
 };
 
-extern int nn_thread_init(struct nn_thread *, void (*)(void *), void *);
+extern int  nn_thread_init(struct nn_thread *, void (*)(void *), void *);
 extern void nn_thread_term(struct nn_thread *);
 
 #endif // COMPAT_TESTUTIL_H_INCLUDED


### PR DESCRIPTION
I am considering converting pipe_id to uint64. but this is for the future only