### PR TITLE
Fix topic alias maxmium negotiation & Sync fix of nano_qos_db QoS msg resend

### DIFF
--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -768,6 +768,7 @@ NNG_DECL nng_listener nng_pipe_listener(nng_pipe);
 // NNG-MQTT
 #define NNG_OPT_MQTT_CONNMSG "mqtt-connect-msg"
 #define NNG_OPT_MQTT_BRIDGE_CONF "mqtt-bridge-config"
+#define NMQ_OPT_MQTT_GET_QOS_RESEND "mqtt_get_resend_msg"
 
 // NNG-QUIC
 #define NNG_OPT_QUIC_ENABLE_0RTT "quic-0rtt"

--- a/include/nng/protocol/mqtt/mqtt_parser.h
+++ b/include/nng/protocol/mqtt/mqtt_parser.h
@@ -103,7 +103,7 @@ NNG_DECL nano_pipe_db *nano_msg_get_subtopic(
 NNG_DECL void nano_msg_free_pipedb(nano_pipe_db *db);
 NNG_DECL void nano_msg_ubsub_free(nano_pipe_db *db);
 NNG_DECL void nmq_connack_encode(
-    nng_msg *msg, conn_param *cparam, uint8_t reason);
+    nng_msg *msg, conf *conf, conn_param *cparam, uint8_t reason);
 NNG_DECL void nmq_connack_session(nng_msg *msg, bool session);
 NNG_DECL nng_msg *nano_encode_publish_msg(uint8_t proto_ver, uint8_t qos,
     bool retain, bool dup, const uint8_t *payload, uint32_t payload_len,

--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -433,6 +433,9 @@ void *
 nni_pipe_get_conn_param(nni_pipe *p)
 {
 	conn_param *cp = p->conn_param;
+
+	if (nni_atomic_get_bool(&p->p_closed))
+		return NULL;
 	if (cp != NULL)
 		nni_atomic_inc(&cp->refcnt);
 	return cp;

--- a/src/mqtt/protocol/mqtt/mqtt_client.c
+++ b/src/mqtt/protocol/mqtt/mqtt_client.c
@@ -603,7 +603,8 @@ mqtt_send_msg(nni_aio *aio, mqtt_ctx_t *arg)
 	}
 	if (s->retry_qos_0 || qos > 0) {
 		if (nni_lmq_full(&p->send_messages)) {
-			if (qos > 0) {
+			if (qos > 0 || ptype == NNG_MQTT_SUBSCRIBE ||
+			    ptype == NNG_MQTT_UNSUBSCRIBE) {
 				log_warn("Cached Message lost! pipe is busy and lmq is full\n");
 				(void) nni_lmq_get(&p->send_messages, &tmsg);
 				nni_msg_free(tmsg);
@@ -614,9 +615,9 @@ mqtt_send_msg(nni_aio *aio, mqtt_ctx_t *arg)
 #endif
 			} else {
 #ifdef NNG_ENABLE_STATS
-			nni_stat_inc(&s->msg_send_drop, 1);
+				nni_stat_inc(&s->msg_send_drop, 1);
 #endif
-			log_warn("QoS 0 Message lost due to full cache lmq");
+				log_warn("QoS 0 Message lost due to full cache lmq");
 			}
 		}
 

--- a/src/mqtt/transport/tcp/mqtt_tcp.c
+++ b/src/mqtt/transport/tcp/mqtt_tcp.c
@@ -1620,7 +1620,8 @@ mqtt_tcptran_ep_connect(void *arg, nni_aio *aio)
 		ep->backoff = ep->backoff > ep->backoff_max
 		    ? (nni_duration) (nni_random() % 1000)
 		    : ep->backoff;
-		log_warn("reconnect to %s in %ld ms", ep->url->u_host, ep->backoff);
+		log_warn("reconnect to %s in %d ms",
+			ep->url->u_host, ep->backoff);
 		nni_msleep(ep->backoff);
 	} else {
 		ep->backoff = nni_random()%2000;

--- a/src/mqtt/transport/tls/mqtt_tls.c
+++ b/src/mqtt/transport/tls/mqtt_tls.c
@@ -1651,7 +1651,7 @@ mqtts_tcptran_ep_connect(void *arg, nni_aio *aio)
 		ep->backoff = ep->backoff > ep->backoff_max
 		    ? (nni_duration) (nni_random() % 1000)
 		    : ep->backoff;
-		log_warn("reconnect to %s in %ld", ep->url->u_host, ep->backoff);
+		log_warn("reconnect to %s in %d", ep->url->u_host, ep->backoff);
 		nni_msleep(ep->backoff);
 	} else {
 		ep->backoff = nni_random()%2000;

--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -791,15 +791,36 @@ conn_handler(uint8_t *packet, conn_param *cparam, size_t max)
  * @brief handle and encode CONNACK packet
  */
 void
-nmq_connack_encode(nng_msg *msg, conn_param *cparam, uint8_t reason)
+nmq_connack_encode(nng_msg *msg, conf *conf, conn_param *cparam, uint8_t reason)
 {
 	uint8_t ack_flag = 0x00;
 	nni_msg_append(msg, &ack_flag, 1);
 	nni_msg_append(msg, &reason, 1);
 
-	if (cparam->pro_ver == MQTT_PROTOCOL_VERSION_v5) {
-		// TODO change properties if necessary.
-		// modify it in nego_cp while init cparam
+	if (cparam->pro_ver == MQTT_PROTOCOL_VERSION_v5 && cparam->properties != NULL) {
+		property *prop = property_get(cparam->properties,
+						TOPIC_ALIAS_MAXIMUM);
+		if (prop != NULL) {
+			// reuse client property to advertise max topic alias
+			prop->data.p_value.u16 = conf->max_topic_alias;
+		} else {
+			property *prop_alias = property_set_value_u16(TOPIC_ALIAS_MAXIMUM,
+				conf->max_topic_alias);
+			property_append(cparam->properties, prop_alias);
+		}
+		prop = property_get(cparam->properties, NANO_MAX_PACKET_SIZE);
+		if (cparam->max_packet_size == 0) {
+			// set default max packet size for client
+			cparam->max_packet_size = conf == NULL
+			    ? NANO_MAX_PACKET_SIZE
+			    : conf->client_max_packet_size;
+			if (prop == NULL)
+				property_append(cparam->properties,
+				    property_set_value_u32(MAXIMUM_PACKET_SIZE,
+				        cparam->max_packet_size));
+			else
+				prop->data.p_value.u32 = cparam->max_packet_size;
+		}
 		encode_properties(msg, cparam->properties, CMD_CONNACK);
 	}
 

--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -630,8 +630,7 @@ conn_handler(uint8_t *packet, conn_param *cparam, size_t max)
 		    packet, max, &pos, &cparam->prop_len, true);
 		if (cparam->properties) {
 			conn_param_set_property(cparam, cparam->properties);
-			if ((rv = check_properties(cparam->properties, NULL)) !=
-			    SUCCESS) {
+			if ((rv = check_properties(cparam->properties, NULL)) != SUCCESS) {
 				log_warn("Malformed CONNECT: property check failed");
 				return rv;
 			}

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -255,45 +255,24 @@ nano_pipe_timer_cb(void *arg)
 	p->ka_refresh++;
 
 	if (!p->busy) {
-		nni_msg *msg, *rmsg;
-		uint16_t pid = p->rid;
-
-		// trying to resend msg
-		msg = nni_qos_db_get_one(
-		    is_sqlite, npipe->nano_qos_db, npipe->p_id, &pid);
-		if (msg != NULL) {
-			rmsg = msg;
-			property      *prop = NULL;
-			property_data *data = NULL;
-			if (p->conn_param->pro_ver == MQTT_PROTOCOL_VERSION_v5) {
-				if (nni_msg_get_proto_data(rmsg) != NULL)
-					prop = nni_mqtt_msg_get_publish_property(rmsg);
-			}
-			if (prop) {
-				data = property_get_value(prop, MESSAGE_EXPIRY_INTERVAL);
-			}
-			nni_time ntime = nni_clock();
-			nni_time mtime = nni_msg_get_timestamp(rmsg);
-			if (data && ntime > mtime + data->p_value.u32 * 1000) {
-				log_info("QoS msg id %d of pipe %p expired!", pid, p->id);
-				// remove expired msg from qos db
-				nni_qos_db_remove_msg(
-				    is_sqlite, npipe->nano_qos_db, rmsg);
-				nni_qos_db_remove(is_sqlite,
-				    npipe->nano_qos_db, npipe->p_id, pid);
-			} else if ((ntime - mtime) >=
-			    (long unsigned) qos_duration * 1250) {
-				p->busy = true;
-				// TODO set max retrying times in nanomq.conf
-				nano_msg_set_dup(rmsg);
-				// deliver packet id to transport here
-				nni_aio_set_prov_data(&p->aio_send, (void *)(uintptr_t)pid);
-				// put original msg into sending
-				nni_msg_clone(rmsg);
-				nni_aio_set_msg(&p->aio_send, rmsg);
-				log_info("resending qos msg id %d to pipe %p", pid, p->id);
-				nni_pipe_send(p->pipe, &p->aio_send);
-			}
+		uint16_t       pid = p->rid;
+		nmq_req req;
+		size_t         sz = sizeof(nmq_req);
+		nni_mtx_unlock(&p->lk);
+		int rv_opt = nni_pipe_getopt(p->pipe, "mqtt_get_resend_msg",
+		    &req, &sz, NNI_TYPE_OPAQUE);
+		nni_mtx_lock(&p->lk);
+		if (rv_opt == 0 && req.msg != NULL) {
+			nni_msg *rmsg = req.msg;
+			uint16_t pid  = req.packet_id;
+			p->busy       = true;
+			nano_msg_set_dup(rmsg);
+			nni_aio_set_prov_data(
+			    &p->aio_send, (void *) (uintptr_t) pid);
+			nni_aio_set_msg(&p->aio_send, rmsg);
+			log_info("resending qos msg id %d to pipe %p",
+				pid, p->id);
+			nni_pipe_send(p->pipe, &p->aio_send);
 		}
 	}
 	nni_sleep_aio(qos_duration * 1000, &p->aio_timer);

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -244,7 +244,7 @@ nano_pipe_timer_cb(void *arg)
 		log_trace("check pipe keepalive interval %d backoff %f, ka %d",
 		    p->keepalive, qos_backoff, p->ka_refresh);
 		if (qos_backoff > 0) {
-			log_warn("Warning: close pipe %p & kick client due to "
+			log_warn("Warning: close pipe %u & kick client due to "
 			         "KeepAlive timeout!", p->id);
 			p->reason_code = NMQ_KEEP_ALIVE_TIMEOUT;
 			nni_mtx_unlock(&p->lk);
@@ -258,10 +258,8 @@ nano_pipe_timer_cb(void *arg)
 		uint16_t       pid = p->rid;
 		nmq_req req;
 		size_t         sz = sizeof(nmq_req);
-		nni_mtx_unlock(&p->lk);
-		int rv_opt = nni_pipe_getopt(p->pipe, "mqtt_get_resend_msg",
+		int rv_opt = nni_pipe_getopt(p->pipe, NMQ_OPT_MQTT_GET_QOS_RESEND,
 		    &req, &sz, NNI_TYPE_OPAQUE);
-		nni_mtx_lock(&p->lk);
 		if (rv_opt == 0 && req.msg != NULL) {
 			nni_msg *rmsg = req.msg;
 			uint16_t pid  = req.packet_id;

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -763,7 +763,7 @@ session_keeping:
 			    p->conn_param, &s->conf->auth_http);
 		}
 	}
-	nmq_connack_encode(msg, p->conn_param, rv);
+	nmq_connack_encode(msg, s->conf, p->conn_param, rv);
 	conn_param_free(p->conn_param);
 	if (rv != 0) {
 		// send connack with reason code 0x05

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -244,8 +244,8 @@ nano_pipe_timer_cb(void *arg)
 		log_trace("check pipe keepalive interval %d backoff %f, ka %d",
 		    p->keepalive, qos_backoff, p->ka_refresh);
 		if (qos_backoff > 0) {
-			log_warn("Warning: close pipe & kick client due to "
-			         "KeepAlive timeout!");
+			log_warn("Warning: close pipe %p & kick client due to "
+			         "KeepAlive timeout!", p->id);
 			p->reason_code = NMQ_KEEP_ALIVE_TIMEOUT;
 			nni_mtx_unlock(&p->lk);
 			nni_pipe_close(p->pipe);
@@ -275,7 +275,7 @@ nano_pipe_timer_cb(void *arg)
 			nni_time ntime = nni_clock();
 			nni_time mtime = nni_msg_get_timestamp(rmsg);
 			if (data && ntime > mtime + data->p_value.u32 * 1000) {
-				log_info("QoS msg %d expired!", pid);
+				log_info("QoS msg id %d of pipe %p expired!", pid, p->id);
 				// remove expired msg from qos db
 				nni_qos_db_remove_msg(
 				    is_sqlite, npipe->nano_qos_db, rmsg);
@@ -291,7 +291,7 @@ nano_pipe_timer_cb(void *arg)
 				// put original msg into sending
 				nni_msg_clone(rmsg);
 				nni_aio_set_msg(&p->aio_send, rmsg);
-				log_info("resending qos msg packetid: %d", pid);
+				log_info("resending qos msg id %d to pipe %p", pid, p->id);
 				nni_pipe_send(p->pipe, &p->aio_send);
 			}
 		}

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -271,7 +271,7 @@ nano_pipe_timer_cb(void *arg)
 			nni_aio_set_prov_data(
 			    &p->aio_send, (void *) (uintptr_t) real_pid);
 			nni_aio_set_msg(&p->aio_send, rmsg);
-			log_info("resending qos msg id %d to pipe u",
+			log_info("resending qos msg id %u to pipe %u",
 				pid, p->id);
 			nni_pipe_send(p->pipe, &p->aio_send);
 		}

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -255,20 +255,23 @@ nano_pipe_timer_cb(void *arg)
 	p->ka_refresh++;
 
 	if (!p->busy) {
-		uint16_t       pid = p->rid;
 		nmq_req req;
+		uint16_t       pid = p->rid;
+		req.packet_id  = pid;
+		req.msg = NULL;
 		size_t         sz = sizeof(nmq_req);
 		int rv_opt = nni_pipe_getopt(p->pipe, NMQ_OPT_MQTT_GET_QOS_RESEND,
 		    &req, &sz, NNI_TYPE_OPAQUE);
 		if (rv_opt == 0 && req.msg != NULL) {
 			nni_msg *rmsg = req.msg;
-			uint16_t pid  = req.packet_id;
+			uint16_t real_pid  = req.packet_id;
+			p->rid        = real_pid == 0xFFFF ? 1 : real_pid + 1;
 			p->busy       = true;
 			nano_msg_set_dup(rmsg);
 			nni_aio_set_prov_data(
-			    &p->aio_send, (void *) (uintptr_t) pid);
+			    &p->aio_send, (void *) (uintptr_t) real_pid);
 			nni_aio_set_msg(&p->aio_send, rmsg);
-			log_info("resending qos msg id %d to pipe %p",
+			log_info("resending qos msg id %d to pipe u",
 				pid, p->id);
 			nni_pipe_send(p->pipe, &p->aio_send);
 		}

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -1779,6 +1779,51 @@ tcptran_pipe_getopt(
     void *arg, const char *name, void *buf, size_t *szp, nni_type t)
 {
 	tcptran_pipe *p = arg;
+	if (strcmp(name, "mqtt_get_resend_msg") == 0) {
+		if (buf == NULL || szp == NULL || *szp < sizeof(nmq_req)) {
+			return NNG_EINVAL;
+		}
+		nmq_req *req = (nmq_req *)buf;
+		nni_msg *msg = NULL;
+		uint16_t pid = 1;
+		bool is_sqlite = false;
+
+		nni_mtx_lock(&p->mtx);
+		is_sqlite = p->conf->sqlite.enable;
+		uint32_t qos_duration = p->conf->qos_duration;
+		msg = nni_qos_db_get_one(p->conf->sqlite.enable, p->npipe->nano_qos_db, p->npipe->p_id, &pid);
+
+		if (msg != NULL) {
+			nni_msg       *rmsg = msg;
+			property      *prop = NULL;
+			property_data *data = NULL;
+			if (p->tcp_cparam->pro_ver == MQTT_PROTOCOL_VERSION_v5) {
+				if (nni_msg_get_proto_data(rmsg) != NULL)
+					prop = nni_mqtt_msg_get_publish_property(rmsg);
+			}
+			if (prop) {
+				data = property_get_value(prop, MESSAGE_EXPIRY_INTERVAL);
+			}
+			nni_time ntime = nni_clock();
+			nni_time mtime = nni_msg_get_timestamp(rmsg);
+			if (data && ntime > mtime + data->p_value.u32 * 1000) {
+				log_info("QoS msg id %d of pipe %p expired!", pid, p->npipe->p_id);
+				// remove expired msg from qos db
+				nni_qos_db_remove_msg(
+				    is_sqlite, p->npipe->nano_qos_db, rmsg);
+				nni_qos_db_remove(is_sqlite,
+				    p->npipe->nano_qos_db, p->npipe->p_id, pid);
+			} else if ((ntime - mtime) >= (long unsigned) qos_duration * 1250) {
+				nni_msg_clone(msg);
+				req->msg = msg;
+				req->packet_id = pid;
+				nni_mtx_unlock(&p->mtx);
+				return 0;
+			}
+		}
+		nni_mtx_unlock(&p->mtx);
+		return NNG_ENOENT;
+	}
 	return (nni_stream_get(p->conn, name, buf, szp, t));
 }
 

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -1770,7 +1770,7 @@ tcptran_pipe_getopt(
 			}
 			nni_time ntime = nni_clock();
 			nni_time mtime = nni_msg_get_timestamp(rmsg);
-			if (data && ntime > mtime + data->p_value.u32 * 1000) {
+			if (data && ntime > mtime + (nni_time)((uint64_t)data->p_value.u32 * 1000)) {
 				log_info("QoS msg id %u of pipe %u expired!", pid, p->npipe->p_id);
 				// remove expired msg from qos db
 				nni_qos_db_remove_msg(

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -411,12 +411,14 @@ tcptran_pipe_nego_cb(void *arg)
 			code = SERVER_UNAVAILABLE;
 			goto error;
 		}
-		if ((rv = conn_handler(
-		         p->conn_buf, p->tcp_cparam, p->wantrxhead)) == 0) {
+		if ((rv = conn_handler(p->conn_buf, p->tcp_cparam, p->wantrxhead)) == 0) {
 			nng_free(p->conn_buf, p->wantrxhead);
 			p->conn_buf = NULL;
-			// connection packet handled successfully. clone it for
-			// protocol or app layer
+			nni_list_remove(&ep->negopipes, p);
+			nni_list_append(&ep->waitpipes, p);
+			// Match happens before accept_cb. Make pipe id ready
+			tcptran_ep_match(ep);
+			// connection packet handled successfully. clone it for protocol or app layer
 			conn_param_clone(p->tcp_cparam);
 			// Connection is accepted.
 			p->pro_ver = p->tcp_cparam->pro_ver;
@@ -424,18 +426,25 @@ tcptran_pipe_nego_cb(void *arg)
 				p->qsend_quota = p->tcp_cparam->rx_max;
 				// add broker config to property for CONNACK
 				if (p->tcp_cparam->properties == NULL) {
-                    p->tcp_cparam->properties = property_alloc();
-                }
-				if (p->conf != NULL && p->conf->max_topic_alias > 0) {
-                    property_append(p->tcp_cparam->properties,
-                        property_set_value_u16(TOPIC_ALIAS_MAXIMUM,
-                            p->conf->max_topic_alias));
+					p->tcp_cparam->properties = property_alloc();
+				}
+				if (p->conf != NULL && p->tcp_cparam->topic_alias_max > 0 &&
+				    p->conf->max_topic_alias > 0) {
+					property *prop = property_get(p->tcp_cparam->properties,
+						TOPIC_ALIAS_MAXIMUM);
+					uint16_t alias_client = p->tcp_cparam->topic_alias_max;
+					uint16_t alias_conf   = p->conf->max_topic_alias;
+					if (prop != NULL) {
+						prop->data.p_value.u16 =
+						    alias_client > alias_conf
+						    ? alias_conf
+						    : alias_client;
+						p->tcp_cparam->topic_alias_max = prop->data.p_value.u16;
+					}
+				} else {
+					p->tcp_cparam->topic_alias_max = 0;
 				}
 			}
-			nni_list_remove(&ep->negopipes, p);
-			nni_list_append(&ep->waitpipes, p);
-			// Match happens before accept_cb. Make pipe id ready
-			tcptran_ep_match(ep);
 			if (p->tcp_cparam->max_packet_size == 0) {
 				// set default max packet size for client
 				p->tcp_cparam->max_packet_size =
@@ -2201,7 +2210,7 @@ tcptran_ep_accept(void *arg, nni_aio *aio)
 		ep->started = true;
 		nng_stream_listener_accept(ep->listener, ep->connaio);
 	} else {
-		tcptran_ep_match(ep);	// not necessary now.
+		tcptran_ep_match(ep);	// Double exec
 	}
 	nni_mtx_unlock(&ep->mtx);
 }

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -309,6 +309,7 @@ tcptran_ep_match(tcptran_ep *ep)
 	p->rcvmax   = ep->rcvmax;
 	p->conf     = ep->conf;
 	nni_aio_set_output(aio, 0, p);
+	// which triggers tcptran_ep_accept
 	nni_aio_finish(aio, 0, 0);
 }
 
@@ -414,52 +415,21 @@ tcptran_pipe_nego_cb(void *arg)
 		if ((rv = conn_handler(p->conn_buf, p->tcp_cparam, p->wantrxhead)) == 0) {
 			nng_free(p->conn_buf, p->wantrxhead);
 			p->conn_buf = NULL;
-			nni_list_remove(&ep->negopipes, p);
-			nni_list_append(&ep->waitpipes, p);
-			// Match happens before accept_cb. Make pipe id ready
-			tcptran_ep_match(ep);
 			// connection packet handled successfully. clone it for protocol or app layer
 			conn_param_clone(p->tcp_cparam);
 			// Connection is accepted.
 			p->pro_ver = p->tcp_cparam->pro_ver;
 			if (p->pro_ver == MQTT_PROTOCOL_VERSION_v5) {
 				p->qsend_quota = p->tcp_cparam->rx_max;
-				// add broker config to property for CONNACK
+				// perpare properties in transport for CONNACK
 				if (p->tcp_cparam->properties == NULL) {
 					p->tcp_cparam->properties = property_alloc();
 				}
-				if (p->conf != NULL && p->conf->max_topic_alias > 0) {
-					property *prop = property_get(p->tcp_cparam->properties,
-						TOPIC_ALIAS_MAXIMUM);
-					uint16_t alias_conf   = p->conf->max_topic_alias;
-					if (prop != NULL) {
-						// reuse client property to advertise max topic alias
-						prop->data.p_value.u16 = alias_conf;
-					}
-				}
 			}
-			if (p->tcp_cparam->max_packet_size == 0) {
-				// set default max packet size for client
-				p->tcp_cparam->max_packet_size =
-				    p->conf == NULL
-				    ? NANO_MAX_PACKET_SIZE
-				    : p->conf->client_max_packet_size;
-				if (p->tcp_cparam->properties != NULL) {
-					property_remove(
-					    p->tcp_cparam->properties,
-					    MAXIMUM_PACKET_SIZE);
-					property_append(
-					    p->tcp_cparam->properties,
-					    property_set_value_u32(
-					        MAXIMUM_PACKET_SIZE,
-					        p->tcp_cparam
-					            ->max_packet_size));
-				}
-			}
-			log_debug("max_packet_size of %.*s is %d",
-			    p->tcp_cparam->clientid.len,
-			    p->tcp_cparam->clientid.body,
-			    p->tcp_cparam->max_packet_size);
+			nni_list_remove(&ep->negopipes, p);
+			nni_list_append(&ep->waitpipes, p);
+			// Match happens before accept_cb. Make pipe id ready
+			tcptran_ep_match(ep);
 			nni_mtx_unlock(&ep->mtx);
 			return;
 		} else {

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -1785,13 +1785,14 @@ tcptran_pipe_getopt(
 		}
 		nmq_req *req = (nmq_req *)buf;
 		nni_msg *msg = NULL;
-		uint16_t pid = 1;
+		uint16_t pid = req->packet_id;
 		bool is_sqlite = false;
 
 		nni_mtx_lock(&p->mtx);
 		is_sqlite = p->conf->sqlite.enable;
 		uint32_t qos_duration = p->conf->qos_duration;
-		msg = nni_qos_db_get_one(p->conf->sqlite.enable, p->npipe->nano_qos_db, p->npipe->p_id, &pid);
+		msg = nni_qos_db_get_one(p->conf->sqlite.enable,
+			p->npipe->nano_qos_db, p->npipe->p_id, &pid);
 
 		if (msg != NULL) {
 			nni_msg       *rmsg = msg;
@@ -1807,7 +1808,7 @@ tcptran_pipe_getopt(
 			nni_time ntime = nni_clock();
 			nni_time mtime = nni_msg_get_timestamp(rmsg);
 			if (data && ntime > mtime + data->p_value.u32 * 1000) {
-				log_info("QoS msg id %d of pipe %p expired!", pid, p->npipe->p_id);
+				log_info("QoS msg id %u of pipe %u expired!", pid, p->npipe->p_id);
 				// remove expired msg from qos db
 				nni_qos_db_remove_msg(
 				    is_sqlite, p->npipe->nano_qos_db, rmsg);

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -428,21 +428,14 @@ tcptran_pipe_nego_cb(void *arg)
 				if (p->tcp_cparam->properties == NULL) {
 					p->tcp_cparam->properties = property_alloc();
 				}
-				if (p->conf != NULL && p->tcp_cparam->topic_alias_max > 0 &&
-				    p->conf->max_topic_alias > 0) {
+				if (p->conf != NULL && p->conf->max_topic_alias > 0) {
 					property *prop = property_get(p->tcp_cparam->properties,
 						TOPIC_ALIAS_MAXIMUM);
-					uint16_t alias_client = p->tcp_cparam->topic_alias_max;
 					uint16_t alias_conf   = p->conf->max_topic_alias;
 					if (prop != NULL) {
-						prop->data.p_value.u16 =
-						    alias_client > alias_conf
-						    ? alias_conf
-						    : alias_client;
-						p->tcp_cparam->topic_alias_max = prop->data.p_value.u16;
+						// reuse client property to advertise max topic alias
+						prop->data.p_value.u16 = alias_conf;
 					}
-				} else {
-					p->tcp_cparam->topic_alias_max = 0;
 				}
 			}
 			if (p->tcp_cparam->max_packet_size == 0) {

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -1779,7 +1779,7 @@ tcptran_pipe_getopt(
     void *arg, const char *name, void *buf, size_t *szp, nni_type t)
 {
 	tcptran_pipe *p = arg;
-	if (strcmp(name, "mqtt_get_resend_msg") == 0) {
+	if (strcmp(name, NMQ_OPT_MQTT_GET_QOS_RESEND) == 0) {
 		if (buf == NULL || szp == NULL || *szp < sizeof(nmq_req)) {
 			return NNG_EINVAL;
 		}

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -1770,7 +1770,7 @@ tlstran_pipe_getopt(
 			}
 			nni_time ntime = nni_clock();
 			nni_time mtime = nni_msg_get_timestamp(rmsg);
-			if (data && ntime > mtime + data->p_value.u32 * 1000) {
+			if (data && ntime > mtime + (nni_time)((uint64_t)data->p_value.u32 * 1000)) {
 				log_info("QoS msg id %u of pipe %u expired!", pid, p->npipe->p_id);
 				// remove expired msg from qos db
 				nni_qos_db_remove_msg(

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -1787,7 +1787,7 @@ tlstran_pipe_getopt(
 		}
 		nmq_req *req = (nmq_req *)buf;
 		nni_msg *msg = NULL;
-		uint16_t pid = 1;
+		uint16_t pid = req->packet_id;
 		bool is_sqlite = false;
 
 		nni_mtx_lock(&p->mtx);
@@ -1809,7 +1809,7 @@ tlstran_pipe_getopt(
 			nni_time ntime = nni_clock();
 			nni_time mtime = nni_msg_get_timestamp(rmsg);
 			if (data && ntime > mtime + data->p_value.u32 * 1000) {
-				log_info("QoS msg id %d of pipe %p expired!", pid, p->npipe->p_id);
+				log_info("QoS msg id %u of pipe %u expired!", pid, p->npipe->p_id);
 				// remove expired msg from qos db
 				nni_qos_db_remove_msg(
 				    is_sqlite, p->npipe->nano_qos_db, rmsg);

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -1781,6 +1781,51 @@ tlstran_pipe_getopt(
     void *arg, const char *name, void *buf, size_t *szp, nni_type t)
 {
 	tlstran_pipe *p = arg;
+	if (strcmp(name, "mqtt_get_resend_msg") == 0) {
+		if (buf == NULL || szp == NULL || *szp < sizeof(nmq_req)) {
+			return NNG_EINVAL;
+		}
+		nmq_req *req = (nmq_req *)buf;
+		nni_msg *msg = NULL;
+		uint16_t pid = 1;
+		bool is_sqlite = false;
+
+		nni_mtx_lock(&p->mtx);
+		is_sqlite = p->conf->sqlite.enable;
+		uint32_t qos_duration = p->conf->qos_duration;
+		msg = nni_qos_db_get_one(p->conf->sqlite.enable, p->npipe->nano_qos_db, p->npipe->p_id, &pid);
+
+		if (msg != NULL) {
+			nni_msg       *rmsg = msg;
+			property      *prop = NULL;
+			property_data *data = NULL;
+			if (p->tcp_cparam->pro_ver == MQTT_PROTOCOL_VERSION_v5) {
+				if (nni_msg_get_proto_data(rmsg) != NULL)
+					prop = nni_mqtt_msg_get_publish_property(rmsg);
+			}
+			if (prop) {
+				data = property_get_value(prop, MESSAGE_EXPIRY_INTERVAL);
+			}
+			nni_time ntime = nni_clock();
+			nni_time mtime = nni_msg_get_timestamp(rmsg);
+			if (data && ntime > mtime + data->p_value.u32 * 1000) {
+				log_info("QoS msg id %d of pipe %p expired!", pid, p->npipe->p_id);
+				// remove expired msg from qos db
+				nni_qos_db_remove_msg(
+				    is_sqlite, p->npipe->nano_qos_db, rmsg);
+				nni_qos_db_remove(is_sqlite,
+				    p->npipe->nano_qos_db, p->npipe->p_id, pid);
+			} else if ((ntime - mtime) >= (long unsigned) qos_duration * 1250) {
+				nni_msg_clone(msg);
+				req->msg = msg;
+				req->packet_id = pid;
+				nni_mtx_unlock(&p->mtx);
+				return 0;
+			}
+		}
+		nni_mtx_unlock(&p->mtx);
+		return NNG_ENOENT;
+	}
 	return (nni_stream_get(p->conn, name, buf, szp, t));
 }
 

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -1781,7 +1781,7 @@ tlstran_pipe_getopt(
     void *arg, const char *name, void *buf, size_t *szp, nni_type t)
 {
 	tlstran_pipe *p = arg;
-	if (strcmp(name, "mqtt_get_resend_msg") == 0) {
+	if (strcmp(name, NMQ_OPT_MQTT_GET_QOS_RESEND) == 0) {
 		if (buf == NULL || szp == NULL || *szp < sizeof(nmq_req)) {
 			return NNG_EINVAL;
 		}

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -431,21 +431,14 @@ tlstran_pipe_nego_cb(void *arg)
 				if (p->tcp_cparam->properties == NULL) {
 					p->tcp_cparam->properties = property_alloc();
 				}
-				if (p->conf != NULL && p->tcp_cparam->topic_alias_max > 0 &&
-				    p->conf->max_topic_alias > 0) {
+				if (p->conf != NULL && p->conf->max_topic_alias > 0) {
 					property *prop = property_get(p->tcp_cparam->properties,
 						TOPIC_ALIAS_MAXIMUM);
-					uint16_t alias_client = p->tcp_cparam->topic_alias_max;
 					uint16_t alias_conf   = p->conf->max_topic_alias;
 					if (prop != NULL) {
-						prop->data.p_value.u16 =
-						    alias_client > alias_conf
-						    ? alias_conf
-						    : alias_client;
-						p->tcp_cparam->topic_alias_max = prop->data.p_value.u16;
+						// reuse client property to advertise max topic alias
+						prop->data.p_value.u16 = alias_conf;
 					}
-				} else {
-					p->tcp_cparam->topic_alias_max = 0;
 				}
 			}
 

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -419,6 +419,9 @@ tlstran_pipe_nego_cb(void *arg)
 		         p->conn_buf, p->tcp_cparam, p->wantrxhead)) == 0) {
 			nng_free(p->conn_buf, p->wantrxhead);
 			p->conn_buf = NULL;
+			nni_list_remove(&ep->negopipes, p);
+			nni_list_append(&ep->waitpipes, p);
+			tlstran_ep_match(ep);
 			// connection packet handled successfully. clone it for protocol or app layer
 			conn_param_clone(p->tcp_cparam);
 			// Connection is accepted.
@@ -428,18 +431,24 @@ tlstran_pipe_nego_cb(void *arg)
 				if (p->tcp_cparam->properties == NULL) {
 					p->tcp_cparam->properties = property_alloc();
 				}
-				if (p->conf != NULL &&
+				if (p->conf != NULL && p->tcp_cparam->topic_alias_max > 0 &&
 				    p->conf->max_topic_alias > 0) {
-					property_append(
-					    p->tcp_cparam->properties,
-					    property_set_value_u16(
-					        TOPIC_ALIAS_MAXIMUM,
-					        p->conf->max_topic_alias));
+					property *prop = property_get(p->tcp_cparam->properties,
+						TOPIC_ALIAS_MAXIMUM);
+					uint16_t alias_client = p->tcp_cparam->topic_alias_max;
+					uint16_t alias_conf   = p->conf->max_topic_alias;
+					if (prop != NULL) {
+						prop->data.p_value.u16 =
+						    alias_client > alias_conf
+						    ? alias_conf
+						    : alias_client;
+						p->tcp_cparam->topic_alias_max = prop->data.p_value.u16;
+					}
+				} else {
+					p->tcp_cparam->topic_alias_max = 0;
 				}
 			}
-			nni_list_remove(&ep->negopipes, p);
-			nni_list_append(&ep->waitpipes, p);
-			tlstran_ep_match(ep);
+
 			if (p->tcp_cparam->max_packet_size == 0) {
 				// set default max packet size for client
 				p->tcp_cparam->max_packet_size =

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -431,38 +431,7 @@ tlstran_pipe_nego_cb(void *arg)
 				if (p->tcp_cparam->properties == NULL) {
 					p->tcp_cparam->properties = property_alloc();
 				}
-				if (p->conf != NULL && p->conf->max_topic_alias > 0) {
-					property *prop = property_get(p->tcp_cparam->properties,
-						TOPIC_ALIAS_MAXIMUM);
-					uint16_t alias_conf   = p->conf->max_topic_alias;
-					if (prop != NULL) {
-						// reuse client property to advertise max topic alias
-						prop->data.p_value.u16 = alias_conf;
-					}
-				}
 			}
-
-			if (p->tcp_cparam->max_packet_size == 0) {
-				// set default max packet size for client
-				p->tcp_cparam->max_packet_size =
-				    p->conf == NULL
-				    ? NANO_MAX_PACKET_SIZE
-				    : p->conf->client_max_packet_size;
-				if (p->tcp_cparam->properties != NULL) {
-					property_remove(
-					    p->tcp_cparam->properties,
-					    MAXIMUM_PACKET_SIZE);
-					property_append(
-					    p->tcp_cparam->properties,
-					    property_set_value_u32(
-					        MAXIMUM_PACKET_SIZE,
-					        p->tcp_cparam
-					            ->max_packet_size));
-				}
-			}
-			log_info("max_packet_size of %.*s is %d",
-					p->tcp_cparam->clientid.len, p->tcp_cparam->clientid.body,
-					p->tcp_cparam->max_packet_size);
 			nni_mtx_unlock(&ep->mtx);
 			return;
 		} else {
@@ -470,7 +439,7 @@ tlstran_pipe_nego_cb(void *arg)
 			nng_free(p->conn_buf, p->wantrxhead);
 			rv = NNG_EPROTO;
 			code = MALFORMED_PACKET;
-			if (p->tcp_cparam->pro_ver == 5) {
+			if (p->tcp_cparam->pro_ver == MQTT_PROTOCOL_VERSION_v5) {
 				goto close;
 			} else {
 				goto error;

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -1568,7 +1568,7 @@ wstran_pipe_getopt(
 		}
 		nmq_req *req = (nmq_req *)buf;
 		nni_msg *msg = NULL;
-		uint16_t pid = 1;
+		uint16_t pid = req->packet_id;
 		bool is_sqlite = false;
 
 		nni_mtx_lock(&p->mtx);
@@ -1589,8 +1589,8 @@ wstran_pipe_getopt(
 			}
 			nni_time ntime = nni_clock();
 			nni_time mtime = nni_msg_get_timestamp(rmsg);
-			if (data && ntime > mtime + data->p_value.u32 * 1000) {
-				log_info("QoS msg id %d of pipe %p expired!", pid, p->npipe->p_id);
+			if (data && ntime > mtime + (nni_time)((uint64_t)data->p_value.u32 * 1000)) {
+				log_info("QoS msg id %d of pipe %u expired!", pid, p->npipe->p_id);
 				// remove expired msg from qos db
 				nni_qos_db_remove_msg(
 				    is_sqlite, p->npipe->nano_qos_db, rmsg);

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -166,6 +166,10 @@ wstran_pipe_qos_send_cb(void *arg)
 	}
 
 	nni_mtx_lock(&p->mtx);
+	qmsg = nni_aio_get_msg(qsaio);
+	if (qmsg != NULL)
+		nni_msg_free(qmsg);
+
 	if (nni_lmq_get(&p->rslmq, &qmsg) == 0) {
 		nni_iov iov[2];
 		iov[0].iov_len = nni_msg_header_len(qmsg);

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -415,21 +415,14 @@ done:
 			if (p->ws_param->properties == NULL) {
 				p->ws_param->properties = property_alloc();
 			}
-			if (p->conf != NULL && p->ws_param->topic_alias_max > 0 &&
-				p->conf->max_topic_alias > 0) {
+			if (p->conf != NULL && p->conf->max_topic_alias > 0) {
 				property *prop = property_get(p->ws_param->properties,
 					TOPIC_ALIAS_MAXIMUM);
-				uint16_t alias_client = p->ws_param->topic_alias_max;
 				uint16_t alias_conf   = p->conf->max_topic_alias;
 				if (prop != NULL) {
-					prop->data.p_value.u16 =
-						alias_client > alias_conf
-						? alias_conf
-						: alias_client;
-					p->ws_param->topic_alias_max = prop->data.p_value.u16;
+					// reuse client property to advertise max topic alias
+					prop->data.p_value.u16 = alias_conf;
 				}
-			} else {
-				p->ws_param->topic_alias_max = 0;
 			}
 		}
 		if (p->ws_param->max_packet_size == 0) {

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -127,11 +127,13 @@ wstran_pipe_send_cb(void *arg)
 	if (nni_aio_result(taio) != 0) {
 		log_warn(" send aio error %s", nng_strerror(rv));
 		nni_msg_free(nni_aio_get_msg(taio));
+		nni_aio_set_msg(taio, NULL);
 	}
 	p->user_txaio = NULL;
 	if (uaio != NULL) {
 		if (nni_atomic_get_bool(&p->closed)){
 			nni_msg_free(nni_aio_get_msg(taio));
+			nni_aio_set_msg(taio, NULL);
 			nni_aio_finish_error(uaio, p->err_code);
 			nni_mtx_unlock(&p->mtx);
 			return;
@@ -163,6 +165,8 @@ wstran_pipe_qos_send_cb(void *arg)
 		if (uaio != NULL) {
 			nni_aio_finish_error(uaio, rv);
 		}
+		// wstran_pipe_close(p);
+		return;
 	}
 
 	nni_mtx_lock(&p->mtx);
@@ -405,6 +409,7 @@ done:
 			goto skip;
 		}
 		log_trace("MQTT Clientid is %s", p->ws_param->clientid.body);
+		conn_param_clone(p->ws_param);
 		if (p->ws_param->pro_ver == 5) {
 			p->qsend_quota = p->ws_param->rx_max;
 			if (p->ws_param->properties == NULL) {
@@ -1368,6 +1373,10 @@ wstran_pipe_fini(void *arg)
 		    false, nano_qos_db, tran_close_unack_msg_cb);
 		nni_qos_db_fini_id_hash(nano_qos_db);
 		p->npipe->nano_qos_db = NULL;
+	}
+	if (p->ws_param) {
+		conn_param_free(p->ws_param);
+		p->ws_param = NULL;
 	}
 	nni_mtx_unlock(&p->mtx);
 

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -406,10 +406,21 @@ done:
 			if (p->ws_param->properties == NULL) {
 				p->ws_param->properties = property_alloc();
 			}
-			if (p->conf != NULL && p->conf->max_topic_alias > 0) {
-				property_append(p->ws_param->properties,
-				    property_set_value_u16(TOPIC_ALIAS_MAXIMUM,
-				        p->conf->max_topic_alias));
+			if (p->conf != NULL && p->ws_param->topic_alias_max > 0 &&
+				p->conf->max_topic_alias > 0) {
+				property *prop = property_get(p->ws_param->properties,
+					TOPIC_ALIAS_MAXIMUM);
+				uint16_t alias_client = p->ws_param->topic_alias_max;
+				uint16_t alias_conf   = p->conf->max_topic_alias;
+				if (prop != NULL) {
+					prop->data.p_value.u16 =
+						alias_client > alias_conf
+						? alias_conf
+						: alias_client;
+					p->ws_param->topic_alias_max = prop->data.p_value.u16;
+				}
+			} else {
+				p->ws_param->topic_alias_max = 0;
 			}
 		}
 		if (p->ws_param->max_packet_size == 0) {

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -1569,7 +1569,51 @@ wstran_pipe_getopt(
 {
 	ws_pipe *p = arg;
 	int      rv;
+	if (strcmp(name, "mqtt_get_resend_msg") == 0) {
+		if (buf == NULL || szp == NULL || *szp < sizeof(nmq_req)) {
+			return NNG_EINVAL;
+		}
+		nmq_req *req = (nmq_req *)buf;
+		nni_msg *msg = NULL;
+		uint16_t pid = 1;
+		bool is_sqlite = false;
 
+		nni_mtx_lock(&p->mtx);
+		is_sqlite = p->conf->sqlite.enable;
+		uint32_t qos_duration = p->conf->qos_duration;
+		msg = nni_qos_db_get_one(p->conf->sqlite.enable, p->npipe->nano_qos_db, p->npipe->p_id, &pid);
+
+		if (msg != NULL) {
+			nni_msg       *rmsg = msg;
+			property      *prop = NULL;
+			property_data *data = NULL;
+			if (p->ws_param->pro_ver == MQTT_PROTOCOL_VERSION_v5) {
+				if (nni_msg_get_proto_data(rmsg) != NULL)
+					prop = nni_mqtt_msg_get_publish_property(rmsg);
+			}
+			if (prop) {
+				data = property_get_value(prop, MESSAGE_EXPIRY_INTERVAL);
+			}
+			nni_time ntime = nni_clock();
+			nni_time mtime = nni_msg_get_timestamp(rmsg);
+			if (data && ntime > mtime + data->p_value.u32 * 1000) {
+				log_info("QoS msg id %d of pipe %p expired!", pid, p->npipe->p_id);
+				// remove expired msg from qos db
+				nni_qos_db_remove_msg(
+				    is_sqlite, p->npipe->nano_qos_db, rmsg);
+				nni_qos_db_remove(is_sqlite,
+				    p->npipe->nano_qos_db, p->npipe->p_id, pid);
+			} else if ((ntime - mtime) >= (long unsigned) qos_duration * 1250) {
+				nni_msg_clone(msg);
+				req->msg = msg;
+				req->packet_id = pid;
+				nni_mtx_unlock(&p->mtx);
+				return 0;
+			}
+		}
+		nni_mtx_unlock(&p->mtx);
+		return NNG_ENOENT;
+	}
 	if ((rv = nni_stream_get(p->ws, name, buf, szp, t)) == NNG_ENOTSUP) {
 		rv = nni_getopt(ws_pipe_options, name, p, buf, szp, t);
 	}

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -1578,7 +1578,7 @@ wstran_pipe_getopt(
 {
 	ws_pipe *p = arg;
 	int      rv;
-	if (strcmp(name, "mqtt_get_resend_msg") == 0) {
+	if (strcmp(name, NMQ_OPT_MQTT_GET_QOS_RESEND) == 0) {
 		if (buf == NULL || szp == NULL || *szp < sizeof(nmq_req)) {
 			return NNG_EINVAL;
 		}

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -410,19 +410,10 @@ done:
 		}
 		log_trace("MQTT Clientid is %s", p->ws_param->clientid.body);
 		conn_param_clone(p->ws_param);
-		if (p->ws_param->pro_ver == 5) {
+		if (p->ws_param->pro_ver == MQTT_PROTOCOL_VERSION_v5) {
 			p->qsend_quota = p->ws_param->rx_max;
 			if (p->ws_param->properties == NULL) {
 				p->ws_param->properties = property_alloc();
-			}
-			if (p->conf != NULL && p->conf->max_topic_alias > 0) {
-				property *prop = property_get(p->ws_param->properties,
-					TOPIC_ALIAS_MAXIMUM);
-				uint16_t alias_conf   = p->conf->max_topic_alias;
-				if (prop != NULL) {
-					// reuse client property to advertise max topic alias
-					prop->data.p_value.u16 = alias_conf;
-				}
 			}
 		}
 		if (p->ws_param->max_packet_size == 0) {

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -4066,10 +4066,6 @@ check_properties(property *prop, nni_msg *msg)
 					log_error("Null conn_param found in PUBLISH msg!");
 					return SERVER_UNAVAILABLE;
 				}
-				if (cparam->topic_alias_max < p1->data.p_value.u16) {
-					log_warn("Topic Alias is explicitly rejected for clients without negotiation!");
-					return TOPIC_ALIAS_INVALID;
-				}
 			}
 			break;
 

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -3869,6 +3869,26 @@ property_remove(property *prop_list, uint8_t prop_id)
 	}
 }
 
+/**
+ * @brief Find and return a property pointer by its property ID
+ *
+ * @param prop The property list (usually has a dummy head)
+ * @param prop_id The property ID to search for
+ * @return property* Returns the property pointer if found, NULL otherwise
+ */
+property *
+property_get(property *prop, uint8_t prop_id)
+{
+	if (prop != NULL) {
+		for (property *p = prop->next; p != NULL; p = p->next) {
+			if (p->id == prop_id) {
+				return p;
+			}
+		}
+	}
+	return NULL;
+}
+
 int
 property_dup(property **dup, const property *src)
 {
@@ -3968,6 +3988,7 @@ property_free(property *prop)
 
 // Check if repeated properties exist, for broker use only.
 // Check if repeated properties exist and validate property bounds, for broker use only.
+// msg as NULL indicates it is a CONNECT aciton
 reason_code
 check_properties(property *prop, nni_msg *msg)
 {
@@ -4027,7 +4048,7 @@ check_properties(property *prop, nni_msg *msg)
 
 		// blocking TOPIC_ALIAS_MAXIMUM
 		case TOPIC_ALIAS_MAXIMUM: // 0x22
-			if (type != CMD_CONNECT && type != CMD_CONNACK) {
+			if (msg != NULL && type != CMD_CONNECT && type != CMD_CONNACK) {
 				log_warn("Client carried TOPIC_ALIAS_MAXIMUM. Connection rejected!");
 				return PROTOCOL_ERROR;
 			}
@@ -4040,8 +4061,11 @@ check_properties(property *prop, nni_msg *msg)
 			}
 
 			if (type == CMD_PUBLISH) {
-				log_warn("Topic Alias is explicitly rejected for security! Disconnecting...");
-				return TOPIC_ALIAS_INVALID;
+				conn_param *cparam = nni_msg_get_conn_param(msg);
+				if (cparam->topic_alias_max < p1->data.p_value.u16) {
+					log_warn("Topic Alias is explicitly rejected for clients without negotiation!");
+					return TOPIC_ALIAS_INVALID;
+				}
 			}
 			break;
 

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -4062,6 +4062,10 @@ check_properties(property *prop, nni_msg *msg)
 
 			if (type == CMD_PUBLISH) {
 				conn_param *cparam = nni_msg_get_conn_param(msg);
+				if (cparam == NULL) {
+					log_error("Null conn_param found in PUBLISH msg!");
+					return SERVER_UNAVAILABLE;
+				}
 				if (cparam->topic_alias_max < p1->data.p_value.u16) {
 					log_warn("Topic Alias is explicitly rejected for clients without negotiation!");
 					return TOPIC_ALIAS_INVALID;

--- a/src/supplemental/mqtt/mqtt_msg.h
+++ b/src/supplemental/mqtt/mqtt_msg.h
@@ -518,6 +518,7 @@ NNG_DECL int encode_properties(nng_msg *msg, property *prop, uint8_t cmd);
 
 NNG_DECL uint32_t  get_properties_len(property *prop, uint8_t cmd);
 NNG_DECL int       property_free(property *prop);
+NNG_DECL property *property_get(property *prop, uint8_t prop_id);
 NNG_DECL void      property_foreach(property *prop, void (*cb)(property *));
 NNG_DECL int       property_dup(property **dup, const property *src);
 NNG_DECL property *property_pub_by_will(property *will_prop);

--- a/src/supplemental/mqtt/mqtt_qos_db_api.h
+++ b/src/supplemental/mqtt/mqtt_qos_db_api.h
@@ -8,6 +8,11 @@
 #ifdef NNG_HAVE_MQTT_BROKER
 #include "nng/supplemental/nanolib/conf.h"
 #endif
+// Obj passing through aio cb as indication of its origins
+typedef struct {
+    uint16_t packet_id;
+    nni_msg *msg;
+} nmq_req;
 
 #define nni_qos_db_init_sqlite(db, user_path, db_name, is_broker) \
 	nni_mqtt_qos_db_init((sqlite3 **) &(db), user_path, db_name, is_broker)

--- a/src/supplemental/nanolib/hash_table.c
+++ b/src/supplemental/nanolib/hash_table.c
@@ -468,32 +468,40 @@ dbhash_get_topic_queue(uint32_t id)
 struct topic_queue *
 dbhash_copy_topic_queue(uint32_t id)
 {
-
-	// dbhash_check_init(pipe_table, ph, pipe_lock);
-	struct topic_queue *ret = NNI_ALLOC_STRUCT(ret);
-	struct topic_queue *res = ret;
-	
+	struct topic_queue *head = NULL;
+	struct topic_queue **tail = &head;
 
 	nni_rwlock_wrlock(&pipe_lock);
 	khint_t k = kh_get(pipe_table, ph, id);
+
 	if (k != kh_end(ph)) {
 		struct topic_queue *tq = kh_val(ph, k);
 		while (tq) {
-			topic_queue *tmp;
-			tmp = ret;
-			tmp->qos = tq->qos;
-			tmp->topic = nng_strdup(tq->topic);
-			ret = ret->next; //???
-			tq = tq->next;
-			if (tq) {
-				ret = NNI_ALLOC_STRUCT(ret);
-				tmp->next = ret;
+
+			if (tq->topic == NULL) {
+				tq = tq->next;
+				continue;
 			}
+
+			struct topic_queue *new_node = nng_zalloc(sizeof(struct topic_queue));
+			if (new_node == NULL) {
+				log_error("Mem alloc failed!");
+				break; 
+			}
+
+			new_node->qos = tq->qos;
+			new_node->topic = nng_strdup(tq->topic);
+			new_node->next = NULL;
+
+			*tail = new_node;
+			tail = &(new_node->next);
+			
+			tq = tq->next;
 		}
 	}
 	nni_rwlock_unlock(&pipe_lock);
 
-	return res;
+	return head;
 }
 
 


### PR DESCRIPTION
only allows client with CONNECT carried topic alias

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved SUBSCRIBE/UNSUBSCRIBE cache-loss handling during busy pipe send scenarios.
  * Improved MQTT v5 topic-alias maximum handling across TCP, TLS, and WebSocket by clamping to configured limits and respecting client properties.
  * Fixed reconnect backoff log formatting and prevented accessing connection parameters after a pipe is closed.

* **New Features**
  * Added retrieval of eligible QoS resend candidates via `mqtt_get_resend_msg`, including MQTT v5 expiry checks.

* **Chores**
  * Hardened MQTT-over-WebSocket cleanup and error-path resource management to avoid stale message references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->