### PR TITLE
Fix memory leak in hocon.c

### DIFF
--- a/src/supplemental/nanolib/hocon.c
+++ b/src/supplemental/nanolib/hocon.c
@@ -124,7 +124,9 @@ deduplication_and_merging(cJSON *jso)
 						    parent->child->prev;
 						parent->child =
 						    parent->child->next;
-						cJSON_free(table[i]);
+						table[i]->next = NULL;
+						table[i]->prev = NULL;
+						cJSON_Delete(table[i]);
 						cvector_erase(table, i);
 
 					} else {
@@ -132,7 +134,9 @@ deduplication_and_merging(cJSON *jso)
 						    table[i]->prev;
 						table[i - 1]->next =
 						    table[i]->next;
-						cJSON_free(table[i]);
+						table[i]->next = NULL;
+						table[i]->prev = NULL;
+						cJSON_Delete(table[i]);
 						cvector_erase(table, i);
 					}
 				}


### PR DESCRIPTION
Hello, I am a new contributor to the repository. I apologize for opening multiple PRs. I wanted to revise the patch and by mistake I opened PR on wrong branch. Please consider this one only.

I tried to fix following issue: 
 #[1652 ](https://github.com/nanomq/nanomq/issues/1652) Memory Leak on parsing conf that is duplicated

I copy pasted `/etc/nanomq.conf` twice to reproduce the conditions in issue. Finally, I was able to reproduce the leaks using `./nanomq/nanomq start --conf ../etc/nanomq.conf`. 

In the function `deduplication_and_merging` there is logic to delete the node from table if we find duplicate node. However, cJSON_free is used for this purpose which does not delete inner fields such as `valuestring` and `string`. Therefore the patch detaches this node and instead performs `cJSON_Delete` on the table node.

After this, the leaks are patched. I was able to verify that the leaks are gone and there is no double free.
Let me know if the patch is helpful :)

