### PR TITLE
Fix double free in `nni_mqtt_msg_decode_subscribe()`

### DIFF
--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -385,6 +385,7 @@ mqtt_msg_content_free(nni_mqtt_proto_data *mqtt)
 			nni_free(mqtt->payload.subscribe.topic_arr,
 			    mqtt->payload.subscribe.topic_count *
 			        sizeof(nni_mqtt_topic_qos));
+			mqtt->payload.subscribe.topic_arr   = NULL;
 			mqtt->payload.subscribe.topic_count = 0;
 		}
 		if (mqtt->var_header.subscribe.properties) {
@@ -404,6 +405,7 @@ mqtt_msg_content_free(nni_mqtt_proto_data *mqtt)
 			nni_free(mqtt->payload.unsubscribe.topic_arr,
 			    mqtt->payload.unsubscribe.topic_count *
 			        sizeof(nni_mqtt_topic));
+			mqtt->payload.unsubscribe.topic_arr   = NULL;
 			mqtt->payload.unsubscribe.topic_count = 0;
 		}
 		if (mqtt->var_header.unsubscribe.properties) {
@@ -2134,6 +2136,8 @@ nni_mqtt_msg_decode_subscribe(nni_msg *msg)
 
 err:
 	nni_free(spld->topic_arr, sizeof(mqtt_topic_qos) * topic_count);
+	spld->topic_arr   = NULL;
+	spld->topic_count = 0;
 	return ret;
 }
 
@@ -2215,6 +2219,8 @@ nni_mqttv5_msg_decode_subscribe(nni_msg *msg)
 
 err:
 	nni_free(spld->topic_arr, sizeof(mqtt_topic_qos) * topic_count);
+	spld->topic_arr   = NULL;
+	spld->topic_count = 0;
 	return ret;
 }
 
@@ -2257,6 +2263,8 @@ nni_mqtt_msg_decode_suback(nni_msg *msg)
 err:
 	nni_free(mqtt->payload.suback.ret_code_arr,
 	    mqtt->payload.suback.ret_code_count);
+	mqtt->payload.suback.ret_code_arr   = NULL;
+	mqtt->payload.suback.ret_code_count = 0;
 	return ret;
 }
 
@@ -2306,6 +2314,8 @@ nni_mqttv5_msg_decode_suback(nni_msg *msg)
 err:
 	nni_free(mqtt->payload.suback.ret_code_arr,
 	    mqtt->payload.suback.ret_code_count);
+	mqtt->payload.suback.ret_code_arr   = NULL;
+	mqtt->payload.suback.ret_code_count = 0;
 	return ret;
 }
 
@@ -2700,6 +2710,8 @@ nni_mqtt_msg_decode_unsubscribe(nni_msg *msg)
 
 err:
 	nni_free(uspld->topic_arr, topic_count * sizeof(mqtt_buf));
+	uspld->topic_arr   = NULL;
+	uspld->topic_count = 0;
 
 	return ret;
 }
@@ -2769,6 +2781,8 @@ nni_mqttv5_msg_decode_unsubscribe(nni_msg *msg)
 
 err:
 	nni_free(uspld->topic_arr, topic_count * sizeof(mqtt_buf));
+	uspld->topic_arr   = NULL;
+	uspld->topic_count = 0;
 
 	return ret;
 }

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -704,6 +704,7 @@ destory_subscribe(nni_mqtt_proto_data *mqtt)
 {
 	nni_mqtt_topic_qos_array_free(mqtt->payload.subscribe.topic_arr,
 	    mqtt->payload.subscribe.topic_count);
+	mqtt->payload.subscribe.topic_arr   = NULL;	
 	mqtt->payload.subscribe.topic_count = 0;
 }
 
@@ -734,6 +735,7 @@ destory_unsubscribe(nni_mqtt_proto_data *mqtt)
 {
 	nni_mqtt_topic_array_free(mqtt->payload.unsubscribe.topic_arr,
 	    mqtt->payload.unsubscribe.topic_count);
+	mqtt->payload.unsubscribe.topic_arr   = NULL;
 	mqtt->payload.unsubscribe.topic_count = 0;
 }
 


### PR DESCRIPTION
Fix the following issue:

Description
Summary
A double-free vulnerability exists in NanoMQ's MQTT message codec (mqtt_codec.c) when a NanoMQ MQTT client decodes a
malformed SUBSCRIBE packet.
DetailsPackage
nanomq (NNG MQTT client library)
Affected Versions
NanoMQ <= 0.24.11 (confirmed)
All versions using the NanoNNG MQTT client SDK with nni_mqtt_msg_decode_subscribe() are likely affected
Root Cause
The function nni_mqtt_msg_decode_subscribe() in nng/src/supplemental/mqtt/mqtt_codec.c allocates a topic_arr array, then frees it in the error path without nullifying the pointer. When the caller (nni_msg_free()) subsequently invokes mqtt_msg_content_free(), the same pointer is freed again.
A malicious MQTT broker can exploit this to crash any connecting NanoMQ MQTTv3.1.1 client process, resulting in remote denial of service. On systems with older glibc versions (< 2.32), this may lead to heap corruption exploitable for arbitrary code execution.
PoC
mkdir build_asan && cd build_asan
cmake .. -DCMAKE_C_FLAGS="-fsanitize=address -g -O0" \
         -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address" \
         -DBUILD_CLIENT=ON -DNNG_ENABLE_TLS=OFF
-DENABLE_QUIC=OFF
make nanomq_cli
Malicious Payload
82 0c 00 01 00 02 74 30 00 00 64 78 78 00
Result
==24469==ERROR: AddressSanitizer: attempting double-free on
0x604000002010 in thread T20:
    #0 free
    #1 nni_free posix_alloc.c:46
    #2 mqtt_msg_content_free mqtt_codec.c:384
    #3 nni_mqtt_msg_free mqtt_codec.c:443
    #4 nni_msg_free message.c:483
    #5 mqtt_recv_cb mqtt_client.c:963

freed by thread T20 here:
    #1 nni_free posix_alloc.c:46
    #2 nni_mqtt_msg_decode_subscribe mqtt_codec.c:2123
    #3 nni_mqtt_msg_decode mqtt_codec.c:228
    #4 mqtt_recv_cb mqtt_client.c:956

previously allocated by thread T20 here:
    #1 nni_alloc posix_alloc.c:22
    #2 nni_mqtt_msg_decode_subscribe mqtt_codec.c:2100
    #3 nni_mqtt_msg_decode mqtt_codec.c:228
    #4 mqtt_recv_cb mqtt_client.c:956
Impact
Remote DoS: A malicious MQTT broker can crash the client
process with a single 14-byte packet
Persistent DoS: Auto-reconnect causes infinite crash loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT codec stability by ensuring freed buffers are nulled and associated counts reset during message destruction and on decode error paths. This prevents stale state after SUBSCRIBE, UNSUBSCRIBE and acknowledgment handling, reducing risk of memory-related issues and improving consistent cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->