### PR TITLE
multipe safe checker added

### DIFF
--- a/src/mqtt/transport/tcp/mqtt_tcp.c
+++ b/src/mqtt/transport/tcp/mqtt_tcp.c
@@ -833,6 +833,12 @@ mqtt_tcptran_pipe_recv_cb(void *arg)
 		break;
 	case CMD_DISCONNECT:
 		break;
+	case CMD_CONNECT:
+	case CMD_SUBSCRIBE:
+	case CMD_UNSUBSCRIBE:
+		log_warn("Malicious Packet Type found from client side! Abort!");
+		rv = PROTOCOL_ERROR;
+		goto recv_error;
 	default:
 		break;
 	}

--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -546,7 +546,6 @@ conn_handler(uint8_t *packet, conn_param *cparam, size_t max)
 	} else {
 		pos++;
 	}
-
 	// remaining length
 	len = get_var_integer(packet + pos, &rm_len);
 	pos += rm_len;
@@ -628,7 +627,7 @@ conn_handler(uint8_t *packet, conn_param *cparam, size_t max)
 		log_debug("remain len %d max len %d prop len %d pos %d",
 				   len, max, cparam->prop_len, pos);
 		cparam->properties = decode_buf_properties(
-		    packet, len, &pos, &cparam->prop_len, true);
+		    packet, max, &pos, &cparam->prop_len, true);
 		if (cparam->properties) {
 			conn_param_set_property(cparam, cparam->properties);
 			if ((rv = check_properties(cparam->properties, NULL)) !=
@@ -677,7 +676,7 @@ conn_handler(uint8_t *packet, conn_param *cparam, size_t max)
 	if (rv == 0 && cparam->will_flag != 0) {
 		if (cparam->pro_ver == MQTT_PROTOCOL_VERSION_v5) {
 			cparam->will_properties = decode_buf_properties(
-			    packet, len, &pos, &cparam->will_prop_len, true);
+			    packet, max, &pos, &cparam->will_prop_len, true);
 			if (cparam->will_properties) {
 				conn_param_set_will_property(
 				    cparam, cparam->will_properties);

--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -1617,20 +1617,21 @@ nmq_subtopic_decode(nng_msg *msg, uint8_t ver, topic_queue **ptq)
 	while (pos < target_pos) {
 		switch (*(var_ptr + pos)) {
 		case USER_PROPERTY:
-			// key
-			NNI_GET16(var_ptr + pos, len_of_str);
-			pos += len_of_str;
-			if (pos > target_pos)
-				return (-3);
-			len_of_str = 0;
-			// value
-			NNI_GET16(var_ptr + pos, len_of_str);
-			pos += len_of_str;
-			if (pos > target_pos)
-				return (-3);
-			len_of_str = 0;
+			pos++;
+			for (int j = 0; j < 2; j++) {
+				len_of_str = 0;
+				if (pos + 2 > target_pos)
+					return (-3);
+				NNI_GET16(var_ptr + pos, len_of_str);
+				pos += (2 + len_of_str);
+				if (pos > target_pos)
+					return (-3);
+			}
 			break;
 		case SUBSCRIPTION_IDENTIFIER:
+			pos++;
+			if (pos >= target_pos)
+				return (-3);
 			uint8_t prop_varint_len = 0;
 			subid = get_var_integer(var_ptr + pos, &prop_varint_len);
 			if (subid == 0)
@@ -1642,6 +1643,7 @@ nmq_subtopic_decode(nng_msg *msg, uint8_t ver, topic_queue **ptq)
 			return (-2);
 		}
 	}
+
 	if (pos > target_pos || nni_msg_len(msg) < target_pos)
 		return (-2);
 
@@ -1740,9 +1742,11 @@ nmq_subinfo_decode(nng_msg *msg, void *l, uint8_t ver)
 		switch (*(var_ptr + pos)) {
 		case USER_PROPERTY:
 			// ID Length
-			pos ++;
+			pos++;
 			for (int j = 0; j < 2; j++) {
 				len_of_str = 0;
+				if (pos + 2 > target_pos)
+					return (-3);
 				// key/Value length
 				NNI_GET16(var_ptr + pos, len_of_str);
 				pos += (2 + len_of_str);
@@ -1752,17 +1756,21 @@ nmq_subinfo_decode(nng_msg *msg, void *l, uint8_t ver)
 			}
 			break;
 		case SUBSCRIPTION_IDENTIFIER:
-			// count id length in len_of_varint
-			subid = get_var_integer(var_ptr + pos, &len_of_varint);
+			pos++;
+			if (pos >= target_pos)
+				return (-3);
+			uint8_t prop_varint_len = 0;
+			subid = get_var_integer(var_ptr + pos, &prop_varint_len);
 			if (subid == 0)
 				return (-1);
-			pos += len_of_varint;
+			pos += prop_varint_len;
 			break;
 		default:
 			log_error("Invalid property id");
 			return (-2);
 		}
 	}
+
 	if (pos > target_pos || nni_msg_len(msg) < target_pos)
 		return (-2);
 
@@ -1858,7 +1866,6 @@ nmq_unsubinfo_decode(nng_msg *msg, void *l, uint8_t ver)
 			return -1;
 	}
 
-
 	var_ptr     = (uint8_t *) nni_msg_body(msg);
 	payload_ptr = (uint8_t *) nni_msg_body(msg) + 2 + len + len_of_varint;
 	size_t pos = 2 + len_of_varint, target_pos = 2 + len_of_varint + len;
@@ -1872,9 +1879,11 @@ nmq_unsubinfo_decode(nng_msg *msg, void *l, uint8_t ver)
 		switch (*(var_ptr + pos)) {
 		case USER_PROPERTY:
 			// ID Length
-			pos ++;
+			pos++;
 			for (int j = 0; j < 2; j++) {
 				len_of_str = 0;
+				if (pos + 2 > target_pos)
+					return (-3);
 				// key/Value length
 				NNI_GET16(var_ptr + pos, len_of_str);
 				pos += (2 + len_of_str);

--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -1631,10 +1631,11 @@ nmq_subtopic_decode(nng_msg *msg, uint8_t ver, topic_queue **ptq)
 			len_of_str = 0;
 			break;
 		case SUBSCRIPTION_IDENTIFIER:
-			subid = get_var_integer(var_ptr + pos, &len_of_varint);
+			uint8_t prop_varint_len = 0;
+			subid = get_var_integer(var_ptr + pos, &prop_varint_len);
 			if (subid == 0)
 				return (-1);
-			pos += len_of_varint;
+			pos += prop_varint_len;
 			break;
 		default:
 			log_error("Invalid property id");

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -2107,6 +2107,9 @@ nni_mqtt_msg_decode_subscribe(nni_msg *msg)
 	saved_current_pos = buf.curpos;
 	while (buf.curpos < buf.endpos) {
 		ret = read_uint16(&buf, &temp_length);
+		if (ret != MQTT_SUCCESS) {
+			return MQTT_ERR_PROTOCOL;
+		}
 		/* jump to the end of topic-name */
 		buf.curpos += temp_length;
 		/* skip QoS field */
@@ -2186,6 +2189,9 @@ nni_mqttv5_msg_decode_subscribe(nni_msg *msg)
 	saved_current_pos = buf.curpos;
 	while (buf.curpos < buf.endpos) {
 		ret = read_uint16(&buf, &temp_length);
+		if (ret != MQTT_SUCCESS) {
+			return MQTT_ERR_PROTOCOL;
+		}
 		/* jump to the end of topic-name */
 		buf.curpos += temp_length;
 		/* skip QoS field */
@@ -2687,6 +2693,9 @@ nni_mqtt_msg_decode_unsubscribe(nni_msg *msg)
 	saved_current_pos = buf.curpos;
 	while (buf.curpos < buf.endpos) {
 		ret = read_uint16(&buf, &temp_length);
+		if (ret != MQTT_SUCCESS) {
+			return MQTT_ERR_PROTOCOL;
+		}
 		/* jump to the end of topic-name */
 		buf.curpos += temp_length;
 		/* skip QoS field */
@@ -2758,6 +2767,9 @@ nni_mqttv5_msg_decode_unsubscribe(nni_msg *msg)
 	saved_current_pos = buf.curpos;
 	while (buf.curpos < buf.endpos) {
 		ret = read_uint16(&buf, &temp_length);
+		if (ret != MQTT_SUCCESS) {
+			return MQTT_ERR_PROTOCOL;
+		}
 		/* jump to the end of topic-name */
 		buf.curpos += temp_length;
 		/* skip QoS field */
@@ -3796,7 +3808,8 @@ property_parse(struct pos_buf *buf, property *prop, uint8_t prop_id,
 
 	default:
 		log_error("Unknown type %d", type);
-		break;
+		free(prop);
+		return NULL;
 	}
 
 	return prop;

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -361,21 +361,25 @@ mqtt_msg_content_free(nni_mqtt_proto_data *mqtt)
 	case NNG_MQTT_PUBACK:
 		if (mqtt->var_header.puback.properties) {
 			property_free(mqtt->var_header.puback.properties);
+			mqtt->var_header.puback.properties = NULL;
 		}
 		break;
 	case NNG_MQTT_PUBREC:
 		if (mqtt->var_header.pubrec.properties) {
 			property_free(mqtt->var_header.pubrec.properties);
+			mqtt->var_header.pubrec.properties = NULL;
 		}
 		break;
 	case NNG_MQTT_PUBREL:
 		if (mqtt->var_header.pubrel.properties) {
 			property_free(mqtt->var_header.pubrel.properties);
+			mqtt->var_header.pubrel.properties = NULL;
 		}
 		break;
 	case NNG_MQTT_PUBCOMP:
 		if (mqtt->var_header.pubcomp.properties) {
 			property_free(mqtt->var_header.pubcomp.properties);
+			mqtt->var_header.pubcomp.properties = NULL;
 		}
 		break;
 	case NNG_MQTT_SUBSCRIBE:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CONNECT parsing to correct cursor/remaining-length handling during property decoding.
  * Prevented use-after-free by clearing freed property pointers during message cleanup.
  * Strengthened SUBSCRIBE/UNSUBSCRIBE parsing with tighter length and bounds validation and safer subscription identifier decoding.
  * Treated unexpected client-side packet types as protocol errors to abort processing.
  * Safer property parsing: unknown types now clean up and fail fast.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanomq/NanoNNG/pull/1518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->