### PR TITLE
 Update nng with Raft configuration struct

### DIFF
--- a/include/nng/supplemental/nanolib/conf.h
+++ b/include/nng/supplemental/nanolib/conf.h
@@ -439,6 +439,36 @@ struct conf_bridge {
 };
 
 typedef struct conf_bridge conf_bridge;
+
+struct conf_raft_conn {
+	uint32_t max_replication_packet_size;
+	uint16_t max_election_packet_size;
+};
+
+typedef struct conf_raft_conn conf_raft_conn;
+
+struct conf_raft_node {
+	char *address;
+	char *host;
+	uint16_t port;
+	uint16_t leader_election_timeout;
+	conf_tcp raft_tcp_conf;
+	conf_raft_conn raft_packets;
+	nng_dialer *raft_node_dialer;
+	nng_aio **raft_node_aio;
+};
+
+typedef struct conf_raft_node conf_raft_node;
+
+struct conf_raft {
+	size_t raft_group_count;
+	uint16_t majority_quorum_count;
+	conf_raft_node **raft_group;
+	bool leader_status;
+};
+
+typedef struct conf_raft conf_raft;
+
 struct conf_preset_session {
 	size_t count;
 	conf_session_node **nodes;
@@ -616,6 +646,7 @@ struct conf {
 	bool       daemon;
 	bool       ipc_internal;
 	bool       bridge_mode;				// global switch of bridging for hot update
+	bool	   raft_mode;
 
 	conf_tcp_list        tcp_list;
 	conf_tls_list        tls_list;
@@ -626,6 +657,7 @@ struct conf {
 	conf_preset_session  pre_sessions;
 	conf_bridge          bridge;		//standard MQTT
 	conf_bridge          aws_bridge;	// AWS IoT Core
+	conf_raft			 raft;	
 	conf_exchange        exchange;
 	conf_parquet         parquet;
 	conf_blf             blf;


### PR DESCRIPTION
This PR adds the initial Raft configuration structs to the nng submodule header file.
These structs define the configuration layout but do not include the full implementation yet.
It serves as a foundation for upcoming Raft-related features and improvements.

Note: This is an early stage update focused only on the struct definitions.

Feedback and suggestions are welcome!


