### PR TITLE
* FIX [broker_tcp] fix a stack overflow of nng transport

### DIFF
--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -1636,6 +1636,7 @@ tcptran_pipe_recv_start(tcptran_pipe *p)
 	p->wantrxhead = NANO_MIN_FIXED_HEADER_LEN;
 	iov.iov_buf   = p->rxlen;
 	iov.iov_len   = NANO_MIN_FIXED_HEADER_LEN;
+	memset(p->rxlen, 0, 5 * sizeof(p->rxlen[0]));
 	nni_aio_set_iov(rxaio, 1, &iov);
 	nng_stream_recv(p->conn, rxaio);
 }


### PR DESCRIPTION
all SP protocols shall do the same in case stack overflow while dealing with huge buffer. 