### PR TITLE
feat: add property retry_qos_0

### DIFF
--- a/include/nng/mqtt/mqtt_client.h
+++ b/include/nng/mqtt/mqtt_client.h
@@ -73,6 +73,11 @@ extern "C" {
 
 #define NNG_OPT_MQTT_RETRY_INTERVAL "mqtt-client-retry-interval"
 
+// Retry sending messages with qos=0
+// if the bridge is not connected
+// when the message is published
+#define NNG_OPT_MQTT_RETRY_QOS_0 "mqtt-client-retry-qos-0"
+
 #define NNG_OPT_MQTT_RETRY_WAIT_TIME "mqtt-client-retry-wait-time"
 
 #define NNG_OPT_MQTT_DISCONNECT_REASON "mqtt-disconnect-reason"

--- a/include/nng/supplemental/nanolib/conf.h
+++ b/include/nng/supplemental/nanolib/conf.h
@@ -280,6 +280,7 @@ struct conf_bridge_node {
 	bool         transparent;
 	bool         will_flag;
 	bool         will_retain;
+	bool         retry_qos_0;
 	void        *sock;
 	void        *bridge_arg;	// for reloading bridge case
 	char        *name;

--- a/src/mqtt/protocol/mqtt/mqtt_client.c
+++ b/src/mqtt/protocol/mqtt/mqtt_client.c
@@ -106,6 +106,7 @@ struct mqtt_sock_s {
 	reason_code     disconnect_code; // disconnect reason code
 	property       *dis_prop;        // disconnect property
 	nni_id_map      sent_unack;      // send messages unacknowledged
+	bool            retry_qos_0;
 #ifdef NNG_SUPP_SQLITE
 	nni_mqtt_sqlite_option *sqlite_opt;
 #endif
@@ -280,6 +281,20 @@ mqtt_sock_set_retry_wait(void *arg, const void *v, size_t sz, nni_opt_type t)
 	}
 	return (rv);
 }
+
+static int
+mqtt_sock_set_retry_qos_0(void *arg, const void *v, size_t sz, nni_opt_type t)
+{
+	mqtt_sock_t *s = arg;
+	bool tmp;
+	int rv;
+
+	if ((rv = nni_copyin_bool(&tmp, v, sz, t)) == 0) {
+		s->retry_qos_0 = tmp;
+	}
+	return (rv);
+}
+
 static int
 mqtt_sock_get_pipeid(void *arg, void *buf, size_t *szp, nni_type t)
 {
@@ -1397,7 +1412,8 @@ mqtt_ctx_send(void *arg, nni_aio *aio)
 #if defined(NNG_SUPP_SQLITE)
 		nni_mqtt_sqlite_option *sqlite =
 		    mqtt_sock_get_sqlite_option(s);
-		if (sqlite_is_enabled(sqlite)) {
+		if (sqlite_is_enabled(sqlite)
+				&& (qos > 0 || s->retry_qos_0)) {
 			// the msg order is exactly as same as the ctx
 			// in send_queue
 			nni_lmq_put(&sqlite->offline_cache, msg);
@@ -1521,6 +1537,10 @@ static nni_option mqtt_sock_options[] = {
 	{
 	    .o_name = NNG_OPT_MQTT_RETRY_WAIT_TIME,
 	    .o_set  = mqtt_sock_set_retry_wait,
+	},
+	{
+	    .o_name = NNG_OPT_MQTT_RETRY_QOS_0,
+	    .o_set  = mqtt_sock_set_retry_qos_0,
 	},
 	{
 	    .o_name = NNG_OPT_MQTT_SQLITE,

--- a/src/supplemental/nanolib/conf_ver2.c
+++ b/src/supplemental/nanolib/conf_ver2.c
@@ -1073,6 +1073,7 @@ conf_bridge_connector_parse_ver2(conf_bridge_node *node, cJSON *jso_connector)
 	hocon_read_time(node, keepalive, jso_connector);
 	hocon_read_time(node, backoff_max, jso_connector);
 	hocon_read_bool(node, clean_start, jso_connector);
+	hocon_read_bool(node, retry_qos_0, jso_connector);
 	hocon_read_bool(node, transparent, jso_connector);
 	hocon_read_bool(node, enable, jso_connector);
 	hocon_read_str(node, username, jso_connector);


### PR DESCRIPTION
It was my first time exploring this codebase, please be kind.

I need to disable caching of qos 0 mqtt messages for bridges when the bridge is not available. [My] applications are usually developed under the assumption that QoS0 messages don't have the guarantee of being delivered, hence they should not be persisted if the connection is not available. 

When the connection is available available most of the time, this should be a minor problem, but for our case brokers are placed in remote networks that may have no internet access for several days until proper maintenance is performed. In such cases, qos0 messages are unimportant and disk space should be left to store qos1 and qos2 messages.