### PR TITLE
Added HTTP read response

### DIFF
--- a/include/nng/mqtt/mqtt_client.h
+++ b/include/nng/mqtt/mqtt_client.h
@@ -197,6 +197,7 @@ typedef enum {
 /* Message types & flags */
 #define CMD_UNKNOWN 0x00
 #define CMD_HTTPREQ 0x01
+#define CMD_HTTPRES 0x02
 #define CMD_CONNECT 0x10
 #define CMD_CONNACK 0x20
 #define CMD_PUBLISH 0x30	// indicates PUBLISH packet & MQTTV4 pub packet


### PR DESCRIPTION
Sub PR of https://github.com/nanomq/nanomq/pull/2140

When using a reverse proxy, since NanoMQ doesn't wait for the HTTP response to close the connection, it causes an error 499 randomly (client closed connection before server response)

This fixes the issue