### PR TITLE
* FIX [mqtt] isolate broker negotiation failures

### DIFF
--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -326,7 +326,6 @@ tcptran_pipe_nego_cb(void *arg)
 	tcptran_pipe *p   = arg;
 	tcptran_ep   *ep  = p->ep;
 	nni_aio      *aio = p->negoaio;
-	nni_aio      *uaio;
 	nni_iov       iov;
 	uint8_t       len_of_varint = 0;
 	uint32_t      len;
@@ -506,11 +505,10 @@ error:
 	}
 	nng_stream_close(p->conn);
 
-	if ((uaio = ep->useraio) != NULL) {
-		ep->useraio = NULL;
-		nni_aio_finish_error(uaio, rv);
-	}
 	nni_list_remove(&ep->negopipes, p);
+	// A negotiation failure belongs to this client pipe. Keep the listener
+	// accept aio pending so one bad or aborted MQTT CONNECT does not report
+	// accept failure for unrelated clients.
 	nni_mtx_unlock(&ep->mtx);
 	tcptran_pipe_reap(p);
 	log_error("connect nego error rv:(%d)", rv);

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -332,7 +332,6 @@ tlstran_pipe_nego_cb(void *arg)
 	tlstran_pipe *p   = arg;
 	tlstran_ep   *ep  = p->ep;
 	nni_aio      *aio = p->negoaio;
-	nni_aio      *uaio;
 	nni_iov       iov;
 	uint8_t       len_of_varint = 0;
 	uint32_t      len;
@@ -510,10 +509,10 @@ error:
 	nni_list_remove(&ep->negopipes, p);
 	nng_stream_close(p->conn);
 
-	if ((uaio = ep->useraio) != NULL) {
-		ep->useraio = NULL;
-		nni_aio_finish_error(uaio, rv);
-	}
+	// A negotiation failure belongs to this client pipe. Do not fail
+	// ep->useraio here, otherwise bursts of malformed or aborted TLS/MQTT
+	// handshakes can surface as listener accept failures and disturb accept
+	// progress for unrelated clients.
 	nni_mtx_unlock(&ep->mtx);
 	tlstran_pipe_reap(p);
 	log_error("connect nego error rv:(%d) %s MQTT reason code %d",


### PR DESCRIPTION
## Summary

- Keep broker listener accept aio pending when a single MQTT TCP/TLS CONNECT negotiation fails.
- Reap only the failed client pipe instead of surfacing the pipe negotiation error as a listener accept failure.
- Apply the same isolation to `broker_tcp.c` and `broker_tls.c`.

## Context

This is intended to reduce the blast radius of malformed or aborted MQTT/TLS handshakes during reconnect storms. We observed a production NanoMQ 0.24.13 broker where the process stayed alive and ports remained listening, but new MQTT/TLS handshakes timed out while several `nng:task` threads consumed sustained high CPU. Logs before the stall contained repeated `tlstran_pipe_nego_cb` `Cryptographic error` / `Connection shutdown` messages.

Related public issues:

- nanomq/nanomq#1764
- nanomq/nanomq#2246
- nanomq/nanomq#2241
- nanomq/NanoNNG#1086

## Validation

- Built NanoMQ 0.24.13 with this NanoNNG patch using Ninja.
- Built with `NNG_TLS_ENGINE=open` successfully.
- Ran a local smoke test with a patched NanoMQ TLS listener:
  - verified `openssl s_client` handshake before bad traffic
  - injected 80 aborted/non-TLS connections to the TLS listener
  - verified `openssl s_client` handshake still succeeded afterward
  - sampled threads afterward; no sustained multi-core `nng:task` busy loop was observed

## Notes

This is opened as a draft because I still want to run a larger reconnect-storm reproducer with repeated same-client-id reconnects before marking it ready.
