### PR TITLE
Disable AES_GCM_CTR_V1 for parquet encryption

### DIFF
--- a/include/nng/supplemental/nanolib/conf.h
+++ b/include/nng/supplemental/nanolib/conf.h
@@ -748,6 +748,7 @@ NNG_DECL void conf_bridge_node_parse_cipher_password(conf_bridge_node *bridge, c
 NNG_DECL bool conf_parquet_unwrap_runtime_key(
 	const char *wrapped_key, const char *wrap_alg, char **plain_key_out);
 NNG_DECL void conf_parquet_free_runtime_key(char *plain_key);
+NNG_DECL void conf_parquet_init(conf_parquet *parquet);
 #endif
 NNG_DECL void conf_gateway_parse_ver2(zmq_gateway_conf *gateway);
 NNG_DECL void conf_vsomeip_gateway_parse_ver2(vsomeip_gateway_conf *config);

--- a/src/supplemental/nanolib/conf.c
+++ b/src/supplemental/nanolib/conf.c
@@ -3302,11 +3302,12 @@ conf_nng_proxy_init(conf_nng_bridge *proxy)
 void
 conf_parquet_init(conf_parquet *parquet)
 {
-	parquet->enable           = false;
-	parquet->encryption.enable= false;
-	parquet->encryption.key   = NULL;
-	parquet->encryption.key_id= NULL;
-	parquet->encryption.type  = AES_GCM_V1;
+	parquet->enable                = false;
+	parquet->encryption.enable     = false;
+	parquet->encryption.key        = NULL;
+	parquet->encryption.key_id     = NULL;
+	parquet->encryption.type       = AES_GCM_V1;
+	parquet->encryption.key_cipher = NULL;
 
 	parquet->limit_frequency  = 5;
 	parquet->file_count       = 5;

--- a/src/supplemental/nanolib/conf.c
+++ b/src/supplemental/nanolib/conf.c
@@ -1078,18 +1078,7 @@ conf_init(conf *nanomq_conf)
 	nanomq_conf->exchange.nodes           = NULL;
 	nanomq_conf->exchange.default_parquet = NULL;
 
-	nanomq_conf->parquet.enable           = false;
-	nanomq_conf->parquet.encryption.enable= false;
-	nanomq_conf->parquet.encryption.key   = NULL;
-	nanomq_conf->parquet.encryption.key_id= NULL;
-	nanomq_conf->parquet.encryption.type  = AES_GCM_V1;
-
-	nanomq_conf->parquet.limit_frequency  = 5;
-	nanomq_conf->parquet.file_count       = 5;
-	nanomq_conf->parquet.file_size        = (10240 * 1024);
-	nanomq_conf->parquet.comp_type        = UNCOMPRESSED;
-	nanomq_conf->parquet.file_name_prefix = NULL;
-	nanomq_conf->parquet.dir              = NULL;
+	conf_parquet_init(&nanomq_conf->parquet);
 
 	nanomq_conf->blf.enable           = false;
 	nanomq_conf->blf.file_count       = 5;
@@ -3308,6 +3297,23 @@ conf_nng_proxy_init(conf_nng_bridge *proxy)
 
 	proxy->pub_count = 0;
 	proxy->sub_count = 0;
+}
+
+void
+conf_parquet_init(conf_parquet *parquet)
+{
+	parquet->enable           = false;
+	parquet->encryption.enable= false;
+	parquet->encryption.key   = NULL;
+	parquet->encryption.key_id= NULL;
+	parquet->encryption.type  = AES_GCM_V1;
+
+	parquet->limit_frequency  = 5;
+	parquet->file_count       = 5;
+	parquet->file_size        = (10240 * 1024);
+	parquet->comp_type        = UNCOMPRESSED;
+	parquet->file_name_prefix = NULL;
+	parquet->dir              = NULL;
 }
 
 void

--- a/src/supplemental/nanolib/conf_ver2.c
+++ b/src/supplemental/nanolib/conf_ver2.c
@@ -2036,6 +2036,11 @@ conf_parquet_parse_ver2(conf *config, conf_exchange_node *node, cJSON *jso)
 			}
 			hocon_read_enum(encryption, type,
 			    jso_parquet_encryption, encryption_type);
+			if (encryption->type == AES_GCM_CTR_V1) {
+				log_error("AES_GCM_CTR_V1 is not available at current,"
+				          " Fallback to AES_GCM_V1.");
+				encryption->type = AES_GCM_V1;
+			}
 		}
 
 		config->parquet.enable = true;
@@ -2078,6 +2083,11 @@ conf_parquet_parse_default_ver2(conf *config, cJSON *jso)
 			}
 			hocon_read_enum(encryption, type,
 			    jso_parquet_encryption, encryption_type);
+			if (encryption->type == AES_GCM_CTR_V1) {
+				log_error("AES_GCM_CTR_V1 is not available at current,"
+				          " Fallback to AES_GCM_V1.");
+				encryption->type = AES_GCM_V1;
+			}
 		}
 	}
 

--- a/src/supplemental/nanolib/conf_ver2.c
+++ b/src/supplemental/nanolib/conf_ver2.c
@@ -2009,14 +2009,12 @@ conf_parquet_parse_ver2(conf *config, conf_exchange_node *node, cJSON *jso)
 	cJSON *jso_parquet = cJSON_GetObjectItem(jso, "parquet");
 	if (jso_parquet) {
 		conf_parquet *parquet = NNI_ALLOC_STRUCT(parquet);
+		conf_parquet_init(parquet);
 		node->parquet = parquet;
-		parquet->enable       = true;
+		parquet->enable = true;
 		hocon_read_bool_base(parquet, enable, "enable", jso_parquet);
-		parquet->file_count       = 5;
 		hocon_read_num(parquet, file_count, jso_parquet);
-		parquet->limit_frequency  = 5;
 		hocon_read_num(parquet, limit_frequency, jso_parquet);
-		parquet->file_size        = (10240 * 1024);
 		hocon_read_size(parquet, file_size, jso_parquet);
 		hocon_read_str(parquet, dir, jso_parquet);
 		hocon_read_str(parquet, file_name_prefix, jso_parquet);

--- a/src/supplemental/nanolib/parquet/parquet.cc
+++ b/src/supplemental/nanolib/parquet/parquet.cc
@@ -899,12 +899,10 @@ parquet_read_set_property(
 	if (key != NULL && strlen(key) > 0) {
 		parquet::FileDecryptionProperties::Builder builder;
 		shared_ptr<parquet::FileDecryptionProperties>
-		    decryption_configuration =
-				builder.footer_key(key)
-				->key_retriever(std::make_shared<UniformKeyRetriever>(
-						key))
-				->build();
-
+			decryption_configuration = builder.footer_key(key)
+		             ->key_retriever(
+		                 std::make_shared<UniformKeyRetriever>(key))
+		             ->build();
 		// Add the current decryption configuration to
 		// ReaderProperties.
 		reader_properties.file_decryption_properties(


### PR DESCRIPTION
1. Disable AES_GCM_CTR_V1 for parquet encryption
2. init parquet conf in exchange before reading from configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for unsupported Parquet encryption types; invalid configurations now log an error and automatically fall back to a compatible encryption method.

* **Refactor**
  * Streamlined Parquet configuration initialization process for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->