### PR TITLE
Fix memory leak in hocon.c

### DIFF
--- a/src/supplemental/nanolib/hocon.c
+++ b/src/supplemental/nanolib/hocon.c
@@ -141,6 +141,12 @@ deduplication_and_merging(cJSON *jso)
 
 		cvector_push_back(table, child);
 
+		child = child->next;
+	}
+
+	// First deduplicate and merge siblings then do it for children
+	// to avoid leaks
+	while (child) {
 		if (child->child) {
 			deduplication_and_merging(child);
 		}


### PR DESCRIPTION
Hello, I am a new contributor to the repository.
I tried to fix following issue: 
 #[1652 ](https://github.com/nanomq/nanomq/issues/1652) Memory Leak on parsing conf that is duplicated

I copy pasted `/etc/nanomq.conf` twice to reproduce the conditions in issue. Finally, I was able to reproduce the leaks using `./nanomq/nanomq start --conf ../etc/nanomq.conf`. 

In the function `deduplication_and_merging` It looks like the sibling json elements are getting deduplicated and merged. Simultaneously the children are also deduplicated and merged at same time. This leads to several leaks.

In order to patch it, I seperated the two by following given strict order:
1. Deduplicating and merging siblings at given level completely
2. Deduplicating and merging children thereafter 

After this, the leaks are patched. I was able to verify that the leaks are gone and there is no double free.
Let me know if the patch is helpful :)

