### PR TITLE
FIX [mqtt] improve TLS recv close mapping and diagnostics

### DIFF
--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -888,7 +888,10 @@ nano_pipe_close(void *arg)
 	}
 	nni_mtx_lock(&s->lk);
 	nni_mtx_lock(&p->lk);
-	log_info("%s pipe close!", p->conn_param->clientid.body);
+	log_info("%s pipe close! pipe=%u reason_code=0x%02x ip=%s clean_start=%u event=%u cache=%u",
+	    p->conn_param->clientid.body, nni_pipe_id(npipe), p->reason_code,
+	    p->conn_param->ip_addr_v4, p->conn_param->clean_start, p->event,
+	    nni_atomic_get_bool(&npipe->cache));
 	// we freed the conn_param when restoring pipe
 	// so check status of conn_param. just let it close silently
 	if (p->conn_param->clean_start == 0) {

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -326,7 +326,6 @@ tcptran_pipe_nego_cb(void *arg)
 	tcptran_pipe *p   = arg;
 	tcptran_ep   *ep  = p->ep;
 	nni_aio      *aio = p->negoaio;
-	nni_aio      *uaio;
 	nni_iov       iov;
 	uint8_t       len_of_varint = 0;
 	uint32_t      len;
@@ -506,11 +505,10 @@ error:
 	}
 	nng_stream_close(p->conn);
 
-	if ((uaio = ep->useraio) != NULL) {
-		ep->useraio = NULL;
-		nni_aio_finish_error(uaio, rv);
-	}
 	nni_list_remove(&ep->negopipes, p);
+	// A negotiation failure belongs to this client pipe. Keep the listener
+	// accept aio pending so one bad or aborted MQTT CONNECT does not report
+	// accept failure for unrelated clients.
 	nni_mtx_unlock(&ep->mtx);
 	tcptran_pipe_reap(p);
 	log_error("connect nego error rv:(%d)", rv);

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -712,6 +712,7 @@ tlstran_pipe_recv_cb(void *arg)
 	aio = nni_list_first(&p->recvq);
 
 	if ((rv = nni_aio_result(rxaio)) != 0) {
+		int raw_rv = rv;
 		log_warn("nni aio recv error!! %s\n", nng_strerror(rv));
 		nni_pipe_bump_error(p->npipe, rv);
 		if (rv == NNG_ECONNRESET || rv == NNG_ECONNSHUT || rv == NNG_ECLOSED) {
@@ -721,6 +722,19 @@ tlstran_pipe_recv_cb(void *arg)
 			rv = NMQ_SERVER_BUSY;
 		} else {
 			rv = NMQ_UNSEPECIFY_ERROR;
+		}
+		if (p->tcp_cparam != NULL) {
+			log_warn("mqtts recv error mapped clientid=%.*s username=%.*s ip=%s pipe=%u raw_rv=%d raw_error=%s reason_code=0x%02x",
+			    p->tcp_cparam->clientid.len,
+			    p->tcp_cparam->clientid.body,
+			    p->tcp_cparam->username.len,
+			    p->tcp_cparam->username.body,
+			    p->tcp_cparam->ip_addr_v4, nni_pipe_id(p->npipe),
+			    raw_rv, nng_strerror(raw_rv), rv);
+		} else {
+			log_warn("mqtts recv error mapped pipe=%u raw_rv=%d raw_error=%s reason_code=0x%02x",
+			    nni_pipe_id(p->npipe), raw_rv, nng_strerror(raw_rv),
+			    rv);
 		}
 		goto recv_error;
 	}

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -332,7 +332,6 @@ tlstran_pipe_nego_cb(void *arg)
 	tlstran_pipe *p   = arg;
 	tlstran_ep   *ep  = p->ep;
 	nni_aio      *aio = p->negoaio;
-	nni_aio      *uaio;
 	nni_iov       iov;
 	uint8_t       len_of_varint = 0;
 	uint32_t      len;
@@ -510,10 +509,10 @@ error:
 	nni_list_remove(&ep->negopipes, p);
 	nng_stream_close(p->conn);
 
-	if ((uaio = ep->useraio) != NULL) {
-		ep->useraio = NULL;
-		nni_aio_finish_error(uaio, rv);
-	}
+	// A negotiation failure belongs to this client pipe. Do not fail
+	// ep->useraio here, otherwise bursts of malformed or aborted TLS/MQTT
+	// handshakes can surface as listener accept failures and disturb accept
+	// progress for unrelated clients.
 	nni_mtx_unlock(&ep->mtx);
 	tlstran_pipe_reap(p);
 	log_error("connect nego error rv:(%d) %s MQTT reason code %d",

--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -96,6 +96,36 @@ print_hex(char *str, const uint8_t *data, size_t len)
 #include "nng/supplemental/tls/tls.h"
 #include <nng/supplemental/tls/engine.h>
 
+static void
+open_log_ssl_error(const char *where, int ssl_error)
+{
+	unsigned long err;
+	char          errbuf[256];
+	bool          has_error = false;
+
+	while ((err = ERR_get_error()) != 0) {
+		ERR_error_string_n(err, errbuf, sizeof(errbuf));
+		log_error("%s ssl_error=%d openssl_error=0x%lx %s",
+		    where, ssl_error, err, errbuf);
+		has_error = true;
+	}
+
+	if (!has_error) {
+		log_error("%s ssl_error=%d openssl_error=none", where,
+		    ssl_error);
+	}
+}
+
+static bool
+open_ssl_error_is_established_close(unsigned long err)
+{
+	int reason = ERR_GET_REASON(err);
+
+	return reason == SSL_R_WRONG_VERSION_NUMBER ||
+	    reason == SSL_R_SHUTDOWN_WHILE_IN_INIT ||
+	    reason == SSL_R_SSLV3_ALERT_BAD_CERTIFICATE;
+}
+
 struct nng_tls_engine_conn {
 	void    *tls; // parent conn
 	SSL     *ssl;
@@ -261,6 +291,8 @@ open_conn_handshake(nng_tls_engine_conn *ec)
 				if (!BIO_should_retry(ec->rbio)) {
 					log_warn("NNG-TLS-CONN-HANDSHAKE"
 						"openssl BIO write failed rv%d", ensz);
+					open_log_ssl_error(
+					    "NNG-TLS-CONN-HANDSHAKE BIO_write", 0);
 					return NNG_ECRYPTO;
 				}
 				continue;
@@ -277,6 +309,8 @@ open_conn_handshake(nng_tls_engine_conn *ec)
 				if (!BIO_should_retry(ec->wbio)) {
 					log_warn("NNG-TLS-CONN-HANDSHAKE"
 						"openssl BIO read failed rv%d", ensz);
+					open_log_ssl_error(
+					    "NNG-TLS-CONN-HANDSHAKE BIO_read", 0);
 					return NNG_ECRYPTO;
 				}
 				continue;
@@ -301,6 +335,7 @@ finished:
 		ec->ok = 1;
 		return 0;
 	}
+	open_log_ssl_error("NNG-TLS-CONN-HANDSHAKE SSL_do_handshake", rv);
 	return NNG_ECRYPTO;
 }
 
@@ -329,7 +364,8 @@ open_conn_recv(nng_tls_engine_conn *ec, uint8_t *buf, size_t *szp)
 		log_debug("NNG-TLS-CONN-RECV" "bio write result %d", ensz);
 		if (!BIO_should_retry(ec->rbio)) {
 			log_error("NNG-TLS-CONN-RECV"
-				"[%d]openssl BIO write failed rv%d", ensz);
+				"openssl BIO write failed rv%d", ensz);
+			open_log_ssl_error("NNG-TLS-CONN-RECV BIO_write", 0);
 			return (NNG_ECRYPTO);
 		}
 	}
@@ -337,15 +373,43 @@ open_conn_recv(nng_tls_engine_conn *ec, uint8_t *buf, size_t *szp)
 			"recv %d from tcp and written %d to BIO", rv, written);
 
 readopenssl:
-	if ((rv = SSL_read(ec->ssl, buf, (int) *szp)) < 0) {
-		rv = SSL_get_error(ec->ssl, rv);
+	ERR_clear_error();
+	rv = SSL_read(ec->ssl, buf, (int) *szp);
+	if (rv <= 0) {
+		int ssl_rv = SSL_get_error(ec->ssl, rv);
 		// TODO return codes according openssl documents
-		if (rv != SSL_ERROR_WANT_READ) {
+		if (ssl_rv == SSL_ERROR_WANT_READ ||
+		    ssl_rv == SSL_ERROR_WANT_WRITE) {
+			*szp = 0;
+		} else if (ssl_rv == SSL_ERROR_ZERO_RETURN) {
+			log_debug("NNG-TLS-CONN-RECV"
+			    "openssl read closed by TLS close_notify rv%d ssl_rv%d",
+			    rv, ssl_rv);
+			return (NNG_ECLOSED);
+		} else if (ssl_rv == SSL_ERROR_SYSCALL &&
+		    ERR_peek_error() == 0) {
+			log_debug("NNG-TLS-CONN-RECV"
+			    "openssl read closed by peer EOF rv%d ssl_rv%d",
+			    rv, ssl_rv);
+			return (NNG_ECLOSED);
+		} else if (ec->ok && ssl_rv == SSL_ERROR_SSL &&
+		    open_ssl_error_is_established_close(ERR_peek_error())) {
+			unsigned long err = ERR_peek_error();
+			char          errbuf[256];
+
+			ERR_error_string_n(err, errbuf, sizeof(errbuf));
+			log_warn("NNG-TLS-CONN-RECV"
+			    "openssl read mapped to closed after established TLS rv%d ssl_rv%d openssl_error=0x%lx %s",
+			    rv, ssl_rv, err, errbuf);
+			ERR_clear_error();
+			return (NNG_ECLOSED);
+		} else {
 			log_error("NNG-TLS-CONN-RECV"
-				"openssl read failed rv%d", rv);
+				"openssl read failed rv%d ssl_rv%d", rv,
+				ssl_rv);
+			open_log_ssl_error("NNG-TLS-CONN-RECV SSL_read", ssl_rv);
 			return (NNG_ECRYPTO);
 		}
-		*szp = 0;
 	} else {
 		*szp = (size_t) rv;
 	}


### PR DESCRIPTION
## Summary
- Fix TLS recv error mapping in NanoNNG so normal TLS close paths return `NNG_ECLOSED` instead of `NNG_ECRYPTO`.
- Add richer diagnostics for broker recv/handshake failures.
- Enrich broker and pipe close logs for disconnect post-mortem.

## Problem
Some normal TLS disconnects were mapped to `NNG_ECRYPTO`, which could bubble up as MQTT disconnect reason `0x80` and be treated as protocol/crypto failure in monitoring.

## Changes
### `src/supplemental/tls/openssl/openssl.c`
- In `open_conn_recv`, map:
  - `SSL_ERROR_ZERO_RETURN` -> `NNG_ECLOSED`
  - `SSL_ERROR_SYSCALL` with `EOF` -> `NNG_ECLOSED`
  - established connection close-related OpenSSL alerts (`WRONG_VERSION_NUMBER`, `SHUTDOWN_WHILE_IN_INIT`, `SSLV3_ALERT_BAD_CERTIFICATE`) -> `NNG_ECLOSED`
- Add `open_log_ssl_error()` and use it for low-level OpenSSL error detail logging.

### `src/sp/transport/mqtts/broker_tls.c`
- Add detailed `raw_rv` and `reason_code` mapping logs to ease correlation by clientid/username/ip.

### `src/sp/protocol/mqtt/nmq_mqtt.c`
- Extend `pipe close` log fields with `pipe`, `reason_code`, `ip`, `clean_start`, `event`, `cache`.

## Verification
- Build passes with local compile in this branch (no blocking errors).

## Related
- This fix is expected to be consumed by NanoMQ through submodule update.
- Related NanoMQ PR: https://github.com/nanomq/nanomq/pull/2313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved issue where a single failed client connection could prevent other clients from establishing connections.

* **Improvements**
  * Enhanced diagnostic logging with additional connection state details for better troubleshooting.
  * Improved error handling and reporting for connection negotiation and protocol failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanomq/NanoNNG/pull/1531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->