### PR TITLE
Make sure the http method will always be send as a capitilized string

### DIFF
--- a/src/supplemental/http/http_msg.c
+++ b/src/supplemental/http/http_msg.c
@@ -1,4 +1,4 @@
-//
+	//
 // Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
@@ -717,7 +717,7 @@ nni_http_req_set_method(nni_http_req *req, const char *meth)
 	if ((meth != NULL) && (nni_strcasecmp(meth, "GET") == 0)) {
 		meth = NULL;
 	}
-	if ((string_set_status = http_set_string(&req->meth, meth)) == 0) {
+	if ((string_set_status = http_set_string(&req->meth, meth)) == 0 && req->meth != NULL) {
 		char * meth_ch = req->meth;
 
 		// Make sure the method is always in upper case since that is

--- a/src/supplemental/http/http_msg.c
+++ b/src/supplemental/http/http_msg.c
@@ -8,6 +8,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include <ctype.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -711,10 +712,22 @@ nni_http_req_set_uri(nni_http_req *req, const char *uri)
 int
 nni_http_req_set_method(nni_http_req *req, const char *meth)
 {
-	if ((meth != NULL) && (strcmp(meth, "GET") == 0)) {
+	int string_set_status;
+
+	if ((meth != NULL) && (nni_strcasecmp(meth, "GET") == 0)) {
 		meth = NULL;
 	}
-	return (http_set_string(&req->meth, meth));
+	if ((string_set_status = http_set_string(&req->meth, meth)) == 0) {
+		char * meth_ch = req->meth;
+
+		// Make sure the method is always in upper case since that is
+		// the only valid representation of a http method
+		while (*meth_ch) {
+			*meth_ch = toupper((unsigned char) *meth_ch);
+			meth_ch++;
+		}
+	}
+	return string_set_status;
 }
 
 int

--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -267,6 +267,14 @@ nni_http_handler_set_method(nni_http_handler *h, const char *method)
 	}
 	nni_strfree(h->method);
 	h->method = dup;
+
+	// Make sure the method is always in upper case since that is
+	// the only valid representation of a http method
+	while (*dup) {
+		*dup = toupper((unsigned char) *dup);
+		dup++;
+	}
+
 	return (0);
 }
 


### PR DESCRIPTION
I came across [this](https://github.com/nanomq/nanomq/issues/1625) issue in the NanoMQ repository. In all of the documentation for NanoMQs http auth config the http method is passed as a lower case string (e.g. "post" in [this](https://nanomq.io/docs/en/latest/config-description/acl.html#http-authentication) one) and I think it should work with the values provided in the examples.

Since the [HTTP spec](https://datatracker.ietf.org/doc/html/rfc2616#section-5.1.1) specifies that the method must be a capitalized string I think the creation of the HTTP requests should only produce valid and therefore capitalized methods in the request line.

So this PR does not fix an issue in this repo but rather an issue in the NanoMQ project. One could argue that changing the documentation would be sufficient but for me It makes more sense to only produce a valid request line. Also the node runtime automatically capitalizes the method string when creating a request so this behaviour accepted by a broad range of developers.

Im looking forward to some feedback on this topic.