### PR TITLE
Update cmake for compiling nanomq with mbedtls

### DIFF
--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -57,7 +57,7 @@ find_library(_MBEDCRYPTO_LIBRARY
         # PATHS /usr/local
         PATH_SUFFIXES lib
         )
-message(STATUS "mbedtls lib dir: ${_MBEDCRYPTO_LIBRARY}")
+message(STATUS "mbedtls crypto lib dir: ${_MBEDCRYPTO_LIBRARY}")
 
 find_library(_MBEDX509_LIBRARY
         NAMES mbedx509
@@ -65,7 +65,6 @@ find_library(_MBEDX509_LIBRARY
         #PATHS /usr/local
         PATH_SUFFIXES lib
         )
-message(STATUS "mbedtls x509 dir: ${_MBEDX509_LIBRARY}")
 
 find_library(_MBEDTLS_LIBRARY
         NAMES mbedtls
@@ -73,7 +72,6 @@ find_library(_MBEDTLS_LIBRARY
         #PATHS /usr/local
         PATH_SUFFIXES lib
         )
-message(STATUS "mbedtls lib dir: ${_MBEDTLS_LIBRARY}")
 
 if ("${_MBEDTLS_TLS_LIBRARY}" STREQUAL "_MBEDTLS_TLS_LIBRARY-NOTFOUND")
     message("Failed to find Mbed TLS library")

--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -55,7 +55,7 @@ find_library(_MBEDCRYPTO_LIBRARY
         NAMES mbedcrypto
         HINTS ${_MBEDTLS_ROOT_HINTS}
         # PATHS /usr/local
-        # PATH_SUFFIXES lib
+        PATH_SUFFIXES lib
         )
 message(STATUS "mbedtls lib dir: ${_MBEDCRYPTO_LIBRARY}")
 
@@ -63,7 +63,7 @@ find_library(_MBEDX509_LIBRARY
         NAMES mbedx509
         HINTS ${_MBEDTLS_ROOT_HINTS}
         #PATHS /usr/local
-        # PATH_SUFFIXES lib
+        PATH_SUFFIXES lib
         )
 message(STATUS "mbedtls x509 dir: ${_MBEDX509_LIBRARY}")
 
@@ -71,7 +71,7 @@ find_library(_MBEDTLS_LIBRARY
         NAMES mbedtls
         HINTS ${_MBEDTLS_ROOT_HINTS}
         #PATHS /usr/local
-        #PATH_SUFFIXES lib
+        PATH_SUFFIXES lib
         )
 message(STATUS "mbedtls lib dir: ${_MBEDTLS_LIBRARY}")
 
@@ -84,6 +84,10 @@ else()
     list(APPEND CMAKE_REQUIRED_LIBRARIES ${_MBEDTLS_LIBRARY} ${_MBEDX509_LIBRARY} ${_MBEDCRYPTO_LIBRARY})
     check_symbol_exists(mbedtls_ssl_init "mbedtls/ssl.h" _MBEDTLS_V2_OR_NEWER)
     cmake_pop_check_state()
+
+    if (NNG_PLATFORM_WINDOWS)
+        set(_MBEDTLS_V2_OR_NEWER ON) # check_symbol_exists doesn't work on windows
+    endif(NNG_PLATFORM_WINDOWS)
 
     if (NOT _MBEDTLS_V2_OR_NEWER)
         message("Mbed TLS too old (must be version 2 or newer) ${_MBEDTLS_V2_OR_NEWER} UP ${_MbedTLS_V2}")
@@ -107,7 +111,6 @@ endif()
 add_library(MbedTLS::mbedtls UNKNOWN IMPORTED)
 add_library(MbedTLS::mbedx509 UNKNOWN IMPORTED)
 add_library(MbedTLS::mbedcrypto UNKNOWN IMPORTED)
-
 
 set_target_properties(MbedTLS::mbedtls PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_MBEDTLS_INCLUDE_DIR}")
 set_target_properties(MbedTLS::mbedx509 PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_MBEDTLS_INCLUDE_DIR}")

--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -36,6 +36,9 @@ if (NOT _MBEDTLS_ROOT_HINTS)
     set(_MBEDTLS_ROOT_HINTS ${MBEDTLS_ROOT_DIR} ENV MBEDTLS_ROOT_DIR)
 endif()
 
+message(STATUS "mbedtls root: ${MBEDTLS_ROOT}")
+message(STATUS "mbedtls root dir: ${MBEDTLS_ROOT_DIR}")
+
 set(_MBED_REQUIRED_VARS MbedTLS_TARGET MbedX509_TARGET MbedCrypto_TARGET MbedTLS_VERSION)
 
 include(FindPackageHandleStandardArgs)
@@ -46,6 +49,7 @@ find_path(_MBEDTLS_INCLUDE_DIR
         HINTS ${_MBEDTLS_ROOT_HINTS}
         # PATHS /usr/local
         PATH_SUFFIXES include)
+message(STATUS "mbedtls include dir: ${_MBEDTLS_INCLUDE_DIR}")
 
 find_library(_MBEDCRYPTO_LIBRARY
         NAMES mbedcrypto
@@ -53,6 +57,7 @@ find_library(_MBEDCRYPTO_LIBRARY
         # PATHS /usr/local
         # PATH_SUFFIXES lib
         )
+message(STATUS "mbedtls lib dir: ${_MBEDCRYPTO_LIBRARY}")
 
 find_library(_MBEDX509_LIBRARY
         NAMES mbedx509
@@ -60,6 +65,7 @@ find_library(_MBEDX509_LIBRARY
         #PATHS /usr/local
         # PATH_SUFFIXES lib
         )
+message(STATUS "mbedtls x509 dir: ${_MBEDX509_LIBRARY}")
 
 find_library(_MBEDTLS_LIBRARY
         NAMES mbedtls
@@ -67,6 +73,7 @@ find_library(_MBEDTLS_LIBRARY
         #PATHS /usr/local
         #PATH_SUFFIXES lib
         )
+message(STATUS "mbedtls lib dir: ${_MBEDTLS_LIBRARY}")
 
 if ("${_MBEDTLS_TLS_LIBRARY}" STREQUAL "_MBEDTLS_TLS_LIBRARY-NOTFOUND")
     message("Failed to find Mbed TLS library")

--- a/src/supplemental/tls/mbedtls/CMakeLists.txt
+++ b/src/supplemental/tls/mbedtls/CMakeLists.txt
@@ -30,24 +30,27 @@ if (NNG_TLS_ENGINE STREQUAL "mbed")
         # mbedTLS v3 has a config file, which should work better than
         # what we do here.  We only make this override locally, to
         # avoid confounding any other package consumers, and we honor overrides.
-        if (NNG_PLATFORM_POSIX)
-          if (NOT (DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG))
-              set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
-              find_package(MbedTLS REQUIRED)
-              unset(CMAKE_FIND_PACKAGE_PREFER_CONFIG)
-          else()
-              find_package(MbedTLS REQUIRED)
-          endif()
-          nng_link_libraries_public(MbedTLS::mbedtls MbedTLS::mbedcrypto MbedTLS::mbedx509)
+        #if (NNG_PLATFORM_POSIX)
+        if (NOT (DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG))
+            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+            find_package(MbedTLS REQUIRED)
+            unset(CMAKE_FIND_PACKAGE_PREFER_CONFIG)
         else()
-          message(STATUS "nng mbedtls root:" ${MBEDTLS_ROOT})
-          nng_include_directories(${MBEDTLS_ROOT}/include)
-          nng_link_libraries(
-            ${MBEDTLS_ROOT}/lib/mbedcrypto.lib
-            ${MBEDTLS_ROOT}/lib/mbedx509.lib
-            ${MBEDTLS_ROOT}/lib/mbedtls.lib
-            bcrypt.lib
-          )
-        endif(NNG_PLATFORM_POSIX)
+            find_package(MbedTLS REQUIRED)
+        endif()
+        nng_link_libraries_public(MbedTLS::mbedtls MbedTLS::mbedcrypto MbedTLS::mbedx509)
+        if (NNG_PLATFORM_WINDOWS)
+          nng_link_libraries(bcrypt.lib)
+        endif (NNG_PLATFORM_WINDOWS)
+        #else()
+        #  message(STATUS "nng mbedtls root:" ${MBEDTLS_ROOT})
+        #  nng_include_directories(${MBEDTLS_ROOT}/include)
+        #  nng_link_libraries(
+        #    ${MBEDTLS_ROOT}/lib/mbedcrypto.lib
+        #    ${MBEDTLS_ROOT}/lib/mbedx509.lib
+        #    ${MBEDTLS_ROOT}/lib/mbedtls.lib
+        #    bcrypt.lib
+        #  )
+        #endif(NNG_PLATFORM_POSIX)
     endif()
 endif()

--- a/src/supplemental/tls/mbedtls/CMakeLists.txt
+++ b/src/supplemental/tls/mbedtls/CMakeLists.txt
@@ -46,6 +46,7 @@ if (NNG_TLS_ENGINE STREQUAL "mbed")
             ${MBEDTLS_ROOT}/lib/mbedcrypto.lib
             ${MBEDTLS_ROOT}/lib/mbedx509.lib
             ${MBEDTLS_ROOT}/lib/mbedtls.lib
+            bcrypt.lib
           )
         endif(NNG_PLATFORM_POSIX)
     endif()

--- a/src/supplemental/tls/mbedtls/CMakeLists.txt
+++ b/src/supplemental/tls/mbedtls/CMakeLists.txt
@@ -30,13 +30,23 @@ if (NNG_TLS_ENGINE STREQUAL "mbed")
         # mbedTLS v3 has a config file, which should work better than
         # what we do here.  We only make this override locally, to
         # avoid confounding any other package consumers, and we honor overrides.
-        if (NOT (DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG))
-            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
-            find_package(MbedTLS REQUIRED)
-            unset(CMAKE_FIND_PACKAGE_PREFER_CONFIG)
+        if (NNG_PLATFORM_POSIX)
+          if (NOT (DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG))
+              set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+              find_package(MbedTLS REQUIRED)
+              unset(CMAKE_FIND_PACKAGE_PREFER_CONFIG)
+          else()
+              find_package(MbedTLS REQUIRED)
+          endif()
+          nng_link_libraries_public(MbedTLS::mbedtls MbedTLS::mbedcrypto MbedTLS::mbedx509)
         else()
-            find_package(MbedTLS REQUIRED)
-        endif()
-        nng_link_libraries_public(MbedTLS::mbedtls MbedTLS::mbedcrypto MbedTLS::mbedx509)
+          message(STATUS "nng mbedtls root:" ${MBEDTLS_ROOT})
+          nng_include_directories(${MBEDTLS_ROOT}/include)
+          nng_link_libraries(
+            ${MBEDTLS_ROOT}/lib/mbedcrypto.lib
+            ${MBEDTLS_ROOT}/lib/mbedx509.lib
+            ${MBEDTLS_ROOT}/lib/mbedxtls.lib
+          )
+        endif(NNG_PLATFORM_POSIX)
     endif()
 endif()

--- a/src/supplemental/tls/mbedtls/CMakeLists.txt
+++ b/src/supplemental/tls/mbedtls/CMakeLists.txt
@@ -45,7 +45,7 @@ if (NNG_TLS_ENGINE STREQUAL "mbed")
           nng_link_libraries(
             ${MBEDTLS_ROOT}/lib/mbedcrypto.lib
             ${MBEDTLS_ROOT}/lib/mbedx509.lib
-            ${MBEDTLS_ROOT}/lib/mbedxtls.lib
+            ${MBEDTLS_ROOT}/lib/mbedtls.lib
           )
         endif(NNG_PLATFORM_POSIX)
     endif()

--- a/src/supplemental/tls/mbedtls/CMakeLists.txt
+++ b/src/supplemental/tls/mbedtls/CMakeLists.txt
@@ -30,7 +30,6 @@ if (NNG_TLS_ENGINE STREQUAL "mbed")
         # mbedTLS v3 has a config file, which should work better than
         # what we do here.  We only make this override locally, to
         # avoid confounding any other package consumers, and we honor overrides.
-        #if (NNG_PLATFORM_POSIX)
         if (NOT (DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG))
             set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
             find_package(MbedTLS REQUIRED)
@@ -42,15 +41,5 @@ if (NNG_TLS_ENGINE STREQUAL "mbed")
         if (NNG_PLATFORM_WINDOWS)
           nng_link_libraries(bcrypt.lib)
         endif (NNG_PLATFORM_WINDOWS)
-        #else()
-        #  message(STATUS "nng mbedtls root:" ${MBEDTLS_ROOT})
-        #  nng_include_directories(${MBEDTLS_ROOT}/include)
-        #  nng_link_libraries(
-        #    ${MBEDTLS_ROOT}/lib/mbedcrypto.lib
-        #    ${MBEDTLS_ROOT}/lib/mbedx509.lib
-        #    ${MBEDTLS_ROOT}/lib/mbedtls.lib
-        #    bcrypt.lib
-        #  )
-        #endif(NNG_PLATFORM_POSIX)
     endif()
 endif()


### PR DESCRIPTION
* mbedtls 3.6.2 requires bcrypt.lib on windows
