### PR TITLE
Support to set alpn for client and server with OpenSSL

### DIFF
--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -362,6 +362,7 @@ struct nng_tls_engine_config {
 	nng_tls_mode mode;
 	char        *pass;
 	char        *server_name;
+	char        *alpns;
 	int          auth_mode;
 	nni_list     psks;
 };
@@ -759,6 +760,8 @@ open_config_fini(nng_tls_engine_config *cfg)
 	if (cfg->pass != NULL) {
 		nng_strfree(cfg->pass);
 	}
+	if (cfg->alpns)
+		nng_free(cfg->alpns, 0);
 	trace("end");
 }
 
@@ -795,6 +798,7 @@ open_config_init(nng_tls_engine_config *cfg, enum nng_tls_mode mode)
 
 	trace("start end %p ctx %p", cfg, cfg->ctx);
 	cfg->auth_mode = nng_auth;
+	cfg->alpns = NULL;
 	return (0);
 }
 
@@ -1199,13 +1203,53 @@ open_config_version(nng_tls_engine_config *cfg, nng_tls_version min_ver,
 	return (0);
 }
 
+static int alpn_select_cb(SSL *ssl, const unsigned char **out,
+		unsigned char *outlen, const unsigned char *in,
+		unsigned int inlen, void *arg)
+{
+	nng_tls_engine_config *cfg = arg;
+	log_info("alpn: %s", cfg->alpns);
+	int rv = SSL_select_next_proto((unsigned char **)out, outlen,
+			(const unsigned char *)cfg->alpns, strlen(cfg->alpns), in, inlen);
+	if (rv != OPENSSL_NPN_NEGOTIATED) {
+		// No overlap between client and server protocols.
+		// Return NOACK to ignore ALPN, or FATAL_ALERT to terminate the connection.
+		return SSL_TLSEXT_ERR_NOACK;
+	}
+	NNI_ARG_UNUSED(ssl);
+	return SSL_TLSEXT_ERR_OK;
+}
+
 static int
 open_config_option(nng_tls_engine_config *cfg, const char *name, void *v, size_t sz)
 {
 	if (!name)
 		return NNG_EINVAL;
-	NNI_ARG_UNUSED(cfg);
-	NNI_ARG_UNUSED(v);
+	if (0 == strcmp(name, NNG_OPT_TLS_ALPN)) {
+		if (!v)
+			return NNG_EINVAL;
+		char **alpn_list = v;
+		size_t alpn_len = 0;
+		char * alpn_str = NULL;
+		size_t alpn_idx = 0;
+		for (char *proto = alpn_list[0]; proto != NULL; proto = *(alpn_list ++))
+			alpn_len += (1+strlen(proto));
+		if ((alpn_str = nng_alloc(sizeof(char) * (alpn_len + 1))) == NULL)
+			return NNG_ENOMEM;
+		alpn_list = v;
+		for (char *proto = alpn_list[0]; proto != NULL; proto = *(++ alpn_list)){
+			alpn_str[alpn_idx++] = (unsigned char)strlen(proto);
+			memcpy(alpn_str + alpn_idx, proto, strlen(proto));
+			alpn_idx += strlen(proto);
+		}
+		alpn_str[alpn_idx] = '\0';
+		if (cfg->alpns)
+			nng_free(cfg->alpns, 0);
+		cfg->alpns = alpn_str;
+		SSL_CTX_set_alpn_select_cb(cfg->ctx, alpn_select_cb, cfg);
+		return 0;
+	}
+
 	NNI_ARG_UNUSED(sz);
 	return (NNG_ENOTSUP);
 }

--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -1207,8 +1207,8 @@ static int alpn_select_cb(SSL *ssl, const unsigned char **out,
 		unsigned char *outlen, const unsigned char *in,
 		unsigned int inlen, void *arg)
 {
+	NNI_ARG_UNUSED(ssl);
 	nng_tls_engine_config *cfg = arg;
-	log_info("alpn: %s", cfg->alpns);
 	int rv = SSL_select_next_proto((unsigned char **)out, outlen,
 			(const unsigned char *)cfg->alpns, strlen(cfg->alpns), in, inlen);
 	if (rv != OPENSSL_NPN_NEGOTIATED) {
@@ -1216,7 +1216,6 @@ static int alpn_select_cb(SSL *ssl, const unsigned char **out,
 		// Return NOACK to ignore ALPN, or FATAL_ALERT to terminate the connection.
 		return SSL_TLSEXT_ERR_NOACK;
 	}
-	NNI_ARG_UNUSED(ssl);
 	return SSL_TLSEXT_ERR_OK;
 }
 
@@ -1234,6 +1233,8 @@ open_config_option(nng_tls_engine_config *cfg, const char *name, void *v, size_t
 		size_t alpn_idx = 0;
 		for (char *proto = alpn_list[0]; proto != NULL; proto = *(alpn_list ++))
 			alpn_len += (1+strlen(proto));
+		if (alpn_len == 0)
+			return NNG_EINVAL;
 		if ((alpn_str = nng_alloc(sizeof(char) * (alpn_len + 1))) == NULL)
 			return NNG_ENOMEM;
 		alpn_list = v;
@@ -1246,7 +1247,15 @@ open_config_option(nng_tls_engine_config *cfg, const char *name, void *v, size_t
 		if (cfg->alpns)
 			nng_free(cfg->alpns, 0);
 		cfg->alpns = alpn_str;
-		SSL_CTX_set_alpn_select_cb(cfg->ctx, alpn_select_cb, cfg);
+		if (cfg->mode == NNG_TLS_MODE_SERVER) {
+			SSL_CTX_set_alpn_select_cb(cfg->ctx, alpn_select_cb, cfg);
+		} else {
+			if (SSL_CTX_set_alpn_protos(cfg->ctx,
+						(const unsigned char *)cfg->alpns, alpn_idx) != 0) {
+				ERR_print_errors_fp(stderr);
+				return NNG_ECRYPTO;
+			}
+		}
 		return 0;
 	}
 

--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -1213,8 +1213,8 @@ static int alpn_select_cb(SSL *ssl, const unsigned char **out,
 			(const unsigned char *)cfg->alpns, strlen(cfg->alpns), in, inlen);
 	if (rv != OPENSSL_NPN_NEGOTIATED) {
 		// No overlap between client and server protocols.
-		// Return NOACK to ignore ALPN, or FATAL_ALERT to terminate the connection.
-		return SSL_TLSEXT_ERR_NOACK;
+		// Return FATAL_ALERT to terminate the connection.
+		return SSL_TLSEXT_ERR_ALERT_FATAL;
 	}
 	return SSL_TLSEXT_ERR_OK;
 }
@@ -1231,7 +1231,7 @@ open_config_option(nng_tls_engine_config *cfg, const char *name, void *v, size_t
 		size_t alpn_len = 0;
 		char * alpn_str = NULL;
 		size_t alpn_idx = 0;
-		for (char *proto = alpn_list[0]; proto != NULL; proto = *(alpn_list ++))
+		for (char *proto = alpn_list[0]; proto != NULL; proto = *(++ alpn_list))
 			alpn_len += (1+strlen(proto));
 		if (alpn_len == 0)
 			return NNG_EINVAL;
@@ -1239,6 +1239,10 @@ open_config_option(nng_tls_engine_config *cfg, const char *name, void *v, size_t
 			return NNG_ENOMEM;
 		alpn_list = v;
 		for (char *proto = alpn_list[0]; proto != NULL; proto = *(++ alpn_list)){
+			if (strlen(proto) > 255 || strlen(proto) == 0) {
+				log_warn("proto length over 255 or eq 0 is NOT supported (%s). Skip", proto);
+				continue;
+			}
 			alpn_str[alpn_idx++] = (unsigned char)strlen(proto);
 			memcpy(alpn_str + alpn_idx, proto, strlen(proto));
 			alpn_idx += strlen(proto);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ALPN (Application Layer Protocol Negotiation) support to the TLS engine, enabling enhanced protocol negotiation for both server and client modes during secure connections. Includes fallback handling when protocol negotiation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->