### PR TITLE
TLS Verifying peer in QUIC layer is supported

### DIFF
--- a/src/supplemental/quic/msquic_dial.c
+++ b/src/supplemental/quic/msquic_dial.c
@@ -104,10 +104,10 @@ static void quic_stream_error(void *arg, int err);
 static void quic_stream_close(void *arg);
 static void quic_stream_dowrite(nni_quic_conn *c);
 
-static QUIC_STATUS verify_peer_cert_tls(QUIC_CERTIFICATE* cert, QUIC_CERTIFICATE* chain, char *cacert);
+static QUIC_STATUS verify_peer_cert_tls(QUIC_CERTIFICATE* cert, QUIC_CERTIFICATE* chain, char *ca);
 
 static QUIC_STATUS
-verify_peer_cert_tls(QUIC_CERTIFICATE* cert, QUIC_CERTIFICATE* chain, char *cacert)
+verify_peer_cert_tls(QUIC_CERTIFICATE* cert, QUIC_CERTIFICATE* chain, char *ca)
 {
 	// local ca
 	X509_LOOKUP *lookup = NULL;
@@ -124,7 +124,7 @@ verify_peer_cert_tls(QUIC_CERTIFICATE* cert, QUIC_CERTIFICATE* chain, char *cace
 	}
 
 	// if (!X509_LOOKUP_load_file(lookup, cacertfile, X509_FILETYPE_PEM)) {
-	if (!X509_LOOKUP_load_file(lookup, cacert, X509_FILETYPE_PEM)) {
+	if (!X509_LOOKUP_load_file(lookup, ca, X509_FILETYPE_PEM)) {
 		log_warn("No load cacertfile be found");
 		X509_STORE_free(trusted);
 		trusted = NULL;
@@ -946,7 +946,7 @@ msquic_connection_cb(_In_ HQUIC Connection, _In_opt_ void *Context,
 		 */
 		if (QUIC_FAILED(rv = verify_peer_cert_tls(
 				Event->PEER_CERTIFICATE_RECEIVED.Certificate,
-				Event->PEER_CERTIFICATE_RECEIVED.Chain, d->cacert))) {
+				Event->PEER_CERTIFICATE_RECEIVED.Chain, d->ca))) {
 			log_error("[conn][%p] Invalid certificate file received from the peer", qconn);
 			return rv;
 		}

--- a/src/supplemental/quic/quic_api.c
+++ b/src/supplemental/quic/quic_api.c
@@ -154,6 +154,7 @@ quic_dialer_set_tls_ca(void *arg, const void *buf, size_t sz, nni_type t)
 	char *           str;
 
 	str = nng_alloc(sz + 1);
+	memset(str, '\0', sz + 1);
 
 	if (((rv = nni_copyin_str(str, buf, sz, sz, t)) != 0) || (d == NULL)) {
 		return rv;
@@ -189,8 +190,8 @@ quic_dialer_set_tls_pwd(void *arg, const void *buf, size_t sz, nni_type t)
 	int              rv;
 	char *           str;
 
-	str = nng_alloc(sz);
-	memset(str, '\0', sz);
+	str = nng_alloc(sz + 1);
+	memset(str, '\0', sz + 1);
 
 	if (((rv = nni_copyin_str(str, buf, sz, sz, t)) != 0) || (d == NULL)) {
 		return rv;
@@ -209,8 +210,8 @@ quic_dialer_set_tls_key(void *arg, const void *buf, size_t sz, nni_type t)
 	int              rv;
 	char *           str;
 
-	str = nng_alloc(sz);
-	memset(str, '\0', sz);
+	str = nng_alloc(sz + 1);
+	memset(str, '\0', sz + 1);
 
 	if (((rv = nni_copyin_str(str, buf, sz, sz, t)) != 0) || (d == NULL)) {
 		return rv;
@@ -243,8 +244,8 @@ quic_dialer_set_tls_cacert(void *arg, const void *buf, size_t sz, nni_type t)
 	int              rv;
 	char *           str;
 
-	str = nng_alloc(sz);
-	memset(str, '\0', sz);
+	str = nng_alloc(sz + 1);
+	memset(str, '\0', sz + 1);
 
 	if (((rv = nni_copyin_str(str, buf, sz, sz, t)) != 0) || (d == NULL)) {
 		return rv;

--- a/src/supplemental/quic/quic_api.c
+++ b/src/supplemental/quic/quic_api.c
@@ -397,6 +397,8 @@ quic_dialer_set_keepalive(void *arg, const void *buf, size_t sz, nni_type t)
 static int
 quic_dialer_set_priority(void *arg, const void *buf, size_t sz, nni_type t)
 {
+	NNI_ARG_UNUSED(sz);
+	NNI_ARG_UNUSED(t);
 	nni_quic_dialer *d = arg;
 	int *_buf = (int *)buf;
 


### PR DESCRIPTION
* TLS Verifying peer in QUIC layer is supported.
* Fix heap overflow error when set tls ca/cert/pwd.
* Fix a warning.
