### PR TITLE
* FIX [transport/mqtt] fix CVE-2025-59947

### DIFF
--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -1050,12 +1050,11 @@ nmq_pipe_send_start_v4(tcptran_pipe *p, nni_msg *msg, nni_aio *aio)
 
 		char *sub_topic = info->topic;
 		if (sub_topic[0] == '$') {
-			if (0 ==
-			    strncmp(sub_topic, "$share/", strlen("$share/"))) {
+			if (0 == strncmp(sub_topic, "$share/", strlen("$share/"))) {
 				sub_topic = strchr(sub_topic, '/');
-				sub_topic++;
+				sub_topic != NULL ? sub_topic++ : NULL;
 				sub_topic = strchr(sub_topic, '/');
-				sub_topic++;
+				sub_topic != NULL ? sub_topic++ : NULL;
 			}
 		}
 		// And we never modify msg itself
@@ -1320,9 +1319,9 @@ nmq_pipe_send_start_v5(tcptran_pipe *p, nni_msg *msg, nni_aio *aio)
 			if (0 ==
 			    strncmp(sub_topic, "$share/", strlen("$share/"))) {
 				sub_topic = strchr(sub_topic, '/');
-				sub_topic++;
+				sub_topic != NULL ? sub_topic++ : NULL;
 				sub_topic = strchr(sub_topic, '/');
-				sub_topic++;
+				sub_topic != NULL ? sub_topic++ : NULL;
 			}
 		}
 		if (topic_filtern(sub_topic, (char *) (body + 2), tlen)) {

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -1016,9 +1016,9 @@ tlstran_pipe_send_start_v4(tlstran_pipe *p, nni_msg *msg, nni_aio *aio)
 		if (sub_topic[0] == '$') {
 			if (0 == strncmp(sub_topic, "$share/", strlen("$share/"))) {
 				sub_topic = strchr(sub_topic, '/');
-				sub_topic++;
+				sub_topic != NULL ? sub_topic++ : NULL;
 				sub_topic = strchr(sub_topic, '/');
-				sub_topic++;
+				sub_topic != NULL ? sub_topic++ : NULL;
 			}
 		}
 		if (false == topic_filtern(sub_topic, topic, topic_len))
@@ -1297,9 +1297,9 @@ tlstran_pipe_send_start_v5(tlstran_pipe *p, nni_msg *msg, nni_aio *aio)
 		if (sub_topic[0] == '$') {
 			if (0 == strncmp(sub_topic, "$share/", strlen("$share/"))) {
 				sub_topic = strchr(sub_topic, '/');
-				sub_topic++;
+				sub_topic != NULL ? sub_topic++ : NULL;
 				sub_topic = strchr(sub_topic, '/');
-				sub_topic++;
+				sub_topic != NULL ? sub_topic++ : NULL;
 			}
 		}
 		if (topic_filtern(sub_topic, (char *)(body + 2), tlen)) {

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -607,9 +607,9 @@ wstran_pipe_send_start_v4(ws_pipe *p, nni_msg *msg, nni_aio *aio)
 		if (sub_topic[0] == '$') {
 			if (0 == strncmp(sub_topic, "$share/", strlen("$share/"))) {
 				sub_topic = strchr(sub_topic, '/');
-				sub_topic++;
+				sub_topic != NULL ? sub_topic++ : NULL;
 				sub_topic = strchr(sub_topic, '/');
-				sub_topic++;
+				sub_topic != NULL ? sub_topic++ : NULL;
 			}
 		}
 		if (topic_filtern(sub_topic, (char *) (body + 2), tlen)) {
@@ -811,9 +811,9 @@ wstran_pipe_send_start_v5(ws_pipe *p, nni_msg *msg, nni_aio *aio)
 			if (0 ==
 			    strncmp(sub_topic, "$share/", strlen("$share/"))) {
 				sub_topic = strchr(sub_topic, '/');
-				sub_topic++;
+				sub_topic != NULL ? sub_topic++ : NULL;
 				sub_topic = strchr(sub_topic, '/');
-				sub_topic++;
+				sub_topic != NULL ? sub_topic++ : NULL;
 			}
 		}
 		if (topic_filtern(sub_topic, (char *) (body + 2), tlen)) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Enhanced robustness of MQTT topic filtering by adding protective null-safety checks to prevent potential crashes when processing shared topics with the `$share/` prefix across TCP, TLS, and WebSocket transports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->