### PR TITLE
Break tls connection when tls receiving is timeout

### DIFF
--- a/src/supplemental/mqtt/mqtt_public.c
+++ b/src/supplemental/mqtt/mqtt_public.c
@@ -845,7 +845,7 @@ nng_mqtt_client_send_cb(void* arg)
 	nng_msg *        msg    = nng_aio_get_msg(aio);
 	nng_aio_set_msg(aio, NULL);
 	if (msg == NULL || rv == NNG_ECLOSED) {
-		log_warn("bridge send failed rv %d", nng_strerror(rv));
+		log_warn("bridge send failed rv%d %s", rv, nng_strerror(rv));
 		client->cb(client, NULL, client->obj);
 		return;
 	}

--- a/src/supplemental/tls/tls_common.c
+++ b/src/supplemental/tls/tls_common.c
@@ -1190,8 +1190,10 @@ tls_tcp_recv_start(tls_conn *conn)
 	conn->tcp_recv_pend = true;
 	nng_aio_set_iov(&conn->tcp_recv, 1, &iov);
 
-	if (conn->is_dialer) {
+	if (conn->is_dialer && !conn->hs_done) {
 		nni_aio_set_timeout(&conn->tcp_recv, 60000); // 60s
+	} else {
+		nni_aio_set_timeout(&conn->tcp_recv, NNG_DURATION_INFINITE);
 	}
 	nng_stream_recv(conn->tcp, &conn->tcp_recv);
 }

--- a/src/supplemental/tls/tls_common.c
+++ b/src/supplemental/tls/tls_common.c
@@ -77,6 +77,7 @@ typedef struct {
 	size_t                  tcp_send_len;
 	size_t                  tcp_send_head;
 	size_t                  tcp_send_tail;
+	bool                    is_dialer;
 	nni_reap_node           reap;
 
 	// ... engine connection data follows
@@ -183,6 +184,7 @@ tls_dialer_dial(void *arg, nng_aio *aio)
 		nni_aio_finish_error(aio, rv);
 		return;
 	}
+	conn->is_dialer = true;
 
 	if ((rv = nni_aio_schedule(aio, tls_conn_cancel, conn)) != 0) {
 		nni_aio_finish_error(aio, rv);
@@ -458,6 +460,7 @@ tls_listener_accept(void *arg, nng_aio *aio)
 		nni_aio_finish_error(aio, rv);
 		return;
 	}
+	conn->is_dialer = false;
 
 	if ((rv = nni_aio_schedule(aio, tls_conn_cancel, conn)) != 0) {
 		nni_aio_finish_error(aio, rv);
@@ -901,6 +904,8 @@ tls_alloc(tls_conn **conn_p, nng_tls_config *cfg, nng_aio *user_aio)
 	conn->user_aio = user_aio;
 	conn->cfg      = cfg;
 
+	conn->is_dialer = false;
+
 	nni_aio_init(&conn->conn_aio, tls_conn_cb, conn);
 	nni_aio_init(&conn->tcp_recv, tls_tcp_recv_cb, conn);
 	nni_aio_init(&conn->tcp_send, tls_tcp_send_cb, conn);
@@ -1185,6 +1190,9 @@ tls_tcp_recv_start(tls_conn *conn)
 	conn->tcp_recv_pend = true;
 	nng_aio_set_iov(&conn->tcp_recv, 1, &iov);
 
+	if (conn->is_dialer) {
+		nni_aio_set_timeout(&conn->tcp_recv, 60000); // 60s
+	}
 	nng_stream_recv(conn->tcp, &conn->tcp_recv);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS connection handling with connection-type-specific timeout configuration, enhancing network stability, reducing timeout-related failures, and providing better overall connection reliability for MQTT bridge operations and inter-node communications.

* **Chores**
  * Updated formatting in log messages for MQTT bridge operations for improved consistency and readability of diagnostic information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanomq/NanoNNG/pull/1519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->