### PR TITLE
FIX `SEGV on unknown address` in `nni_mqttv5_msg_decode_connect() `

### DIFF
--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -472,7 +472,8 @@ nni_mqtt_msg_dup(void **dest, const void *src)
 			    s->var_header.connect.properties);
 		}
 		if (s->payload.connect.will_properties) {
-			rv += property_dup(&mqtt->var_header.connect.properties,
+			rv += property_dup(
+			    &mqtt->payload.connect.will_properties,
 			    s->payload.connect.will_properties);
 		}
 		break;

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -1877,8 +1877,8 @@ nni_mqttv5_msg_decode_connect(nni_msg *msg)
 			if ((ret = check_properties(will_prop, msg)) != SUCCESS)
 				return ret;
 			// Check Invalid properties
-			for (property *p = prop->next; p != NULL;
-			     p           = p->next) {
+			for (property *p = will_prop->next; p != NULL;
+			    p            = p->next) {
 				switch (p->id) {
 				case PAYLOAD_FORMAT_INDICATOR:
 					if (p->data.p_value.u8 > 1)


### PR DESCRIPTION
Fix the following issue:

Description
Summary
A NULL pointer dereference in nni_mqttv5_msg_decode_connect() allows a malicious MQTT broker to crash any connecting NanoMQ MQTTv5 client (including bridge mode) with a single packet, causing remote denial of service via SIGSEGV.
Details
In nni_mqttv5_msg_decode_connect() (mqtt_codec.c:1863), the code iterates over CONNECT properties using variable prop when it should use will_prop. When a CONNECT packet has no connect-level properties (prop == NULL) but has will properties (will_prop != NULL), dereferencing prop->next causes SIGSEGV at address 0x38 (NULL + offsetof(property, next)).
This affects both nanomq_cli and NanoMQ bridge mode (Core component), as both use the same mqtt_client.c receive path.
PoC

```bash
mkdir build_asan && cd build_asan
cmake .. -DCMAKE_C_FLAGS="-fsanitize=address -g -O0" \
         -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address" \
         -DBUILD_CLIENT=ON -DNNG_ENABLE_TLS=OFF -DENABLE_QUIC=OFF
make nanomq_cli
```

Malicious Pyaload
A malicious MQTT broker accepts the MQTTv5 client's CONNECT and responds with a valid CONNACK. It then sends the following crafted MQTTv5 CONNECT packet:
```bash
10 23 00 04 4d 51 54 54 05 04 00 3c 00 00 04 65
76 69 6c 05 18 00 00 00 00 00 04 77 69 6c 6c 00
04 64 65 61 64
```
Result
```bash
==24532==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000038
  (pc 0x56a1752e519b bp 0x72549ececf80 sp 0x72549ececd00 T18)
==24532==The signal is caused by a READ memory access.
==24532==Hint: address points to the zero page.
    #0 nni_mqttv5_msg_decode_connect mqtt_codec.c:1863
    #1 nni_mqttv5_msg_decode mqtt_codec.c:259
    #2 mqtt_recv_cb mqtt_client.c:969
    #3 nni_task_exec taskq.c:141
    #4 nni_aio_finish_impl aio.c:462
    #5 nni_aio_finish_sync aio.c:477
    #6 mqtt_tcptran_pipe_recv_cb mqtt_tcp.c:873
```
Without ASan, the client crashes with Segmentation fault (core dumped).
Impact
Remote DoS: A malicious MQTT broker can crash the client process with a single 35-byte packet (SIGSEGV, 100% reliable)
Persistent DoS: Auto-reconnect causes infinite crash loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MQTT v5 protocol validation for Will message properties during connection establishment. The validator now correctly checks Will-specific properties against allowed property types, ensuring proper protocol compliance and error handling for malformed Will sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->