### PR TITLE
Fix the crash when mqtt quic server shutdown.

### DIFF
--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -449,7 +449,7 @@ nano_ctx_send(void *arg, nni_aio *aio)
 		nni_mtx_unlock(&p->lk);
 		return;
 	}
-	log_info("pipe %d occupied! resending in cb!", pipe);
+	log_debug("pipe %d occupied! resending in cb!", pipe);
 	if (nni_lmq_full(&p->rlmq)) {
 		// Make space for the new message.
 		if (nni_lmq_cap(&p->rlmq) <= NANO_MAX_QOS_PACKET) {

--- a/src/supplemental/quic/msquic_dial.c
+++ b/src/supplemental/quic/msquic_dial.c
@@ -228,8 +228,8 @@ quic_dialer_cb(void *arg)
 
 error:
 
+	d->currcon = NULL;
 	if (rv != 0) {
-		d->currcon = NULL;
 		c->dial_aio = NULL;
 
 		nni_aio_set_prov_data(aio, NULL);

--- a/src/supplemental/quic/quic_api.h
+++ b/src/supplemental/quic/quic_api.h
@@ -41,7 +41,7 @@ extern void nni_msquic_quic_dialer_rele(nni_quic_dialer *);
 
 struct nni_quic_dialer {
 	nni_aio                *qconaio; // for quic connection
-	nni_quic_conn          *currcon;
+	nni_quic_conn          *currcon; // a var to record conn context for one dial action
 	nni_list                connq;   // pending connections/quic streams
 	bool                    closed;
 	bool                    nodelay;


### PR DESCRIPTION
This fixed the crash said in https://github.com/nanomq/nanomq/issues/1665

But more tests are required.
