### PR TITLE
Update check_properties() function to use command type instead of nng_msg for validation

### DIFF
--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -1643,6 +1643,7 @@ NNG_DECL uint8_t *nng_msg_payload_ptr(nng_msg *msg);
 NNG_DECL void     nng_msg_set_payload_ptr(nng_msg *msg, uint8_t *ptr);
 NNG_DECL void     nng_msg_clone(nng_msg *msg);
 NNG_DECL void     nng_msg_set_cmd_type(nng_msg *m, uint8_t cmd);
+NNG_DECL uint8_t  nng_msg_get_cmd_type(nng_msg *m);
 NNG_DECL nng_msg *nng_msg_unique(nng_msg *m);
 NNG_DECL int      nng_make_parent_dirs(const char *name);
 NNG_DECL int      nng_file_put(const char *name, const void *data, size_t sz);

--- a/include/nng/protocol/mqtt/mqtt_parser.h
+++ b/include/nng/protocol/mqtt/mqtt_parser.h
@@ -109,7 +109,7 @@ NNG_DECL nng_msg *nano_encode_publish_msg(uint8_t proto_ver, uint8_t qos,
     bool retain, bool dup, const uint8_t *payload, uint32_t payload_len,
     property *prop, const char *topic, const char *topic_suffix);
 // TODO : check duplicated declaration
-NNG_DECL reason_code check_properties(property *prop, nng_msg *msg);
+NNG_DECL reason_code check_properties(property *prop, uint8_t cmd_type);
 NNG_DECL property *decode_buf_properties(uint8_t *packet, uint32_t packet_len,
     uint32_t *pos, uint32_t *len, bool copy_value);
 NNG_DECL property *decode_properties(

--- a/src/nng.c
+++ b/src/nng.c
@@ -2424,6 +2424,12 @@ nng_msg_set_cmd_type(nng_msg *m, uint8_t cmd)
 	nni_msg_set_cmd_type(m, cmd);
 }
 
+uint8_t
+nng_msg_get_cmd_type(nng_msg *m)
+{
+    return nni_msg_get_cmd_type(m);
+}
+
 const char *
 conn_param_get_clientid(conn_param *cparam)
 {

--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -630,7 +630,7 @@ conn_handler(uint8_t *packet, conn_param *cparam, size_t max)
 		    packet, max, &pos, &cparam->prop_len, true);
 		if (cparam->properties) {
 			conn_param_set_property(cparam, cparam->properties);
-			if ((rv = check_properties(cparam->properties, NULL)) !=
+			if ((rv = check_properties(cparam->properties, CMD_CONNECT)) !=
 			    SUCCESS) {
 				log_warn("Malformed CONNECT: property check failed");
 				return rv;
@@ -681,8 +681,10 @@ conn_handler(uint8_t *packet, conn_param *cparam, size_t max)
 				conn_param_set_will_property(
 				    cparam, cparam->will_properties);
 				if ((rv = check_properties(
-						cparam->will_properties, NULL)) != SUCCESS) {
-					log_info("Malformed CONNECT: check will property failed");
+				         cparam->will_properties,
+				         CMD_CONNECT)) != SUCCESS) {
+					log_info("Malformed CONNECT: check "
+					         "will property failed");
 					return PROTOCOL_ERROR;
 				}
 			}

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -1837,7 +1837,7 @@ nni_mqttv5_msg_decode_connect(nni_msg *msg)
 	// Check connect properties
 	property *prop = mqtt->var_header.connect.properties;
 	if (prop != NULL) {
-		if ((ret = check_properties(prop, msg)) != SUCCESS)
+		if ((ret = check_properties(prop, CMD_CONNECT)) != SUCCESS)
 			return ret;
 		// Check Invalid properties
 		for (property *p = prop->next; p != NULL; p = p->next) {
@@ -1879,7 +1879,7 @@ nni_mqttv5_msg_decode_connect(nni_msg *msg)
 
 		property *will_prop = mqtt->payload.connect.will_properties;
 		if (will_prop != NULL) {
-			if ((ret = check_properties(will_prop, msg)) != SUCCESS)
+			if ((ret = check_properties(will_prop, CMD_CONNECT)) != SUCCESS)
 				return ret;
 			// Check Invalid properties
 			for (property *p = will_prop->next; p != NULL;
@@ -2044,7 +2044,7 @@ nni_mqttv5_msg_decode_connack(nni_msg *msg)
 	// Check properties
 	property *prop = mqtt->var_header.connack.properties;
 	if (prop != NULL) {
-		if ((result = check_properties(prop, msg)) != SUCCESS)
+		if ((result = check_properties(prop, CMD_CONNACK)) != SUCCESS)
 			return result;
 		// Check Invalid properties
 		for (property *p = prop->next; p != NULL; p = p->next) {
@@ -2410,7 +2410,13 @@ nni_mqttv5_msg_decode_publish(nni_msg *msg)
 	uint32_t pos1 = pos;
 	mqtt->var_header.publish.properties =
 	    decode_buf_properties(body, length, &pos, &prop_len, true);
-	check_properties(mqtt->var_header.publish.properties, msg);
+
+	if ((ret = check_properties(mqtt->var_header.publish.properties,
+	         CMD_PUBLISH_V5)) != SUCCESS) {
+		property_free(mqtt->var_header.publish.properties);
+		return ret;
+	}
+
 	buf.curpos = &body[0] + pos;
 	prop_sz = pos - pos1;
 
@@ -2500,9 +2506,10 @@ nni_mqttv5_msg_decode_puback(nni_msg *msg)
 
 	mqtt->var_header.puback.properties =
 	    decode_properties(msg, &pos, &prop_len, false);
-	if (check_properties(mqtt->var_header.puback.properties, msg) != SUCCESS) {
+	if ((rv = check_properties(mqtt->var_header.puback.properties, CMD_PUBACK)) !=
+	    SUCCESS) {
 		property_free(mqtt->var_header.puback.properties);
-		return PROTOCOL_ERROR;
+		return rv;
 	}
 
 	return MQTT_SUCCESS;
@@ -2550,9 +2557,10 @@ nni_mqttv5_msg_decode_pubrec(nni_msg *msg)
 
 	mqtt->var_header.pubrec.properties =
 	    decode_properties(msg, &pos, &prop_len, false);
-	if (check_properties(mqtt->var_header.pubrec.properties, msg) != SUCCESS) {
+	if ((rv = check_properties(
+	         mqtt->var_header.pubrec.properties, CMD_PUBREC)) != SUCCESS) {
 		property_free(mqtt->var_header.pubrec.properties);
-		return PROTOCOL_ERROR;
+		return rv;
 	}
 
 	return MQTT_SUCCESS;
@@ -2607,9 +2615,10 @@ nni_mqttv5_msg_decode_pubrel(nni_msg *msg)
 
 	mqtt->var_header.pubrel.properties =
 	    decode_properties(msg, &pos, &prop_len, false);
-	if (check_properties(mqtt->var_header.pubrel.properties, msg) != SUCCESS) {
+	if ((rv = check_properties(
+	         mqtt->var_header.pubrel.properties, CMD_PUBREL)) != SUCCESS) {
 		property_free(mqtt->var_header.pubrel.properties);
-		return PROTOCOL_ERROR;
+		return rv;
 	}
 
 	return MQTT_SUCCESS;
@@ -2657,9 +2666,10 @@ nni_mqttv5_msg_decode_pubcomp(nni_msg *msg)
 
 	mqtt->var_header.pubcomp.properties =
 	    decode_properties(msg, &pos, &prop_len, false);
-	if (check_properties(mqtt->var_header.pubcomp.properties, msg) != SUCCESS) {
+	if ((rv = check_properties(mqtt->var_header.pubcomp.properties,
+	         CMD_PUBCOMP)) != SUCCESS) {
 		property_free(mqtt->var_header.pubcomp.properties);
-		return PROTOCOL_ERROR;
+		return rv;
 	}
 
 	return MQTT_SUCCESS;
@@ -3969,16 +3979,15 @@ property_free(property *prop)
 // Check if repeated properties exist, for broker use only.
 // Check if repeated properties exist and validate property bounds, for broker use only.
 reason_code
-check_properties(property *prop, nni_msg *msg)
+check_properties(property *prop, uint8_t cmd_type)
 {
-	uint8_t type = 0x00;
-	if (msg != NULL) {
-		type = nni_msg_get_type(msg);
-		if (type == 0x00) {
-			log_warn("Invalid msg type found!");
-			return UNSPECIFIED_ERROR;
-		}
+	if (cmd_type == 0x00) {
+		log_warn("Invalid msg type found!");
+		return UNSPECIFIED_ERROR;
 	}
+
+	uint8_t type = cmd_type;
+
 	if (prop == NULL) {
 		return SUCCESS;
 	}
@@ -4028,19 +4037,19 @@ check_properties(property *prop, nni_msg *msg)
 		// blocking TOPIC_ALIAS_MAXIMUM
 		case TOPIC_ALIAS_MAXIMUM: // 0x22
 			if (type != CMD_CONNECT && type != CMD_CONNACK) {
-				log_warn("Client carried TOPIC_ALIAS_MAXIMUM. Connection rejected!");
+				log_warn("Client packet type [%02X] carried TOPIC_ALIAS_MAXIMUM. Connection rejected!", type);
 				return PROTOCOL_ERROR;
 			}
 			break;
 
 		case TOPIC_ALIAS: // 0x23
+			if (type != CMD_PUBLISH_V5) {
+				log_warn("Topic Alias is explicitly rejected "
+				         "for security! Disconnecting...");
+				return PROTOCOL_ERROR;
+			}
 			if (p1->data.p_value.u16 == 0) {
 				log_warn("TOPIC_ALIAS cannot be 0!");
-				return TOPIC_ALIAS_INVALID;
-			}
-
-			if (type == CMD_PUBLISH) {
-				log_warn("Topic Alias is explicitly rejected for security! Disconnecting...");
 				return TOPIC_ALIAS_INVALID;
 			}
 			break;
@@ -4444,10 +4453,10 @@ nni_mqtt_pubres_decode(nng_msg *msg, uint16_t *packet_id, uint8_t *reason_code,
 	uint32_t prop_len = 0;
 
 	*prop = decode_properties(msg, &pos, &prop_len, false);
-	if (check_properties(*prop, msg) != SUCCESS) {
+	if ((rv = check_properties(*prop, CMD_PUBREC)) != SUCCESS) {
 		property_free(*prop);
 		*prop = NULL;
-		return PROTOCOL_ERROR;
+		return rv;
 	}
 
 	return MQTT_SUCCESS;

--- a/src/supplemental/nanolib/conf.c
+++ b/src/supplemental/nanolib/conf.c
@@ -899,6 +899,7 @@ conf_init(conf *nanomq_conf)
 	conf_rule_init(&nanomq_conf->rule_eng);
 #endif
 
+	nanomq_conf->max_topic_alias        = 65535;
 	nanomq_conf->max_packet_size        = (10240 * 1024);
 	nanomq_conf->client_max_packet_size = (10240 * 1024);
 

--- a/tests/trantest.h
+++ b/tests/trantest.h
@@ -804,7 +804,7 @@ decode_sub_msg(nano_work *work)
 	if (MQTT_PROTOCOL_VERSION_v5 == proto_ver) {
 		sub_pkt->properties =
 		    decode_properties(msg, (uint32_t *)&vpos, &sub_pkt->prop_len, true);
-		if (check_properties(sub_pkt->properties, NULL) != SUCCESS) {
+		if (check_properties(sub_pkt->properties, CMD_SUBSCRIBE) != SUCCESS) {
 			return PROTOCOL_ERROR;
 		}
 	}
@@ -994,7 +994,7 @@ decode_unsub_msg(nano_work *work)
 	if (MQTT_PROTOCOL_VERSION_v5 == proto_ver) {
 		unsub_pkt->properties =
 		    decode_properties(msg, &vpos, &unsub_pkt->prop_len, false);
-		if (check_properties(unsub_pkt->properties, NULL) != SUCCESS) {
+		if (check_properties(unsub_pkt->properties, CMD_UNSUBSCRIBE) != SUCCESS) {
 			return PROTOCOL_ERROR;
 		}
 	}


### PR DESCRIPTION
Fix issue https://github.com/emqx/NanoMQ_mirror/issues/604.

Update check_properties() function to use command type instead of nng_msg for validation, because nng_msg is null in conn_handler()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter MQTT v5 property validation driven by command type, improving protocol correctness.
  * Enhanced topic-alias handling to reject invalid alias values where appropriate.

* **New Features**
  * Added public accessor to obtain a message's MQTT command type.

* **Chores**
  * Raised default maximum topic-alias to 65535 in configuration.
  * Updated tests and utilities to align with validation changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->