### PR TITLE
* FIX [auth] Fix crash in HTTP auth when using %u/%P with anonymous connections

### DIFF
--- a/src/sp/protocol/mqtt/auth_http.c
+++ b/src/sp/protocol/mqtt/auth_http.c
@@ -240,13 +240,15 @@ set_data(
 
 	if (nni_strcasecmp(req_conf->method, "post") == 0 ||
 	    nni_strcasecmp(req_conf->method, "put") == 0) {
-		if (req_data)
-			nng_http_req_copy_data(req, req_data, strlen(req_data));
-	} else {
-		size_t uri_len =
-		    strlen(nng_http_req_get_uri(req)) + strlen(req_data) + 2;
-		char *uri = nng_alloc(uri_len);
-		sprintf(uri, "%s?%s", nng_http_req_get_uri(req), req_data);
+		if (req_data && req_data[0] != '\0') {
+			nng_http_req_copy_data(
+			    req, req_data, strlen(req_data));
+		}
+	} else if (req_data && req_data[0] != '\0') {
+		const char *base_uri = nng_http_req_get_uri(req);
+		size_t      uri_len  = strlen(base_uri) + strlen(req_data) + 2;
+		char *      uri      = nng_alloc(uri_len);
+		snprintf(uri, uri_len, "%s?%s", base_uri, req_data);
 		nng_http_req_set_uri(req, uri);
 		nng_free(uri, uri_len);
 	}


### PR DESCRIPTION
fixes https://github.com/nanomq/nanomq/issues/2191

1. Add NULL and empty string checks for req_data in auth_http.c:set_data().
2. Avoid calling strlen(req_data) for GET requests when no effective params are built (e.g. username/password missing).
3. Prevent remotely triggerable SIGSEGV and broker DoS caused by HTTP authentication


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MQTT authentication requests no longer send empty POST/PUT bodies and no longer append empty query parameters to other HTTP requests.
  * Request and URI construction made more robust to prevent malformed requests and ensure predictable request behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->