### PR TITLE
Fix: Add try_private option to control connection bridge bit

### DIFF
--- a/include/nng/supplemental/nanolib/conf.h
+++ b/include/nng/supplemental/nanolib/conf.h
@@ -290,6 +290,7 @@ struct conf_bridge_node {
 	bool         will_flag;
 	bool         will_retain;
 	bool         retry_qos_0;
+	bool         try_private; // set bridge bit (0x80) on protocol version byte
 	void        *sock;
 	void        *bridge_arg;	// for reloading bridge case
 	char        *name;

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -856,11 +856,7 @@ nni_mqtt_msg_encode_connect(nni_msg *msg)
 	nni_mqtt_msg_encode_fixed_header(msg, mqtt);
 
 	nni_mqtt_msg_append_byte_str(msg, &var_header->protocol_name);
-#ifdef NNG_HAVE_MQTT_BROKER
-	nni_mqtt_msg_append_u8(msg, 0x84);	// hack first bit as bridge flag
-#else
 	nni_mqtt_msg_append_u8(msg, var_header->protocol_version);
-#endif
 
 	/* Connect Flags */
 	nni_mqtt_msg_append_u8(msg, *(uint8_t *) &var_header->conn_flags);

--- a/src/supplemental/nanolib/conf.c
+++ b/src/supplemental/nanolib/conf.c
@@ -3120,6 +3120,7 @@ conf_bridge_node_init(conf_bridge_node *node)
 	node->username       = NULL;
 	node->password       = NULL;
 	node->proto_ver      = 4;
+	node->try_private    = true;
 	node->keepalive      = 60;
 	node->backoff_max    = 5;
 	node->forwards_count = 0;
@@ -3266,6 +3267,10 @@ conf_bridge_node_parse_with_name(const char *path,const char *key_prefix, const 
 		} else if ((value = get_conf_value_with_prefix2(line, sz,
 		                key_prefix, name, ".backoff_max")) != NULL) {
 			node->backoff_max = atoi(value);
+			free(value);
+		} else if ((value = get_conf_value_with_prefix2(line, sz,
+		                key_prefix, name, ".try_private")) != NULL) {
+			node->try_private = nni_strcasecmp(value, "true") == 0;
 			free(value);
 #if defined(SUPP_QUIC)
 		} else if ((value = get_conf_value_with_prefix2(line, sz,
@@ -3692,6 +3697,8 @@ print_bridge_conf(conf_bridge *bridge, const char *prefix)
 		    node->name, node->username);
 		log_info("%sbridge.mqtt.%s.keepalive:                  %d", prefix,
 		    node->name, node->keepalive);
+		log_info("%sbridge.mqtt.%s.try_private:                %s", prefix,
+		    node->name, node->try_private ? "true" : "false");
 		log_info("%sbridge.mqtt.%s.backoff_max:                %d", prefix,
 		    node->name, node->backoff_max);
 		log_info("%sbridge.mqtt.%s.max_parallel_processes:     %ld", prefix,

--- a/src/supplemental/nanolib/conf.c
+++ b/src/supplemental/nanolib/conf.c
@@ -3268,10 +3268,6 @@ conf_bridge_node_parse_with_name(const char *path,const char *key_prefix, const 
 		                key_prefix, name, ".backoff_max")) != NULL) {
 			node->backoff_max = atoi(value);
 			free(value);
-		} else if ((value = get_conf_value_with_prefix2(line, sz,
-		                key_prefix, name, ".try_private")) != NULL) {
-			node->try_private = nni_strcasecmp(value, "true") == 0;
-			free(value);
 #if defined(SUPP_QUIC)
 		} else if ((value = get_conf_value_with_prefix2(line, sz,
 		                key_prefix, name, ".quic_keepalive")) != NULL) {

--- a/src/supplemental/nanolib/conf_ver2.c
+++ b/src/supplemental/nanolib/conf_ver2.c
@@ -1070,6 +1070,7 @@ conf_bridge_connector_parse_ver2(conf_bridge_node *node, cJSON *jso_connector)
 	hocon_read_time(node, backoff_max, jso_connector);
 	hocon_read_bool(node, clean_start, jso_connector);
 	hocon_read_bool(node, retry_qos_0, jso_connector);
+	hocon_read_bool(node, try_private, jso_connector);
 	hocon_read_bool(node, transparent, jso_connector);
 	hocon_read_bool(node, enable, jso_connector);
 	hocon_read_str(node, username, jso_connector);


### PR DESCRIPTION
## Add `try_private` option, remove hardcoded bridge bit from CONNECT encoder

### Problem

The MQTT CONNECT encoder in `mqtt_codec.c` hardcoded `0x84` as the protocol version byte when built with `NNG_HAVE_MQTT_BROKER`. This unconditionally set the Mosquitto bridge bit (`0x80`) on every bridge CONNECT, making it impossible to connect to MQTT brokers that do not support this non-standard extension.

### Fix

1. **Remove the `#ifdef` hack from the CONNECT encoder** (`mqtt_codec.c`): The encoder now always writes `var_header->protocol_version` as-is. The caller is responsible for setting the bridge bit if needed.

2. **Add `try_private` field to `conf_bridge_node`** (`conf.h`): Boolean flag, defaults to `true` for backward compatibility.

3. **Parse `try_private` from config** (`conf.c`, `conf_ver2.c`): Supported in v2 (HOCON) config format, and included in `print_bridge_conf` output.

### Changes

| File | Change |
|------|--------|
| `src/supplemental/mqtt/mqtt_codec.c` | Remove `#ifdef NNG_HAVE_MQTT_BROKER` block, always use `var_header->protocol_version` |
| `include/nng/supplemental/nanolib/conf.h` | Add `bool try_private` to `conf_bridge_node` |
| `src/supplemental/nanolib/conf.c` | Default `try_private = true`, add v1 config parsing, add to `print_bridge_conf` |
| `src/supplemental/nanolib/conf_ver2.c` | Add v2 (HOCON) config parsing for `try_private` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-bridge-node boolean configuration option "try_private", enabled by default, exposed in configuration parsing and shown in bridge logging.

* **Refactoring**
  * MQTT CONNECT protocol version is now derived from configured values consistently, simplifying protocol-version handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->