### PR TITLE
Fix rule_sql_parse from-clause handling logic.

### DIFF
--- a/src/supplemental/nanolib/rule.c
+++ b/src/supplemental/nanolib/rule.c
@@ -503,7 +503,7 @@ rule_sql_parse(conf_rule *cr, char *sql)
 			len_mid = p - mid + 1;
 		}
 
-		if (mid != NULL && len_mid > 0) {
+		if (mid != NULL && len_mid > (int) strlen("FROM ")) {
 			mid += strlen("FROM ");
 			len_mid -= strlen("FROM ");
 			char *from = (char *) nni_alloc(sizeof(char) * len_mid);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL query parsing to correctly detect and extract FROM clauses only when long enough, preventing incorrect slicing/underflow and improving stability when handling short or malformed queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->