### PR TITLE
Fix some gap between nng reap thread and msquic.

### DIFF
--- a/src/mqtt/transport/tcp/mqtt_tcp.c
+++ b/src/mqtt/transport/tcp/mqtt_tcp.c
@@ -781,12 +781,13 @@ mqtt_tcptran_pipe_send_start(mqtt_tcptran_pipe *p)
 				p->qosmax == 0 ? *header &= 0XF9 : NNI_ARG_UNUSED(*header);
 			}
 		}
-		// check max packet size
-		if (nni_msg_header_len(msg) + nni_msg_len(msg) > p->packmax) {
-			txaio = p->txaio;
-			nni_aio_finish_error(txaio, UNSPECIFIED_ERROR);
-			return;
-		}
+	}
+
+	// check max packet size
+	if (nni_msg_header_len(msg) + nni_msg_len(msg) > p->packmax) {
+		txaio = p->txaio;
+		nni_aio_finish_error(txaio, UNSPECIFIED_ERROR);
+		return;
 	}
 
 	txaio = p->txaio;

--- a/src/supplemental/quic/msquic_dial.c
+++ b/src/supplemental/quic/msquic_dial.c
@@ -1385,7 +1385,7 @@ msquic_strm_open(HQUIC qconn, nni_quic_dialer *d)
 	}
 
 	if (d->priority != -1) {
-		printf("Ready to create a quic stream with priority: %d\n", d->priority);
+		log_info("Ready to create a quic stream with priority: %d\n", d->priority);
 		MsQuic->SetParam(strm, QUIC_PARAM_STREAM_PRIORITY, sizeof(int), &d->priority);
 	}
 


### PR DESCRIPTION
* The pack max restrict should be applied to both mqttv311 and mqtv5.
* Fix the double free of msg when cancel stream sending.
* Fix the double free of quic stream.
