### PR TITLE
Add bridge exclusion

### DIFF
--- a/include/nng/supplemental/nanolib/conf.h
+++ b/include/nng/supplemental/nanolib/conf.h
@@ -223,6 +223,11 @@ typedef struct conf_websocket conf_websocket;
 #define NO_QOS    3 // default QoS level value for forwarding bridge msg, 3 = keep old qos
 
 typedef struct {
+	char       *topic;
+	size_t 		  topic_len;
+} exclusions;
+
+typedef struct {
 	char       *remote_topic;
 	uint32_t    remote_topic_len;
 	char       *local_topic;
@@ -309,10 +314,12 @@ struct conf_bridge_node {
 	uint64_t     resend_interval; // resend caching message interval (ms)
 	uint64_t     resend_wait;
 	size_t       sub_count;
+	size_t       exclusions_count;
 	size_t       forwards_count;
 	size_t       max_recv_queue_len;
 	size_t       max_send_queue_len;
 	topics     **forwards_list;
+	exclusions **exclusions_list;
 	uint64_t     parallel;
 	topics     **sub_list;
 	conf_tls     tls;

--- a/src/supplemental/nanolib/conf.c
+++ b/src/supplemental/nanolib/conf.c
@@ -3580,6 +3580,19 @@ conf_bridge_node_destroy(conf_bridge_node *node)
 		cvector_free(node->forwards_list);
 		node->forwards_list = NULL;
 	}
+	if (node->exclusions_count > 0 && node->exclusions_list) {
+		for (size_t j = 0; j < node->exclusions_count; j++) {
+			exclusions *e = node->exclusions_list[j];
+			if (e->topic) {
+				free(e->topic);
+				e->topic = NULL;
+			}
+			NNI_FREE_STRUCT(e);
+		}
+		node->exclusions_count = 0;
+		cvector_free(node->exclusions_list);
+		node->exclusions_list = NULL;
+	}
 	if (node->sub_count > 0 && node->sub_list) {
 		for (size_t i = 0; i < node->sub_count; i++) {
 			topics *s = node->sub_list[i];
@@ -3702,7 +3715,7 @@ print_bridge_conf(conf_bridge *bridge, const char *prefix)
 		    node->name, node->resend_wait);
 		log_info("%sbridge.mqtt.%s.cancel_timeout:             %ld", prefix,
 		    node->name, node->cancel_timeout);
-		log_info("%sbridge.mqtt.%s.hybrid_bridging       :     %s", prefix,
+		log_info("%sbridge.mqtt.%s.hybrid_bridging:            %s", prefix,
 		    node->name, node->hybrid ? "true" : "false");
 		log_info("%sbridge.mqtt.%s.hybrid_servers: ", prefix, node->name);
 		for (size_t j = 0; j < cvector_size(node->hybrid_servers); j++) {
@@ -3746,13 +3759,20 @@ print_bridge_conf(conf_bridge *bridge, const char *prefix)
 
 		for (size_t j = 0; j < node->forwards_count; j++) {
 			log_info(
-			    "\t[%ld] remote topic:        %.*s", j,
+			    "\t[%ld] remote topic:\t\t%.*s", j,
 										node->forwards_list[j]->remote_topic_len,
 										node->forwards_list[j]->remote_topic);
 			log_info(
-			    "\t[%ld] local topic:        %.*s", j,
+			    "\t[%ld] local topic:\t\t%.*s", j,
 										node->forwards_list[j]->local_topic_len,
 										node->forwards_list[j]->local_topic);
+		}
+		log_info("%sbridge.mqtt.%s.exclusions: ", prefix, node->name);
+		for (size_t j = 0; j < node->exclusions_count; j++) {
+			log_info(
+				"\t[%ld] topic:\t\t%.*s", j, 
+				node->exclusions_list[j]->topic_len,
+				node->exclusions_list[j]->topic);
 		}
 		log_info(
 		    "%sbridge.mqtt.%s.subscription: ", prefix, node->name);

--- a/src/supplemental/nanolib/conf_ver2.c
+++ b/src/supplemental/nanolib/conf_ver2.c
@@ -1264,6 +1264,23 @@ conf_bridge_node_parse(
 	}
 	node->forwards_count = cvector_size(node->forwards_list);
 
+	cJSON *exclusions_list = hocon_get_obj("exclusions", obj);
+	cJSON *exclusion = NULL;
+	cJSON_ArrayForEach(exclusion, exclusions_list)
+	{
+		exclusions *exc = NNI_ALLOC_STRUCT(exc);
+		hocon_read_str(exc, topic, exclusion);
+		size_t topic_len = exc->topic ? strlen(exc->topic) : 0;
+		if (topic_len == 0) {
+			log_error("Exclusion topic should not be null or empty");
+			NNI_FREE_STRUCT(exc); 
+			break;
+		}
+		exc->topic_len = topic_len;
+		cvector_push_back(node->exclusions_list, exc);
+	}
+	node->exclusions_count = cvector_size(node->exclusions_list);
+
 	cJSON *subscriptions = hocon_get_obj("subscription", obj);
 
 	cJSON *subscription = NULL;
@@ -1919,7 +1936,6 @@ conf_authorization_prase_ver2(conf *config, cJSON *jso)
 		conf_auth_http_parse_ver2(config, jso_auth_http);
 	}
 	cJSON *jso_auth_pwd = hocon_get_obj("auth.password", jso);
-
 	if (jso_auth_pwd) {
 		conf_auth_parse_ver2(config, jso_auth_pwd);
 	}


### PR DESCRIPTION
*Recreated after i completly destroid #1464. Git submodules are such fun.*

This pull request introduces support for "exclusions" in the bridge configuration, allowing specific topics to be excluded from bridge operations. The changes include updates to the bridge node structure, parsing logic, cleanup routines, and configuration printing to handle exclusions alongside existing forwards and subscriptions.

**Bridge exclusions support:**

* Added a new `exclusions` struct and corresponding `exclusions_list` and `exclusions_count` fields to the `conf_bridge_node` structure in `conf.h`, enabling storage of excluded topics. [[1]](diffhunk://#diff-0659e7bca02caca43e7f1e07cb50fa1cef4dfb73f9993b81234f3f195a7445baR225-R229) [[2]](diffhunk://#diff-0659e7bca02caca43e7f1e07cb50fa1cef4dfb73f9993b81234f3f195a7445baR317-R322)
* Updated the bridge node parsing function (`conf_bridge_node_parse`) to read and validate the `exclusions` array from the configuration, allocate exclusion entries, and track their count.
* Enhanced the bridge node destruction logic (`conf_bridge_node_destroy`) to properly free all allocated exclusions and their topics, preventing memory leaks.
* Modified the configuration printing function (`print_bridge_conf`) to display the exclusions for each bridge node, improving debuggability and transparency.

**Minor code cleanup:**

* Removed an unnecessary blank line in the authorization parsing function for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added support for topic exclusions in bridge node configuration, allowing users to specify topics that should be excluded from bridge forwarding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->