### PR TITLE
* FIX [sqlite pragma] set synchronous=NORMAL to prevent excessive syncing

### DIFF
--- a/src/supplemental/mqtt/mqtt_qos_db.c
+++ b/src/supplemental/mqtt/mqtt_qos_db.c
@@ -141,7 +141,7 @@ static void
 set_db_pragma(sqlite3 *db)
 {
 	sqlite3_exec(db, "PRAGMA journal_mode=WAL", NULL, 0, 0);
-	sqlite3_exec(db, "PRAGMA synchronous=FULL", NULL, 0, 0);
+	sqlite3_exec(db, "PRAGMA synchronous=NORMAL", NULL, 0, 0);
 	sqlite3_exec(db, "PRAGMA wal_autocheckpoint", NULL, 0, 0);
 }
 


### PR DESCRIPTION
Hello,

I started to use nanomq on IoT project with ~100 connected devices.

Nanomq runs on i.MX6UL machine with eMMC memory and I had a problem with very high system load and very slow MQTT message publishing. I traced it to persistence problem, more precisely *VERY* frequent syncing of sqlite database to storage. *VERY* frequent means like 10 times per second, which is bad for eMMC memory wear. I even set `    flush_mem_threshold = 1000`, but it did not help.

So I changed sqlite synchronous setting to `NORMAL`, and it helped much with both performance and eMMC wear.

Setting synchronous=FULL forces sqlite to use syncing calls very often, many times per second in this case, leading to very slow execution and excessive flash wear even in very small use cases.

But according to Sqlite docs here:
https://www.sqlite.org/pragma.html#pragma_synchronous

WAL journalling mode as NNG use is safe from corruption just with synchronous=NORMAL. It loses durability, but offers much higher performance and *MUCH* lower FLASH wear.

I think setting synchronous=FULL is overkill for edge devices targeted by nanomq project, so please consider merging this patch.