### PR TITLE
Fix fail to build with `parquet`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,10 +328,18 @@ if (NNG_ENABLE_SCRAM)
     find_package(OpenSSL)
     if (NNG_ENABLE_QUIC)
     else ()
-        target_link_libraries(nng PRIVATE OpenSSL::SSL OpenSSL:Crypto)
+        target_link_libraries(nng PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+        target_link_libraries(nng_testing PRIVATE OpenSSL::SSL OpenSSL::Crypto)
     endif (NNG_ENABLE_QUIC)
 
     add_definitions(-DSUPP_SCRAM)
+endif ()
+
+if (NNG_ENABLE_PARQUET)
+    find_package(OpenSSL REQUIRED)
+    # parquet enables AES helpers that require EVP_* symbols from libcrypto.
+    target_link_libraries(nng PRIVATE OpenSSL::Crypto)
+    target_link_libraries(nng_testing PRIVATE OpenSSL::Crypto)
 endif ()
 
 if (ENABLE_LICENSE_STD OR ENABLE_LICENSE_DK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,9 +337,11 @@ endif ()
 
 if (NNG_ENABLE_PARQUET)
     find_package(OpenSSL REQUIRED)
-    # parquet enables AES helpers that require EVP_* symbols from libcrypto.
-    target_link_libraries(nng PRIVATE OpenSSL::Crypto)
-    target_link_libraries(nng_testing PRIVATE OpenSSL::Crypto)
+    if (NOT NNG_ENABLE_QUIC)
+        # parquet enables AES helpers that require EVP_* symbols from libcrypto.
+        target_link_libraries(nng PRIVATE OpenSSL::Crypto)
+        target_link_libraries(nng_testing PRIVATE OpenSSL::Crypto)
+    endif (NNG_ENABLE_QUIC)
 endif ()
 
 if (ENABLE_LICENSE_STD OR ENABLE_LICENSE_DK)


### PR DESCRIPTION
Fixes build with parquet



Here is the compiling error logs: 
```
[ 47%] Linking CXX executable reconnect_test
/usr/bin/ld: ../../libnng_testing.a(aes.c.o): undefined reference to symbol 'EVP_EncryptUpdate@@OPENSSL_3.0.0'
/usr/bin/ld: /usr/lib64/libcrypto.so.3: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
/usr/bin/ld: ../../libnng_testing.a(aes.c.o): undefined reference to symbol 'EVP_EncryptUpdate@@OPENSSL_3.0.0'
/usr/bin/ld: /usr/lib64/libcrypto.so.3: error adding symbols: DSO missing from command line
make[2]: *** [nng/src/core/CMakeFiles/aio_test.dir/build.make:104: nng/src/core/aio_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:1994: nng/src/core/CMakeFiles/aio_test.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
/usr/bin/ld: ../../libnng_testing.a(aes.c.o): undefined reference to symbol 'EVP_EncryptUpdate@@OPENSSL_3.0.0'
/usr/bin/ld: /usr/lib64/libcrypto.so.3: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
/usr/bin/ld: ../../libnng_testing.a(aes.c.o): undefined reference to symbol 'EVP_EncryptUpdate@@OPENSSL_3.0.0'
/usr/bin/ld: /usr/lib64/libcrypto.so.3: error adding symbols: DSO missing from command line
/usr/bin/ld: ../../libnng_testing.a(aes.c.o): undefined reference to symbol 'EVP_EncryptUpdate@@OPENSSL_3.0.0'
/usr/bin/ld: /usr/lib64/libcrypto.so.3: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [nng/src/core/CMakeFiles/message_test.dir/build.make:104: nng/src/core/message_test] Error 1
collect2: error: ld returned 1 exit status
make[1]: *** [CMakeFiles/Makefile2:2186: nng/src/core/CMakeFiles/message_test.dir/all] Error 2
/usr/bin/ld: ../../libnng_testing.a(aes.c.o): undefined reference to symbol 'EVP_EncryptUpdate@@OPENSSL_3.0.0'
/usr/bin/ld: /usr/lib64/libcrypto.so.3: error adding symbols: DSO missing from command line
make[2]: *** [nng/src/core/CMakeFiles/buf_size_test.dir/build.make:104: nng/src/core/buf_size_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:2026: nng/src/core/CMakeFiles/buf_size_test.dir/all] Error 2
collect2: error: ld returned 1 exit status
make[2]: *** [nng/src/core/CMakeFiles/init_test.dir/build.make:104: nng/src/core/init_test] Error 1
/usr/bin/ld: ../../libnng_testing.a(aes.c.o): undefined reference to symbol 'EVP_EncryptUpdate@@OPENSSL_3.0.0'
/usr/bin/ld: /usr/lib64/libcrypto.so.3: error adding symbols: DSO missing from command line
make[1]: *** [CMakeFiles/Makefile2:2122: nng/src/core/CMakeFiles/init_test.dir/all] Error 2
collect2: error: ld returned 1 exit status
make[2]: *** [nng/src/core/CMakeFiles/id_test.dir/build.make:104: nng/src/core/id_test] Error 1
collect2: error: ld returned 1 exit status
make[1]: *** [CMakeFiles/Makefile2:2090: nng/src/core/CMakeFiles/id_test.dir/all] Error 2
make[2]: *** [nng/src/core/CMakeFiles/list_test.dir/build.make:104: nng/src/core/list_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:2154: nng/src/core/CMakeFiles/list_test.dir/all] Error 2
/usr/bin/ld: ../../libnng_testing.a(aes.c.o): undefined reference to symbol 'EVP_EncryptUpdate@@OPENSSL_3.0.0'
/usr/bin/ld: /usr/lib64/libcrypto.so.3: error adding symbols: DSO missing from command line
make[2]: *** [nng/src/core/CMakeFiles/reconnect_test.dir/build.make:104: nng/src/core/reconnect_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:2218: nng/src/core/CMakeFiles/reconnect_test.dir/all] Error 2
collect2: error: ld returned 1 exit status
make[2]: *** [nng/src/core/CMakeFiles/errors_test.dir/build.make:104: nng/src/core/errors_test] Error 1
make[1]: *** [CMakeFiles/Makefile2:2058: nng/src/core/CMakeFiles/errors_test.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```