### PR TITLE
* FIX [proto/mqtt] Fixed the statistic if cached bytes.

### DIFF
--- a/src/mqtt/protocol/mqtt/mqtt_client.c
+++ b/src/mqtt/protocol/mqtt/mqtt_client.c
@@ -448,6 +448,12 @@ mqtt_sock_close(void *arg)
 		aio       = ctx->saio;
 		ctx->saio = NULL;
 		msg       = nni_aio_get_msg(aio);
+#ifdef NNG_ENABLE_STATS
+		if (msg) {
+			nni_stat_inc(&s->msg_send_drop, 1);
+			nni_stat_dec(&s->msg_bytes_cached, nni_msg_len(msg));
+		}
+#endif
 		nni_aio_set_msg(aio, NULL);
 		nni_aio_finish_error(aio, NNG_ECLOSED);
 		nni_msg_free(msg);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved statistics tracking for dropped messages during connection closure, ensuring accurate monitoring of message drop counts and cached message bytes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->