### PR TITLE
Fix a heap use after free bug of conn_param

### DIFF
--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -843,11 +843,11 @@ close_pipe(nano_pipe *p)
 
 	nni_atomic_set_bool(&p->closed, true);
 	if (nni_list_active(&s->recvpipes, p)) {
-		nni_msg *msg = nni_aio_get_msg(&p->aio_recv);
-					uint8_t type = nng_msg_cmd_type(msg);
-	if (type == CMD_SUBSCRIBE || type == CMD_UNSUBSCRIBE ||
-		   		type == CMD_CONNACK || type == CMD_PUBLISH)
-		conn_param_free(p->conn_param);
+		nni_msg *msg  = nni_aio_get_msg(&p->aio_recv);
+		uint8_t  type = nng_msg_cmd_type(msg);
+		if (type == CMD_SUBSCRIBE || type == CMD_UNSUBSCRIBE ||
+		    type == CMD_CONNACK || type == CMD_PUBLISH)
+			conn_param_free(p->conn_param);
 		if (msg)
 			nni_msg_free(msg);
 
@@ -911,10 +911,11 @@ nano_pipe_close(void *arg)
 			nni_atomic_swap_bool(&npipe->p_closed, false);
 			if (nni_list_active(&s->recvpipes, p)) {
 				nni_msg *tmsg = nni_aio_get_msg(&p->aio_recv);
-							uint8_t type = nng_msg_cmd_type(tmsg);
-	if (type == CMD_SUBSCRIBE || type == CMD_UNSUBSCRIBE ||
-		   		type == CMD_CONNACK || type == CMD_PUBLISH)
-		conn_param_free(p->conn_param);
+				uint8_t  type = nng_msg_cmd_type(tmsg);
+				if (type == CMD_SUBSCRIBE ||
+				    type == CMD_UNSUBSCRIBE ||
+				    type == CMD_CONNACK || type == CMD_PUBLISH)
+					conn_param_free(p->conn_param);
 				if (tmsg)
 					nni_msg_free(tmsg);
 

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -844,12 +844,14 @@ close_pipe(nano_pipe *p)
 	nni_atomic_set_bool(&p->closed, true);
 	if (nni_list_active(&s->recvpipes, p)) {
 		nni_msg *msg  = nni_aio_get_msg(&p->aio_recv);
-		uint8_t  type = nng_msg_cmd_type(msg);
-		if (type == CMD_SUBSCRIBE || type == CMD_UNSUBSCRIBE ||
-		    type == CMD_CONNACK || type == CMD_PUBLISH)
-			conn_param_free(p->conn_param);
-		if (msg)
+		if (msg) {
+			uint8_t  type = nng_msg_cmd_type(msg);
+			if (type == CMD_SUBSCRIBE || type == CMD_UNSUBSCRIBE ||
+				type == CMD_CONNACK || type == CMD_PUBLISH)
+				conn_param_free(p->conn_param);
 			nni_msg_free(msg);
+			nni_aio_set_msg(&p->aio_recv, NULL);
+		}
 
 		nni_list_remove(&s->recvpipes, p);
 	}
@@ -911,14 +913,16 @@ nano_pipe_close(void *arg)
 			nni_atomic_swap_bool(&npipe->p_closed, false);
 			if (nni_list_active(&s->recvpipes, p)) {
 				nni_msg *tmsg = nni_aio_get_msg(&p->aio_recv);
-				uint8_t  type = nng_msg_cmd_type(tmsg);
-				if (type == CMD_SUBSCRIBE ||
-				    type == CMD_UNSUBSCRIBE ||
-				    type == CMD_CONNACK || type == CMD_PUBLISH)
-					conn_param_free(p->conn_param);
-				if (tmsg)
+				if (tmsg) {
+					uint8_t type = nng_msg_cmd_type(tmsg);
+					if (type == CMD_SUBSCRIBE ||
+					    type == CMD_UNSUBSCRIBE ||
+					    type == CMD_CONNACK ||
+					    type == CMD_PUBLISH)
+						conn_param_free(p->conn_param);
 					nni_msg_free(tmsg);
-
+					nni_aio_set_msg(&p->aio_recv, NULL);
+				}
 				nni_list_remove(&s->recvpipes, p);
 			}
 			nano_nni_lmq_flush(&p->rlmq, false);

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -844,9 +844,13 @@ close_pipe(nano_pipe *p)
 	nni_atomic_set_bool(&p->closed, true);
 	if (nni_list_active(&s->recvpipes, p)) {
 		nni_msg *msg = nni_aio_get_msg(&p->aio_recv);
+					uint8_t type = nng_msg_cmd_type(msg);
+	if (type == CMD_SUBSCRIBE || type == CMD_UNSUBSCRIBE ||
+		   		type == CMD_CONNACK || type == CMD_PUBLISH)
+		conn_param_free(p->conn_param);
 		if (msg)
 			nni_msg_free(msg);
-		conn_param_free(p->conn_param);
+
 		nni_list_remove(&s->recvpipes, p);
 	}
 	// only remove matched pipe, could have been overwritten
@@ -907,9 +911,13 @@ nano_pipe_close(void *arg)
 			nni_atomic_swap_bool(&npipe->p_closed, false);
 			if (nni_list_active(&s->recvpipes, p)) {
 				nni_msg *tmsg = nni_aio_get_msg(&p->aio_recv);
+							uint8_t type = nng_msg_cmd_type(tmsg);
+	if (type == CMD_SUBSCRIBE || type == CMD_UNSUBSCRIBE ||
+		   		type == CMD_CONNACK || type == CMD_PUBLISH)
+		conn_param_free(p->conn_param);
 				if (tmsg)
 					nni_msg_free(tmsg);
-				conn_param_free(p->conn_param);
+
 				nni_list_remove(&s->recvpipes, p);
 			}
 			nano_nni_lmq_flush(&p->rlmq, false);
@@ -1217,10 +1225,16 @@ nano_pipe_recv_cb(void *arg)
 	if ((ctx = nni_list_first(&s->recvq)) == NULL) {
 		// No one waiting to receive yet, holding pattern.
 		// Dont use waitlmq cache, cause back-pressure.
-		if (!nni_list_active(&s->recvpipes, p))
+		if (!nni_list_active(&s->recvpipes, p)) {
 			nni_list_append(&s->recvpipes, p);
-		else
+		} else {
+			nni_aio_set_msg(&p->aio_recv, NULL);
+			nni_msg_free(msg);
 			log_error("Unscheduled receving!");
+			if (type == CMD_SUBSCRIBE || type == CMD_UNSUBSCRIBE ||
+			    type == CMD_CONNACK || type == CMD_PUBLISH)
+				conn_param_free(cparam);
+		}
 		nni_mtx_unlock(&s->lk);
 		// this gonna cause broker lagging, so we reduce outputs 1 in 256
 		rotate ++;

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -229,7 +229,7 @@ tcptran_pipe_fini(void *arg)
 	}
 	nni_mtx_lock(&p->mtx);
 	if (p->tcp_cparam) {
-		conn_param_free(p->tcp_cparam);
+		conn_param_free(p->tcp_cparam);	//reap thread working
 		p->tcp_cparam = NULL;
 	}
 	if (p->rxmsg != NULL)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved MQTT message handling with refined connection parameter cleanup logic, optimizing resource usage for specific message types
* Enhanced error handling for scenarios where messages arrive without a receiver context, improving system resilience and preventing unscheduled message handling issues
* Optimized transport layer cleanup behavior for better resource management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->