### PR TITLE
* FIX[nmq_mqtt] fix send offline msg with `dup` flag

### DIFF
--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -274,7 +274,7 @@ nano_pipe_timer_cb(void *arg)
 			    (long unsigned) qos_duration * 1250) {
 				p->busy = true;
 				// TODO set max retrying times in nanomq.conf
-				nano_msg_set_dup(rmsg);
+				// nano_msg_set_dup(rmsg);
 				// deliver packet id to transport here
 				nni_aio_set_prov_data(&p->aio_send, (void *)(uintptr_t)pid);
 				// put original msg into sending


### PR DESCRIPTION
Fix send offline message to no-clean-session client with `dup` flag;
> According to the MQTT Protocol description, when sending a message for the first time, there is no need to set the DUP flag regardless of whether it is an offline message or not

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Modified MQTT QoS message resend handling to adjust DUP flag marking during retry intervals, improving protocol compliance for message resend operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->