### PR TITLE
upgrade to hash64 of pipeid

### DIFF
--- a/include/nng/mqtt/packet.h
+++ b/include/nng/mqtt/packet.h
@@ -47,7 +47,7 @@
 	} while (0)
 
 struct mqtt_msg_info {
-	uint32_t pipe;
+	uint64_t pipe;
 };
 typedef struct mqtt_msg_info mqtt_msg_info;
 
@@ -58,8 +58,8 @@ struct topic_node {
 	uint8_t retain_handling : 2;
 
 	struct {
-		char *body;
-		int   len;
+		char   *body;
+		size_t  len;
 	} topic;
 
 	uint8_t reason_code;

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -24,7 +24,7 @@ extern "C" {
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-
+#include <inttypes.h> 
 // NNG_DECL is used on declarations to deal with scope.
 // For building Windows DLLs, it should be the appropriate __declspec().
 // For shared libraries with platforms that support hidden visibility,
@@ -95,7 +95,7 @@ typedef struct nng_listener_s {
 } nng_listener;
 
 typedef struct nng_pipe_s {
-	uint32_t id;
+	uint64_t id;
 } nng_pipe;
 
 typedef struct nng_socket_s {

--- a/include/nng/protocol/mqtt/mqtt_parser.h
+++ b/include/nng/protocol/mqtt/mqtt_parser.h
@@ -85,8 +85,9 @@ NNG_DECL uint16_t get_variable_binary(uint8_t **dest, const uint8_t *src);
 
 NNG_DECL uint32_t DJBHash(char *str);
 NNG_DECL uint32_t DJBHashn(char *str, uint16_t len);
-NNG_DECL uint64_t DJBHash64(char *str);
-NNG_DECL uint64_t DJBHash64n(uint8_t* str, uint32_t len);
+NNG_DECL uint64_t DJBHash64n(char* str, uint32_t len);
+NNG_DECL uint64_t fnv1a_hash64n(const char *str, size_t len);
+
 NNG_DECL uint32_t fnv1a_hashn(char *str, size_t n);
 NNG_DECL uint8_t  crc_hashn(char *str, size_t n);
 NNG_DECL uint32_t crc32_hashn(char *str, size_t n);

--- a/include/nng/supplemental/nanolib/binary_search.h
+++ b/include/nng/supplemental/nanolib/binary_search.h
@@ -62,8 +62,8 @@ _binary_search(
 }
 
 static inline bool
-_binary_search_uint32(uint32_t *vec, int l, size_t *index, uint32_t e,
-    int (*cmp)(uint32_t x, uint32_t y))
+_binary_search_uint64(uint64_t *vec, int l, size_t *index, uint64_t e,
+    int (*cmp)(uint64_t x, uint64_t y))
 {
 	int r = cvector_size(vec) - 1;
 	int m = 0;
@@ -110,7 +110,7 @@ _binary_search_uint32(uint32_t *vec, int l, size_t *index, uint32_t e,
 
 #define binary_search(vec, l, index, e, cmp) \
 	_binary_search(vec, l, index, e, cmp)
-#define binary_search_uint32(vec, l, index, e, cmp) \
-	_binary_search_uint32(vec, l, index, e, cmp)
+#define binary_search_uint64(vec, l, index, e, cmp) \
+	_binary_search_uint64(vec, l, index, e, cmp)
 
 #endif

--- a/include/nng/supplemental/nanolib/conf.h
+++ b/include/nng/supplemental/nanolib/conf.h
@@ -280,7 +280,7 @@ typedef struct {
 struct conf_session_node {
 	char    *name;
 	char    *clientid;
-	uint32_t idhash;
+	uint64_t idhash;
 	size_t   sub_count;
 	topics **sub_list;
 };

--- a/include/nng/supplemental/nanolib/hash_table.h
+++ b/include/nng/supplemental/nanolib/hash_table.h
@@ -26,7 +26,7 @@ typedef struct msg_queue msg_queue;
 typedef struct dbhash_atpair_s dbhash_atpair_t;
 
 struct dbhash_atpair_s {
-	uint32_t alias;
+	uint64_t alias;
 	char *   topic;
 };
 
@@ -34,7 +34,7 @@ typedef struct dbhash_ptpair_s dbhash_ptpair_t;
 
 // ptpair is pipe topic pair
 struct dbhash_ptpair_s {
-	uint32_t pipe;
+	uint64_t pipe;
 	char *   topic;
 };
 
@@ -44,10 +44,10 @@ struct dbhash_ptpair_s {
  * @param y - normally y is pointer of alias
  * @return 0, minus or plus
  */
-static inline int
+static inline uint64_t
 alias_cmp(void *x_, void *y_)
 {
-	uint32_t *       alias = (uint32_t *) y_;
+	uint64_t *       alias = (uint64_t *) y_;
 	dbhash_atpair_t *ele_x = (dbhash_atpair_t *) x_;
 	return *alias - ele_x->alias;
 }
@@ -58,21 +58,21 @@ NNG_DECL void dbhash_destroy_alias_table(void);
 // This function do not verify value of alias and topic,
 // therefore you should make sure alias and topic is
 // not illegal.
-NNG_DECL void dbhash_insert_atpair(uint32_t pipe_id, uint32_t alias, const char *topic);
+NNG_DECL void dbhash_insert_atpair(uint64_t pipe_id, uint64_t alias, const char *topic);
 
-NNG_DECL const char *dbhash_find_atpair(uint32_t pipe_id, uint32_t alias);
+NNG_DECL const char *dbhash_find_atpair(uint64_t pipe_id, uint64_t alias);
 
-NNG_DECL void dbhash_del_atpair_queue(uint32_t pipe_id);
+NNG_DECL void dbhash_del_atpair_queue(uint64_t pipe_id);
 
 NNG_DECL void dbhash_init_pipe_table(void);
 
 NNG_DECL void dbhash_destroy_pipe_table(void);
 
-NNG_DECL void dbhash_insert_topic(uint32_t id, char *val, uint8_t qos);
+NNG_DECL void dbhash_insert_topic(uint64_t id, char *val, uint8_t qos);
 
-NNG_DECL bool dbhash_check_topic(uint32_t id, char *val);
+NNG_DECL bool dbhash_check_topic(uint64_t id, char *val);
 
-NNG_DECL char *dbhash_get_first_topic(uint32_t id);
+NNG_DECL char *dbhash_get_first_topic(uint64_t id);
 
 NNG_DECL topic_queue *topic_queue_init(char *topic, int topic_len);
 
@@ -80,24 +80,24 @@ NNG_DECL void topic_queue_release(topic_queue *tq);
 
 NNG_DECL topic_queue *init_topic_queue_with_topic_node(topic_node *tn);
 
-NNG_DECL struct topic_queue *dbhash_get_topic_queue(uint32_t id);
+NNG_DECL struct topic_queue *dbhash_get_topic_queue(uint64_t id);
 
-NNG_DECL struct topic_queue *dbhash_copy_topic_queue(uint32_t id);
+NNG_DECL struct topic_queue *dbhash_copy_topic_queue(uint64_t id);
 
-NNG_DECL void dbhash_del_topic(uint32_t id, char *topic);
+NNG_DECL void dbhash_del_topic(uint64_t id, char *topic);
 
 NNG_DECL void *dbhash_del_topic_queue(
-     uint32_t id, void *(*cb)(void *, char *), void *args);
+     uint64_t id, void *(*cb)(void *, char *), void *args);
 
-NNG_DECL bool dbhash_check_id(uint32_t id);
+NNG_DECL bool dbhash_check_id(uint64_t id);
 
-NNG_DECL void *dbhash_check_id_and_do(uint32_t id, void *(*cb)(void *), void *arg);
+NNG_DECL void *dbhash_check_id_and_do(uint64_t id, void *(*cb)(void *), void *arg);
 
-NNG_DECL void dbhash_print_topic_queue(uint32_t id);
+NNG_DECL void dbhash_print_topic_queue(uint64_t id);
 
 NNG_DECL topic_queue **dbhash_get_topic_queue_all(size_t *sz);
 
-NNG_DECL dbhash_ptpair_t *dbhash_ptpair_alloc(uint32_t p, char *t);
+NNG_DECL dbhash_ptpair_t *dbhash_ptpair_alloc(uint64_t p, char *t);
 
 NNG_DECL void dbhash_ptpair_free(dbhash_ptpair_t *pt);
 
@@ -108,14 +108,14 @@ NNG_DECL size_t dbhash_get_pipe_cnt(void);
 NNG_DECL void dbhash_init_cached_table(void);
 NNG_DECL void dbhash_destroy_cached_table(void);
 
-NNG_DECL void dbhash_cache_topic_all(uint32_t pid, uint32_t cid);
+NNG_DECL void dbhash_cache_topic_all(uint64_t pid, uint64_t cid);
 
-NNG_DECL void dbhash_restore_topic_all(uint32_t cid, uint32_t pid);
+NNG_DECL void dbhash_restore_topic_all(uint64_t cid, uint64_t pid);
 
-NNG_DECL struct topic_queue *dbhash_get_cached_topic(uint32_t cid);
+NNG_DECL struct topic_queue *dbhash_get_cached_topic(uint64_t cid);
 
-NNG_DECL void dbhash_del_cached_topic_all(uint32_t key);
+NNG_DECL void dbhash_del_cached_topic_all(uint64_t key);
 
-NNG_DECL bool dbhash_cached_check_id(uint32_t key);
+NNG_DECL bool dbhash_cached_check_id(uint64_t key);
 
 #endif

--- a/include/nng/supplemental/nanolib/hash_table.h
+++ b/include/nng/supplemental/nanolib/hash_table.h
@@ -44,12 +44,16 @@ struct dbhash_ptpair_s {
  * @param y - normally y is pointer of alias
  * @return 0, minus or plus
  */
-static inline uint64_t
+static inline int
 alias_cmp(void *x_, void *y_)
 {
 	uint64_t *       alias = (uint64_t *) y_;
 	dbhash_atpair_t *ele_x = (dbhash_atpair_t *) x_;
-	return *alias - ele_x->alias;
+	if (*alias < ele_x->alias)
+		return -1;
+	if (*alias > ele_x->alias)
+		return 1;
+	return 0;
 }
 
 NNG_DECL void dbhash_init_alias_table(void);

--- a/include/nng/supplemental/nanolib/mqtt_db.h
+++ b/include/nng/supplemental/nanolib/mqtt_db.h
@@ -54,7 +54,7 @@ NNG_DECL void dbtree_print(dbtree *db);
  * @return
  */
 NNG_DECL void *dbtree_insert_client(
-    dbtree *db, char *topic, uint32_t pipe_id);
+    dbtree *db, char *topic, uint64_t pipe_id);
 
 /**
  * @brief dbtree_find_client - check if this
@@ -80,7 +80,7 @@ NNG_DECL void *dbtree_insert_client(
  * @return
  */
 NNG_DECL void *dbtree_delete_client(
-    dbtree *db, char *topic, uint32_t pipe_id);
+    dbtree *db, char *topic, uint64_t pipe_id);
 
 /**
  * @brief dbtree_find_clients_and_cache_msg - Get all
@@ -89,7 +89,7 @@ NNG_DECL void *dbtree_delete_client(
  * @param topic - topic
  * @return pipe id array
  */
-NNG_DECL uint32_t *dbtree_find_clients(dbtree *db, char *topic);
+NNG_DECL uint64_t *dbtree_find_clients(dbtree *db, char *topic);
 
 /**
  * @brief dbtree_insert_retain - Insert retain message to this topic.
@@ -124,7 +124,7 @@ NNG_DECL nng_msg **dbtree_find_retain(dbtree *db, char *topic);
  * @param topic - topic
  * @return pipe id array
  */
-NNG_DECL uint32_t *dbtree_find_shared_clients(dbtree *db, char *topic);
+NNG_DECL uint64_t *dbtree_find_shared_clients(dbtree *db, char *topic);
 
 /**
  * @brief dbtree_get_tree - This function will
@@ -133,7 +133,7 @@ NNG_DECL uint32_t *dbtree_find_shared_clients(dbtree *db, char *topic);
  * @param cb - a callback function
  * @return all info about this tree
  */
-NNG_DECL void ***dbtree_get_tree(dbtree *db, void *(*cb)(uint32_t pipe_id));
+NNG_DECL void ***dbtree_get_tree(dbtree *db, void *(*cb)(uint64_t pipe_id));
 
 /**
  * @brief tran_close_unack_msg_cb - This function is used as callback func to

--- a/src/core/idhash.c
+++ b/src/core/idhash.c
@@ -155,7 +155,7 @@ nni_id_get_min(nni_id_map *m, uint16_t *pid)
 				break;
 			}
 		} else {
-			*pid = m->id_entries[index].key;
+			*pid = (uint16_t) m->id_entries[index].key;
 			return (m->id_entries[index].val);
 		}
 	}

--- a/src/core/message.c
+++ b/src/core/message.c
@@ -30,7 +30,7 @@ struct nng_msg {
 	nni_chunk m_body; // equal to variable header + payload
 	nni_proto_msg_ops *m_proto_ops;
 	void *             m_proto_data;
-	uint32_t           m_pipe; // set on receive
+	uint64_t           m_pipe; // set on receive
 	nni_atomic_int     m_refcnt;
 	// FOR NANOMQ
 	uint8_t          CMD_TYPE;
@@ -676,7 +676,7 @@ nni_msg_set_pipe(nni_msg *m, uint32_t pid)
 	m->m_pipe = pid;
 }
 
-uint32_t
+uint64_t
 nni_msg_get_pipe(const nni_msg *m)
 {
 	return (m->m_pipe);

--- a/src/core/message.c
+++ b/src/core/message.c
@@ -671,7 +671,7 @@ nni_msg_header_clear(nni_msg *m)
 }
 
 void
-nni_msg_set_pipe(nni_msg *m, uint32_t pid)
+nni_msg_set_pipe(nni_msg *m, uint64_t pid)
 {
 	m->m_pipe = pid;
 }

--- a/src/core/message.h
+++ b/src/core/message.h
@@ -47,7 +47,7 @@ extern uint32_t nni_msg_trim_u32(nni_msg *);
 extern uint32_t nni_msg_header_peek_u32(nni_msg *);
 extern void     nni_msg_header_poke_u32(nni_msg *, uint32_t);
 extern void     nni_msg_set_pipe(nni_msg *, uint32_t);
-extern uint32_t nni_msg_get_pipe(const nni_msg *);
+extern uint64_t nni_msg_get_pipe(const nni_msg *);
 
 // Reference counting messages. This allows the same message to be
 // cheaply reused instead of copied over and over again.  Callers of

--- a/src/core/message.h
+++ b/src/core/message.h
@@ -46,7 +46,7 @@ extern uint32_t nni_msg_trim_u32(nni_msg *);
 // It's faster than trim and append, but logically equivalent.
 extern uint32_t nni_msg_header_peek_u32(nni_msg *);
 extern void     nni_msg_header_poke_u32(nni_msg *, uint32_t);
-extern void     nni_msg_set_pipe(nni_msg *, uint32_t);
+extern void     nni_msg_set_pipe(nni_msg *, uint64_t);
 extern uint64_t nni_msg_get_pipe(const nni_msg *);
 
 // Reference counting messages. This allows the same message to be

--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -226,8 +226,8 @@ pipe_stats_init(nni_pipe *p)
 	pipe_stat_init(p, &p->st_rx_bytes, &rx_bytes_info);
 	pipe_stat_init(p, &p->st_tx_bytes, &tx_bytes_info);
 
-	nni_stat_set_id(&p->st_root, (int) p->p_id);	// FIX sv_id shall be uint64_t
-	nni_stat_set_id(&p->st_id, (int) p->p_id);
+	nni_stat_set_id(&p->st_root, p->p_id);	// FIX sv_id shall be uint64_t
+	nni_stat_set_id(&p->st_id, p->p_id);
 	nni_stat_set_id(&p->st_sock_id, (int) nni_sock_id(p->p_sock));
 
 }
@@ -472,8 +472,8 @@ nni_pipe_set_pid(nni_pipe *new_pipe, uint64_t id)
 	nni_id_remove(&pipes, new_pipe->p_id);
 	new_pipe->p_id = id;
 	#ifdef NNG_ENABLE_STATS
-	nni_stat_set_id(&new_pipe->st_root, (int) new_pipe->p_id);
-	nni_stat_set_id(&new_pipe->st_id, (int) new_pipe->p_id);
+	nni_stat_set_id(&new_pipe->st_root, new_pipe->p_id);
+	nni_stat_set_id(&new_pipe->st_id, new_pipe->p_id);
 	#endif
 	// we leave session restore job to protocol layer.
 	if ((p = nni_id_get(&pipes, id)) != NULL) {

--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -19,7 +19,7 @@
 // performed in the context of the protocol.
 
 static nni_id_map pipes =
-    NNI_ID_MAP_INITIALIZER(1, 0x7fffffff, NNI_ID_FLAG_RANDOM);
+    NNI_ID_MAP_INITIALIZER(1, UINT64_MAX, NNI_ID_FLAG_RANDOM);
 static nni_mtx pipes_lk = NNI_MTX_INITIALIZER;
 
 static void pipe_destroy(void *);
@@ -76,7 +76,7 @@ pipe_destroy(void *arg)
 }
 
 int
-nni_pipe_find(nni_pipe **pp, uint32_t id)
+nni_pipe_find(nni_pipe **pp, uint64_t id)
 {
 	nni_pipe *p;
 
@@ -104,8 +104,8 @@ nni_pipe_rele(nni_pipe *p)
 	nni_mtx_unlock(&pipes_lk);
 }
 
-// nni_pipe_id returns the 32-bit pipe id, which can be used in backtraces.
-uint32_t
+// nni_pipe_id returns the 64-bit pipe id, which can be used in backtraces.
+uint64_t
 nni_pipe_id(nni_pipe *p)
 {
 	return (p->p_id);
@@ -226,7 +226,7 @@ pipe_stats_init(nni_pipe *p)
 	pipe_stat_init(p, &p->st_rx_bytes, &rx_bytes_info);
 	pipe_stat_init(p, &p->st_tx_bytes, &tx_bytes_info);
 
-	nni_stat_set_id(&p->st_root, (int) p->p_id);
+	nni_stat_set_id(&p->st_root, (int) p->p_id);	// FIX sv_id shall be uint64_t
 	nni_stat_set_id(&p->st_id, (int) p->p_id);
 	nni_stat_set_id(&p->st_sock_id, (int) nni_sock_id(p->p_sock));
 
@@ -271,7 +271,7 @@ pipe_create(nni_pipe **pp, nni_sock *sock, nni_sp_tran *tran, void *tran_data)
 	nni_cv_init(&p->p_cv, &pipes_lk);
 
 	nni_mtx_lock(&pipes_lk);
-	rv = nni_id_alloc32(&pipes, &p->p_id, p);
+	rv = nni_id_alloc(&pipes, &p->p_id, p);
 	nni_mtx_unlock(&pipes_lk);
 
 #ifdef NNG_ENABLE_STATS
@@ -463,7 +463,7 @@ nni_pipe_inc_packetid(nni_pipe *p)
  * @param id 
  */
 int
-nni_pipe_set_pid(nni_pipe *new_pipe, uint32_t id)
+nni_pipe_set_pid(nni_pipe *new_pipe, uint64_t id)
 {
 	int rv;
 	nni_pipe *p;

--- a/src/core/pipe.h
+++ b/src/core/pipe.h
@@ -24,7 +24,7 @@ extern void nni_pipe_recv(nni_pipe *, nni_aio *);
 extern void nni_pipe_send(nni_pipe *, nni_aio *);
 
 // Pipe operations that protocols use.
-extern uint32_t nni_pipe_id(nni_pipe *);
+extern uint64_t nni_pipe_id(nni_pipe *);
 
 // nni_pipe_close closes the underlying transport for the pipe.  Further
 // operations against will return NNG_ECLOSED.  This is idempotent.  The
@@ -40,7 +40,7 @@ extern int nni_pipe_getopt(
 
 // nni_pipe_find finds a pipe given its ID.  It places a hold on the
 // pipe, which must be released by the caller when it is done.
-extern int nni_pipe_find(nni_pipe **, uint32_t);
+extern int nni_pipe_find(nni_pipe **, uint64_t);
 
 // nni_pipe_sock_id returns the socket id for the pipe (used by public API).
 extern uint32_t nni_pipe_sock_id(nni_pipe *);
@@ -66,8 +66,7 @@ extern void     nni_pipe_set_conn_param(nni_pipe *p, void *c);
 extern void *   nni_pipe_get_conn_param(nni_pipe *p);
 extern bool     nni_pipe_get_status(nni_pipe *p);
 extern uint16_t nni_pipe_inc_packetid(nni_pipe *p);
-extern void     nni_pipe_id_swap(uint32_t old_id, uint32_t new_id);
-extern int      nni_pipe_set_pid(nni_pipe *new_pipe, uint32_t id);
+extern int      nni_pipe_set_pid(nni_pipe *new_pipe, uint64_t id);
 // extern nni_id_map* nni_pipe_get_idhash(nni_pipe *p);
 
 #endif // CORE_PIPE_H

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -1611,8 +1611,8 @@ nni_dialer_add_pipe(nni_dialer *d, void *tpipe)
 		return;
 	}
 #ifdef NNG_ENABLE_STATS
-	nni_stat_set_id(&p->st_root, (int) p->p_id);
-	nni_stat_set_id(&p->st_id, (int) p->p_id);
+	nni_stat_set_id(&p->st_root, p->p_id);
+	nni_stat_set_id(&p->st_id, p->p_id);
 	nni_stat_register(&p->st_root);
 #endif
 	nni_pipe_run_cb(p, NNG_PIPE_EV_ADD_POST);
@@ -1721,8 +1721,8 @@ nni_listener_add_pipe(nni_listener *l, void *tpipe)
 		return;
 	}
 #ifdef NNG_ENABLE_STATS
-	nni_stat_set_id(&p->st_root, (int) p->p_id);
-	nni_stat_set_id(&p->st_id, (int) p->p_id);
+	nni_stat_set_id(&p->st_root, p->p_id);
+	nni_stat_set_id(&p->st_id, p->p_id);
 	nni_stat_register(&p->st_root);
 #endif
 	nni_pipe_run_cb(p, NNG_PIPE_EV_ADD_POST);

--- a/src/core/sockimpl.h
+++ b/src/core/sockimpl.h
@@ -105,7 +105,7 @@ struct subinfo {
 };
 
 struct nni_pipe {
-	uint32_t           p_id;
+	uint64_t           p_id;
 	nni_sp_pipe_ops    p_tran_ops;
 	nni_proto_pipe_ops p_proto_ops;
 	size_t             p_size;

--- a/src/core/stats.c
+++ b/src/core/stats.c
@@ -23,7 +23,7 @@ struct nng_stat {
 	nni_list_node        s_node;
 	nni_time             s_timestamp;
 	union {
-		int      sv_id;
+		uint64_t sv_id;
 		bool     sv_bool;
 		uint64_t sv_value;
 		char    *sv_string;
@@ -153,7 +153,7 @@ nni_stat_dec(nni_stat_item *item, uint64_t inc)
 }
 
 void
-nni_stat_set_id(nni_stat_item *item, int id)
+nni_stat_set_id(nni_stat_item *item, uint64_t id)
 {
 #ifdef NNG_ENABLE_STATS
 	// IDs don't change, so just set it.
@@ -480,7 +480,7 @@ nng_stat_find_pipe(nng_stat *stat, uint64_t pipeid)
 }
 
 nng_stat *
-nng_stat_find_scope(nng_stat *stat, const char *name, int id)
+nng_stat_find_scope(nng_stat *stat, const char *name, uint64_t id)
 {
 	nng_stat *child;
 	if (stat == NULL || stat->s_info->si_type != NNG_STAT_SCOPE) {
@@ -526,7 +526,7 @@ stat_sprint_scope(nni_stat *stat, char **scope, int *lenp)
 		stat_sprint_scope(stat->s_parent, scope, lenp);
 	}
 	if (strlen(stat->s_info->si_name) > 0) {
-		snprintf(*scope, *lenp, "%s#%d.", stat->s_info->si_name,
+		snprintf(*scope, *lenp, "%s#%" PRIu64 ".", stat->s_info->si_name,
 		    stat->s_val.sv_id);
 	} else {
 		(*scope)[0] = '\0';

--- a/src/core/stats.h
+++ b/src/core/stats.h
@@ -44,7 +44,7 @@ struct nni_stat_item {
 		nni_atomic_u64 sv_atomic;
 		char *         sv_string;
 		bool           sv_bool;
-		int            sv_id;
+		uint64_t       sv_id;
 	} si_u;
 };
 
@@ -70,7 +70,7 @@ void nni_stat_register(nni_stat_item *);
 void nni_stat_unregister(nni_stat_item *);
 
 void nni_stat_set_value(nni_stat_item *, uint64_t);
-void nni_stat_set_id(nni_stat_item *, int);
+void nni_stat_set_id(nni_stat_item *, uint64_t);
 void nni_stat_set_bool(nni_stat_item *, bool);
 void nni_stat_set_string(nni_stat_item *, const char *);
 void nni_stat_init(nni_stat_item *, const nni_stat_info *);

--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 
+
 #if defined(__APPLE__)
 
 #include <libkern/OSByteOrder.h>
@@ -981,7 +982,7 @@ DJBHashn(char *str, uint16_t len)
 }
 
 uint64_t
-DJBHash64n(uint8_t* str, uint32_t len)
+DJBHash64n(char* str, uint32_t len)
 {
     uint64_t hash = 5381;
     uint64_t i    = 0;
@@ -993,16 +994,13 @@ DJBHash64n(uint8_t* str, uint32_t len)
     return hash;
 }
 
-uint64_t
-DJBHash64(char *str)
-{
-	uint64_t hash = 5381;
-	int      c;
-
-	while ((c = *str++))
-		hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
-	                                         // hash = hash * 33 + c;
-	return hash;
+uint64_t fnv1a_hash64n(const char *str, size_t len) {
+    uint64_t hash = 14695981039346656037ULL;
+    for (size_t i = 0; i < len; ++i) {
+        hash ^= (uint64_t)(unsigned char)str[i];
+        hash *= 1099511628211ULL;
+    }
+    return hash;
 }
 
 /* Fowler/Noll/Vo (FNV) hash function, variant 1a */

--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -809,7 +809,7 @@ nmq_connack_encode(nng_msg *msg, conf *conf, conn_param *cparam, uint8_t reason)
 				conf->max_topic_alias);
 			property_append(cparam->properties, prop_alias);
 		}
-		prop = property_get(cparam->properties, NANO_MAX_PACKET_SIZE);
+		prop = property_get(cparam->properties, MAXIMUM_PACKET_SIZE);
 		if (cparam->max_packet_size == 0) {
 			// set default max packet size for client
 			cparam->max_packet_size = conf == NULL

--- a/src/sp/protocol/mqtt/mqtt_parser_test.c
+++ b/src/sp/protocol/mqtt/mqtt_parser_test.c
@@ -137,8 +137,7 @@ test_hash()
 	NUTS_ASSERT(DJBHashn(str, strlen(str)) == 2090756197);
 	NUTS_ASSERT(fnv1a_hashn(str, strlen(str)) == (uint32_t)-1345293851); 
 	NUTS_ASSERT(crc_hashn(str, strlen(str)) == 191);
-	NUTS_ASSERT(DJBHash64(str) == 6385723493);
-	NUTS_ASSERT(DJBHash64n((uint8_t *)str, strlen(str)) == 6385723493);
+	NUTS_ASSERT(DJBHash64n(str, strlen(str)) == 6385723493);
 
 	NUTS_ASSERT(crc32_hashn(str2, strlen(str2)) == (uint32_t)-620996987);
 	NUTS_ASSERT(crc32c_hashn(str2, strlen(str2)) == 788723578);

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -175,8 +175,9 @@ nano_pipe_timer_cb(void *arg)
 	nni_pipe        *npipe        = p->pipe;
 	nni_time         time;
 	int 		 rv = 0;
-
+#ifdef NNG_SUPP_SQLITE
 	bool is_sqlite = p->broker->conf->sqlite.enable;
+#endif
 	rv = nng_aio_result(&p->aio_timer);
 	if (rv != 0) {
 		log_warn("sleep aio error %d", rv);
@@ -488,8 +489,8 @@ nano_sock_init(void *arg, nni_sock *sock)
 
 	nni_mtx_init(&s->lk);
 
-	nni_id_map_init(&s->pipes, 0, 0, false);
-	nni_id_map_init(&s->cached_sessions, 0, 0, false);
+	nni_id_map_init(&s->pipes, 0x0000u, UINT64_MAX, false);
+	nni_id_map_init(&s->cached_sessions, 0x0000u, UINT64_MAX, false);
 	nni_lmq_init(&s->waitlmq, 256);
 	NNI_LIST_INIT(&s->recvq, nano_ctx, rqnode);
 	NNI_LIST_INIT(&s->recvpipes, nano_pipe, rnode);
@@ -718,7 +719,7 @@ session_keeping:
 			if (nni_pipe_peer(old->pipe) != 0) {
 				log_error("Session restore failed!");
 			} else {
-				log_info("resuming session %d with %d", npipe->p_id, old->pipe->p_id);
+				log_info("resuming session %ld with %d", npipe->p_id, old->pipe->p_id);
 			}
 			p->id = nni_pipe_id(npipe);
 			// set event to false so that no notification will be sent
@@ -888,7 +889,7 @@ nano_pipe_close(void *arg)
 				// also cache kicked session
 				// merging 2 pipes together in pipe start
 			}
-			log_info("session stored %d", npipe->p_id);
+			log_info("session stored %ld", npipe->p_id);
 			nni_id_set(&s->cached_sessions, npipe->p_id, p);
 			// set event to false avoid of sending the disconnecting msg
 			p->event     = false;
@@ -1362,7 +1363,7 @@ nano_sock_setdb(void *arg, void *data)
 	// or switch to lmq for better msg rate?
 	for (size_t y = 0; y < nano_conf->pre_sessions.count; y++) {
 		conf_session_node *node = nano_conf->pre_sessions.nodes[y];
-		uint32_t hashn = DJBHashn(node->clientid, strlen(node->clientid));
+		uint64_t hashn = fnv1a_hash64n(node->clientid, strlen(node->clientid));
 		node->idhash = hashn;
 		if (!nano_conf->sqlite.enable) {
 			void *qos_db;

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -719,7 +719,8 @@ session_keeping:
 			if (nni_pipe_peer(old->pipe) != 0) {
 				log_error("Session restore failed!");
 			} else {
-				log_info("resuming session %ld with %d", npipe->p_id, old->pipe->p_id);
+				log_info("resuming session %" PRIu64 " with %" PRIu64,
+					npipe->p_id, old->pipe->p_id);
 			}
 			p->id = nni_pipe_id(npipe);
 			// set event to false so that no notification will be sent
@@ -889,7 +890,7 @@ nano_pipe_close(void *arg)
 				// also cache kicked session
 				// merging 2 pipes together in pipe start
 			}
-			log_info("session stored %ld", npipe->p_id);
+			log_info("session stored %" PRIu64, npipe->p_id);
 			nni_id_set(&s->cached_sessions, npipe->p_id, p);
 			// set event to false avoid of sending the disconnecting msg
 			p->event     = false;

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -186,7 +186,7 @@ tcptran_pipe_init(void *arg, nni_pipe *npipe)
 
 	nni_pipe_set_conn_param(npipe, p->tcp_cparam);
 	cid = (char *) conn_param_get_clientid(p->tcp_cparam);
-	clientid_key = DJBHashn(cid, conn_param_get_clientid_len(p->tcp_cparam));
+	clientid_key = fnv1a_hash64n(cid, conn_param_get_clientid_len(p->tcp_cparam));
 	rv = nni_pipe_set_pid(npipe, clientid_key);
 	log_debug("change p_id by hashing %d rv %d", clientid_key, rv);
 	p->npipe    = npipe;

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -182,7 +182,7 @@ tcptran_pipe_init(void *arg, nni_pipe *npipe)
 	int           rv;
 	char         *cid;
 	tcptran_pipe *p            = arg;
-	uint32_t      clientid_key = 0;
+	uint64_t      clientid_key = 0;
 
 	nni_pipe_set_conn_param(npipe, p->tcp_cparam);
 	cid = (char *) conn_param_get_clientid(p->tcp_cparam);

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -185,7 +185,7 @@ tlstran_pipe_init(void *arg, nni_pipe *npipe)
 	int           rv;
 	char         *cid;
 	tlstran_pipe *p = arg;
-	uint32_t      clientid_key = 0;
+	uint64_t      clientid_key = 0;
 
 	nni_pipe_set_conn_param(npipe, p->tcp_cparam);
 	cid = (char *) conn_param_get_clientid(p->tcp_cparam);

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -189,7 +189,7 @@ tlstran_pipe_init(void *arg, nni_pipe *npipe)
 
 	nni_pipe_set_conn_param(npipe, p->tcp_cparam);
 	cid = (char *) conn_param_get_clientid(p->tcp_cparam);
-	clientid_key = DJBHashn(cid, conn_param_get_clientid_len(p->tcp_cparam));
+	clientid_key = fnv1a_hash64n(cid, conn_param_get_clientid_len(p->tcp_cparam));
 	rv = nni_pipe_set_pid(npipe, clientid_key);
 	log_debug("change p_id by hashing %d rv %d", clientid_key, rv);
 	p->npipe = npipe;
@@ -874,7 +874,7 @@ tlstran_pipe_recv_cb(void *arg)
 			p->qsend_quota++;
 		}
 		uint8_t *ptr = nni_msg_body(msg);
-		uint16_t    ackid;
+		uint16_t ackid;
 		NNI_GET16(ptr, ackid);
 		nni_msg *qos_msg;
 		if ((qos_msg = nni_qos_db_get(p->conf->sqlite.enable, p->npipe->nano_qos_db,

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -1311,7 +1311,7 @@ wstran_pipe_init(void *arg, nni_pipe *pipe)
 
 	nni_atomic_init_bool(&p->closed);
 	char    *cid;
-	uint32_t clientid_key = 0;
+	uint64_t clientid_key = 0;
 	cid = (char *) conn_param_get_clientid(p->ws_param);
 	clientid_key = fnv1a_hash64n(cid,
 		conn_param_get_clientid_len(p->ws_param));

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -1313,7 +1313,8 @@ wstran_pipe_init(void *arg, nni_pipe *pipe)
 	char    *cid;
 	uint32_t clientid_key = 0;
 	cid = (char *) conn_param_get_clientid(p->ws_param);
-	clientid_key = DJBHashn(cid, conn_param_get_clientid_len(p->ws_param));
+	clientid_key = fnv1a_hash64n(cid,
+		conn_param_get_clientid_len(p->ws_param));
 	id = nni_pipe_id(pipe);
 	rv = nni_pipe_set_pid(pipe, clientid_key);
 	log_debug("change p_id by hashing from %d to %d rv %d",

--- a/src/supplemental/mqtt/mqtt_qos_db.c
+++ b/src/supplemental/mqtt/mqtt_qos_db.c
@@ -37,7 +37,7 @@ static void    remove_oldest_client_msg(sqlite3 *db, const char *table_name,
        const char *col_name, uint64_t limit, const char *config_name);
 static int64_t get_id_by_msg(sqlite3 *db, nni_msg *msg);
 static int64_t insert_msg(sqlite3 *db, nni_msg *msg);
-static int64_t get_id_by_pipe(sqlite3 *db, uint32_t pipe_id);
+static int64_t get_id_by_pipe(sqlite3 *db, uint64_t pipe_id);
 static int64_t get_id_by_client_id(sqlite3 *db, const char *client_id);
 static int     get_id_by_p_id(sqlite3 *db, int64_t p_id, uint16_t packet_id,
         uint8_t *out_qos, int64_t *out_m_id);
@@ -46,7 +46,7 @@ static int     insert_main(
         sqlite3 *db, int64_t p_id, uint16_t packet_id, uint8_t qos, int64_t m_id);
 static int update_main(
     sqlite3 *db, int64_t p_id, uint16_t packet_id, uint8_t qos, int64_t m_id);
-static void set_main(sqlite3 *db, uint32_t pipe_id, uint16_t packet_id,
+static void set_main(sqlite3 *db, uint64_t pipe_id, uint16_t packet_id,
     uint8_t qos, nni_msg *msg);
 
 static int
@@ -257,7 +257,7 @@ insert_msg(sqlite3 *db, nni_msg *msg)
 }
 
 static int64_t
-get_id_by_pipe(sqlite3 *db, uint32_t pipe_id)
+get_id_by_pipe(sqlite3 *db, uint64_t pipe_id)
 {
 	int64_t       id = 0;
 	sqlite3_stmt *stmt;
@@ -392,7 +392,7 @@ nni_mqtt_qos_db_remove_oldest(sqlite3 *db, uint64_t limit)
 
 void
 nni_mqtt_qos_db_insert_pipe(
-    sqlite3 *db, uint32_t pipe_id, const char *client_id)
+    sqlite3 *db, uint64_t pipe_id, const char *client_id)
 {
 	sqlite3_stmt *stmt;
 	char *        sql = "INSERT INTO " table_pipe_client ""
@@ -409,7 +409,7 @@ nni_mqtt_qos_db_insert_pipe(
 }
 
 void
-nni_mqtt_qos_db_remove_pipe(sqlite3 *db, uint32_t pipe_id)
+nni_mqtt_qos_db_remove_pipe(sqlite3 *db, uint64_t pipe_id)
 {
 	sqlite3_stmt *stmt;
 	char *        sql = "DELETE FROM " table_pipe_client ""
@@ -425,7 +425,7 @@ nni_mqtt_qos_db_remove_pipe(sqlite3 *db, uint32_t pipe_id)
 
 void
 nni_mqtt_qos_db_update_pipe_by_clientid(
-    sqlite3 *db, uint32_t pipe_id, const char *client_id)
+    sqlite3 *db, uint64_t pipe_id, const char *client_id)
 {
 	sqlite3_stmt *stmt;
 	char *        sql = "UPDATE " table_pipe_client " SET pipe_id = ?"
@@ -442,7 +442,7 @@ nni_mqtt_qos_db_update_pipe_by_clientid(
 }
 
 void
-nni_mqtt_qos_db_set_pipe(sqlite3 *db, uint32_t pipe_id, const char *client_id)
+nni_mqtt_qos_db_set_pipe(sqlite3 *db, uint64_t pipe_id, const char *client_id)
 {
 	int64_t id = get_id_by_client_id(db, client_id);
 	if (id == 0) {
@@ -455,7 +455,7 @@ nni_mqtt_qos_db_set_pipe(sqlite3 *db, uint32_t pipe_id, const char *client_id)
 }
 
 void
-nni_mqtt_qos_db_update_all_pipe(sqlite3 *db, uint32_t pipe_id)
+nni_mqtt_qos_db_update_all_pipe(sqlite3 *db, uint64_t pipe_id)
 {
 	sqlite3_stmt *stmt;
 	char *        sql = "UPDATE " table_pipe_client " SET pipe_id = ?"
@@ -567,7 +567,7 @@ nni_mqtt_qos_db_remove_oldest_and_unused(sqlite3 *db, uint64_t limit)
 
 void
 nni_mqtt_qos_db_set(
-    sqlite3 *db, uint32_t pipe_id, uint16_t packet_id, nni_msg *msg)
+    sqlite3 *db, uint64_t pipe_id, uint16_t packet_id, nni_msg *msg)
 {
 	uint8_t  qos = MQTT_DB_GET_QOS_BITS(msg);
 	nni_msg *m   = MQTT_DB_GET_MSG_POINTER(msg);
@@ -575,7 +575,7 @@ nni_mqtt_qos_db_set(
 }
 
 static void
-set_main(sqlite3 *db, uint32_t pipe_id, uint16_t packet_id, uint8_t qos,
+set_main(sqlite3 *db, uint64_t pipe_id, uint16_t packet_id, uint8_t qos,
     nni_msg *msg)
 {
 	int64_t p_id = get_id_by_pipe(db, pipe_id);
@@ -601,7 +601,7 @@ set_main(sqlite3 *db, uint32_t pipe_id, uint16_t packet_id, uint8_t qos,
 }
 
 nni_msg *
-nni_mqtt_qos_db_get(sqlite3 *db, uint32_t pipe_id, uint16_t packet_id)
+nni_mqtt_qos_db_get(sqlite3 *db, uint64_t pipe_id, uint16_t packet_id)
 {
 	nni_msg *     msg = NULL;
 	uint8_t       qos = 0;
@@ -638,7 +638,7 @@ nni_mqtt_qos_db_get(sqlite3 *db, uint32_t pipe_id, uint16_t packet_id)
 }
 
 nni_msg *
-nni_mqtt_qos_db_get_one(sqlite3 *db, uint32_t pipe_id, uint16_t *packet_id)
+nni_mqtt_qos_db_get_one(sqlite3 *db, uint64_t pipe_id, uint16_t *packet_id)
 {
 	nni_msg *     msg = NULL;
 	uint8_t       qos = 0;
@@ -675,7 +675,7 @@ nni_mqtt_qos_db_get_one(sqlite3 *db, uint32_t pipe_id, uint16_t *packet_id)
 }
 
 void
-nni_mqtt_qos_db_remove(sqlite3 *db, uint32_t pipe_id, uint16_t packet_id)
+nni_mqtt_qos_db_remove(sqlite3 *db, uint64_t pipe_id, uint16_t packet_id)
 {
 	sqlite3_stmt *stmt;
 	char *sql = "DELETE FROM " table_main " AS main WHERE main.p_id = "
@@ -685,7 +685,7 @@ nni_mqtt_qos_db_remove(sqlite3 *db, uint32_t pipe_id, uint16_t packet_id)
 	sqlite3_prepare_v2(db, sql, strlen(sql), &stmt, 0);
 	sqlite3_reset(stmt);
 
-	sqlite3_bind_int(stmt, 1, pipe_id);
+	sqlite3_bind_int64(stmt, 1, pipe_id);
 	sqlite3_bind_int(stmt, 2, packet_id);
 	sqlite3_step(stmt);
 
@@ -694,7 +694,7 @@ nni_mqtt_qos_db_remove(sqlite3 *db, uint32_t pipe_id, uint16_t packet_id)
 }
 
 void
-nni_mqtt_qos_db_remove_by_pipe(sqlite3 *db, uint32_t pipe_id)
+nni_mqtt_qos_db_remove_by_pipe(sqlite3 *db, uint64_t pipe_id)
 {
 	sqlite3_stmt *stmt;
 	char *sql = "DELETE FROM " table_main " AS main WHERE main.p_id = "
@@ -726,7 +726,7 @@ nni_mqtt_qos_db_foreach(sqlite3 *db, nni_idhash_cb cb)
 	sqlite3_reset(stmt);
 
 	while (SQLITE_ROW == sqlite3_step(stmt)) {
-		uint32_t pipe_id = sqlite3_column_int64(stmt, 0);
+		uint64_t pipe_id = sqlite3_column_int64(stmt, 0);
 		size_t   nbyte   = (size_t) sqlite3_column_bytes16(stmt, 1);
 		uint8_t *bytes   = sqlite3_malloc(nbyte);
 		memcpy(bytes, sqlite3_column_blob(stmt, 1), nbyte);
@@ -881,7 +881,7 @@ nni_mqtt_qos_db_remove_retain(sqlite3 *db, const char *topic)
 }
 
 int
-nni_mqtt_qos_db_set_client_msg(sqlite3 *db, uint32_t pipe_id,
+nni_mqtt_qos_db_set_client_msg(sqlite3 *db, uint64_t pipe_id,
     uint16_t packet_id, nni_msg *msg, const char *config_name, uint8_t proto_ver)
 {
 	char sql[] =
@@ -915,7 +915,7 @@ nni_mqtt_qos_db_set_client_msg(sqlite3 *db, uint32_t pipe_id,
 
 nni_msg *
 nni_mqtt_qos_db_get_client_msg(
-    sqlite3 *db, uint32_t pipe_id, uint16_t packet_id, const char *config_name)
+    sqlite3 *db, uint64_t pipe_id, uint16_t packet_id, const char *config_name)
 {
 	nni_msg *     msg = NULL;
 	sqlite3_stmt *stmt;
@@ -951,7 +951,7 @@ nni_mqtt_qos_db_get_client_msg(
 
 void
 nni_mqtt_qos_db_remove_client_msg(
-    sqlite3 *db, uint32_t pipe_id, uint16_t packet_id, const char *config_name)
+    sqlite3 *db, uint64_t pipe_id, uint16_t packet_id, const char *config_name)
 {
 	sqlite3_stmt *stmt;
 
@@ -1063,7 +1063,7 @@ nni_mqtt_qos_db_get_one_client_msg(
 
 	if (SQLITE_ROW == sqlite3_step(stmt)) {
 		*id              = (uint64_t) sqlite3_column_int64(stmt, 0);
-		uint32_t pipe_id = sqlite3_column_int64(stmt, 1);
+		uint64_t pipe_id = sqlite3_column_int64(stmt, 1);
 		*packet_id       = sqlite3_column_int(stmt, 2);
 		size_t   nbyte   = (size_t) sqlite3_column_bytes16(stmt, 3);
 		uint8_t *bytes   = sqlite3_malloc(nbyte);

--- a/src/supplemental/mqtt/mqtt_qos_db.c
+++ b/src/supplemental/mqtt/mqtt_qos_db.c
@@ -655,7 +655,7 @@ nni_mqtt_qos_db_get_one(sqlite3 *db, uint64_t pipe_id, uint16_t *packet_id)
 	sqlite3_exec(db, "BEGIN;", 0, 0, 0);
 	sqlite3_prepare_v2(db, sql, strlen(sql), &stmt, 0);
 	sqlite3_reset(stmt);
-	sqlite3_bind_int(stmt, 1, pipe_id);
+	sqlite3_bind_int64(stmt, 1, pipe_id);
 
 	if (SQLITE_ROW == sqlite3_step(stmt)) {
 		*packet_id     = sqlite3_column_int64(stmt, 0);
@@ -704,7 +704,7 @@ nni_mqtt_qos_db_remove_by_pipe(sqlite3 *db, uint64_t pipe_id)
 	sqlite3_prepare_v2(db, sql, strlen(sql), &stmt, 0);
 	sqlite3_reset(stmt);
 
-	sqlite3_bind_int(stmt, 1, pipe_id);
+	sqlite3_bind_int64(stmt, 1, pipe_id);
 	sqlite3_step(stmt);
 
 	sqlite3_finalize(stmt);
@@ -899,7 +899,7 @@ nni_mqtt_qos_db_set_client_msg(sqlite3 *db, uint64_t pipe_id,
 	sqlite3_exec(db, "BEGIN;", 0, 0, 0);
 	sqlite3_prepare_v2(db, sql, strlen(sql), &stmt, 0);
 	sqlite3_reset(stmt);
-	sqlite3_bind_int(stmt, 1, pipe_id);
+	sqlite3_bind_int64(stmt, 1, pipe_id);
 	sqlite3_bind_int64(stmt, 2, packet_id);
 	sqlite3_bind_blob64(stmt, 3, blob, len, SQLITE_TRANSIENT);
 	sqlite3_bind_int(stmt, 4, proto_ver);

--- a/src/supplemental/mqtt/mqtt_qos_db.h
+++ b/src/supplemental/mqtt/mqtt_qos_db.h
@@ -97,22 +97,22 @@ typedef struct nng_mqtt_sqlite_option nni_mqtt_sqlite_option;
 
 extern void nni_mqtt_qos_db_init(sqlite3 **, const char *, const char *, bool);
 extern void nni_mqtt_qos_db_close(sqlite3 *);
-extern void     nni_mqtt_qos_db_set(sqlite3 *, uint32_t, uint16_t, nni_msg *);
-extern nni_msg *nni_mqtt_qos_db_get(sqlite3 *, uint32_t, uint16_t);
-extern nni_msg *nni_mqtt_qos_db_get_one(sqlite3 *, uint32_t, uint16_t *);
-extern void     nni_mqtt_qos_db_remove(sqlite3 *, uint32_t, uint16_t);
+extern void     nni_mqtt_qos_db_set(sqlite3 *, uint64_t, uint16_t, nni_msg *);
+extern nni_msg *nni_mqtt_qos_db_get(sqlite3 *, uint64_t, uint16_t);
+extern nni_msg *nni_mqtt_qos_db_get_one(sqlite3 *, uint64_t, uint16_t *);
+extern void     nni_mqtt_qos_db_remove(sqlite3 *, uint64_t, uint16_t);
 extern void     nni_mqtt_qos_db_remove_oldest(sqlite3 *, uint64_t) NNG_DEPRECATED;
-extern void     nni_mqtt_qos_db_remove_by_pipe(sqlite3 *, uint32_t);
+extern void     nni_mqtt_qos_db_remove_by_pipe(sqlite3 *, uint64_t);
 extern void     nni_mqtt_qos_db_remove_msg(sqlite3 *, nni_msg *);
 extern void     nni_mqtt_qos_db_remove_unused_msg(sqlite3 *);
 extern void     nni_mqtt_qos_db_remove_all_msg(sqlite3 *);
 extern void     nni_mqtt_qos_db_foreach(sqlite3 *, nni_idhash_cb);
-extern void     nni_mqtt_qos_db_set_pipe(sqlite3 *, uint32_t, const char *);
-extern void     nni_mqtt_qos_db_insert_pipe(sqlite3 *, uint32_t, const char *);
-extern void     nni_mqtt_qos_db_remove_pipe(sqlite3 *, uint32_t);
+extern void     nni_mqtt_qos_db_set_pipe(sqlite3 *, uint64_t, const char *);
+extern void     nni_mqtt_qos_db_insert_pipe(sqlite3 *, uint64_t, const char *);
+extern void     nni_mqtt_qos_db_remove_pipe(sqlite3 *, uint64_t);
 extern void     nni_mqtt_qos_db_update_pipe_by_clientid(
-        sqlite3 *, uint32_t, const char *);
-extern void nni_mqtt_qos_db_update_all_pipe(sqlite3 *, uint32_t);
+        sqlite3 *, uint64_t, const char *);
+extern void nni_mqtt_qos_db_update_all_pipe(sqlite3 *, uint64_t);
 extern void nni_mqtt_qos_db_check_remove_msg(sqlite3 *, nni_msg *);
 
 extern int nni_mqtt_qos_db_set_retain(
@@ -127,11 +127,11 @@ extern void nni_mqtt_qos_db_remove_oldest_client_offline_msg(
     sqlite3 *, uint64_t ,const char *);
 // Only work for client
 extern int nni_mqtt_qos_db_set_client_msg(
-    sqlite3 *, uint32_t, uint16_t, nni_msg *, const char *, uint8_t);
+    sqlite3 *, uint64_t, uint16_t, nni_msg *, const char *, uint8_t);
 extern nni_msg *nni_mqtt_qos_db_get_client_msg(
-    sqlite3 *, uint32_t, uint16_t, const char *);
+    sqlite3 *, uint64_t, uint16_t, const char *);
 extern void nni_mqtt_qos_db_remove_client_msg(
-    sqlite3 *, uint32_t, uint16_t, const char *);
+    sqlite3 *, uint64_t, uint16_t, const char *);
 extern void nni_mqtt_qos_db_remove_client_msg_by_id(sqlite3 *, uint64_t);
 extern nni_msg *nni_mqtt_qos_db_get_one_client_msg(
     sqlite3 *, uint64_t *, uint16_t *, const char *);

--- a/src/supplemental/mqtt/mqtt_qos_db_api.c
+++ b/src/supplemental/mqtt/mqtt_qos_db_api.c
@@ -4,7 +4,7 @@
 #endif
 
 void
-nni_qos_db_set(bool is_sqlite, void *db, uint32_t pipe_id, uint16_t packet_id,
+nni_qos_db_set(bool is_sqlite, void *db, uint64_t pipe_id, uint16_t packet_id,
     nng_msg *msg)
 {
 	if (db == NULL)
@@ -29,7 +29,7 @@ nni_qos_db_set(bool is_sqlite, void *db, uint32_t pipe_id, uint16_t packet_id,
 }
 
 nng_msg *
-nni_qos_db_get(bool is_sqlite, void *db, uint32_t pipe_id, uint16_t packet_id)
+nni_qos_db_get(bool is_sqlite, void *db, uint64_t pipe_id, uint16_t packet_id)
 {
 	if (db == NULL)
 		return NULL;
@@ -48,7 +48,7 @@ nni_qos_db_get(bool is_sqlite, void *db, uint32_t pipe_id, uint16_t packet_id)
 
 nng_msg *
 nni_qos_db_get_one(
-    bool is_sqlite, void *db, uint32_t pipe_id, uint16_t *packet_id)
+    bool is_sqlite, void *db, uint64_t pipe_id, uint16_t *packet_id)
 {
 	nng_msg *msg = NULL;
 	if (db == NULL)
@@ -67,7 +67,7 @@ nni_qos_db_get_one(
 
 void
 nni_qos_db_remove(
-    bool is_sqlite, void *db, uint32_t pipe_id, uint16_t packet_id)
+    bool is_sqlite, void *db, uint64_t pipe_id, uint16_t packet_id)
 {
 	if (db == NULL)
 		return;
@@ -95,7 +95,7 @@ nni_qos_db_remove_oldest(bool is_sqlite, void *db, uint64_t limit)
 }
 
 void
-nni_qos_db_remove_by_pipe(bool is_sqlite, void *db, uint32_t pipe_id)
+nni_qos_db_remove_by_pipe(bool is_sqlite, void *db, uint64_t pipe_id)
 {
 	if (is_sqlite) {
 #ifdef NNG_SUPP_SQLITE
@@ -159,7 +159,7 @@ nni_qos_db_reset_pipe(bool is_sqlite, void *db)
 
 void
 nni_qos_db_set_pipe(
-    bool is_sqlite, void *db, uint32_t pipe_id, const char *client_id)
+    bool is_sqlite, void *db, uint64_t pipe_id, const char *client_id)
 {
 	if (is_sqlite) {
 #ifdef NNG_SUPP_SQLITE
@@ -173,7 +173,7 @@ nni_qos_db_set_pipe(
 }
 
 void
-nni_qos_db_remove_pipe(bool is_sqlite, void *db, uint32_t pipe_id)
+nni_qos_db_remove_pipe(bool is_sqlite, void *db, uint64_t pipe_id)
 {
 	if (is_sqlite) {
 #ifdef NNG_SUPP_SQLITE
@@ -186,7 +186,7 @@ nni_qos_db_remove_pipe(bool is_sqlite, void *db, uint32_t pipe_id)
 }
 
 int
-nni_qos_db_set_client_msg(bool is_sqlite, void *db, uint32_t pipe_id,
+nni_qos_db_set_client_msg(bool is_sqlite, void *db, uint64_t pipe_id,
     uint16_t packet_id, nng_msg *msg, const char *config_name,
     uint8_t proto_ver)
 {
@@ -206,7 +206,7 @@ nni_qos_db_set_client_msg(bool is_sqlite, void *db, uint32_t pipe_id,
 }
 
 nng_msg *
-nni_qos_db_get_client_msg(bool is_sqlite, void *db, uint32_t pipe_id,
+nni_qos_db_get_client_msg(bool is_sqlite, void *db, uint64_t pipe_id,
     uint16_t packet_id, const char *config_name)
 {
 	nng_msg *msg = NULL;
@@ -225,7 +225,7 @@ nni_qos_db_get_client_msg(bool is_sqlite, void *db, uint32_t pipe_id,
 
 void
 nni_qos_db_remove_client_msg(
-    bool is_sqlite, void *db, uint32_t pipe_id, uint16_t packet_id, const char *config_name)
+    bool is_sqlite, void *db, uint64_t pipe_id, uint16_t packet_id, const char *config_name)
 {
 	if (is_sqlite) {
 #ifdef NNG_SUPP_SQLITE

--- a/src/supplemental/mqtt/mqtt_qos_db_api.h
+++ b/src/supplemental/mqtt/mqtt_qos_db_api.h
@@ -35,18 +35,18 @@ typedef struct {
 		nni_id_map_init((nni_id_map *) db, lo, hi, randomize); \
 	}
 
-extern void     nni_qos_db_set(bool is_sqlite, void *db, uint32_t pipe_id,
+extern void     nni_qos_db_set(bool is_sqlite, void *db, uint64_t pipe_id,
         uint16_t packet_id, nng_msg *msg);
 extern nng_msg *nni_qos_db_get(
-    bool is_sqlite, void *db, uint32_t pipe_id, uint16_t packet_id);
+    bool is_sqlite, void *db, uint64_t pipe_id, uint16_t packet_id);
 extern nng_msg *nni_qos_db_get_one(
-    bool is_sqlite, void *db, uint32_t pipe_id, uint16_t *packet_id);
+    bool is_sqlite, void *db, uint64_t pipe_id, uint16_t *packet_id);
 extern void nni_qos_db_remove(
-    bool is_sqlite, void *db, uint32_t pipe_id, uint16_t packet_id);
+    bool is_sqlite, void *db, uint64_t pipe_id, uint16_t packet_id);
 extern void nni_qos_db_remove_oldest(bool is_sqlite, void *db, uint64_t limit);
 
 extern void nni_qos_db_remove_by_pipe(
-    bool is_sqlite, void *db, uint32_t pipe_id);
+    bool is_sqlite, void *db, uint64_t pipe_id);
 extern void nni_qos_db_remove_msg(bool is_sqlite, void *db, nng_msg *msg);
 extern void nni_qos_db_remove_unused_msg(bool is_sqlite, void *db);
 extern void nni_mqtt_qos_db_remove_oldest_and_unused(
@@ -55,17 +55,17 @@ extern void nni_qos_db_remove_all_msg(
     bool is_sqlite, void *db, nni_idhash_cb cb);
 extern void nni_qos_db_reset_pipe(bool is_sqlite, void *db);
 extern void nni_qos_db_set_pipe(
-    bool is_sqlite, void *db, uint32_t pipe_id, const char *client_id);
-extern void nni_qos_db_remove_pipe(bool is_sqlite, void *db, uint32_t pipe_id);
+    bool is_sqlite, void *db, uint64_t pipe_id, const char *client_id);
+extern void nni_qos_db_remove_pipe(bool is_sqlite, void *db, uint64_t pipe_id);
 
 extern int      nni_qos_db_set_client_msg(bool is_sqlite, void *db,
-         uint32_t pipe_id, uint16_t packet_id, nng_msg *msg,
+         uint64_t pipe_id, uint16_t packet_id, nng_msg *msg,
          const char *config_name, uint8_t proto_ver);
 extern nng_msg *nni_qos_db_get_client_msg(
-    bool is_sqlite, void *db, uint32_t pipe_id, uint16_t packet_id,
+    bool is_sqlite, void *db, uint64_t pipe_id, uint16_t packet_id,
     const char *config_name);
 extern void nni_qos_db_remove_client_msg(bool is_sqlite, void *db,
-    uint32_t pipe_id, uint16_t packet_id, const char *config_name);
+    uint64_t pipe_id, uint16_t packet_id, const char *config_name);
 extern void nni_qos_db_remove_oldest_client_msg(
     bool is_sqlite, void *db, uint64_t limit, const char *config_name);
 extern void nni_qos_db_remove_client_msg_by_id(

--- a/src/supplemental/nanolib/conf_ver2.c
+++ b/src/supplemental/nanolib/conf_ver2.c
@@ -352,7 +352,7 @@ conf_basic_parse_ver2(conf *config, cJSON *jso)
 		hocon_read_time(config, await_rel_timeout, jso_mqtt);
 	}
 	config->ext_qos_db = nni_zalloc(sizeof(nni_id_map));
-	nni_id_map_init((nni_id_map *)config->ext_qos_db, 0, 0, false);
+	nni_id_map_init((nni_id_map *)config->ext_qos_db, 0000u, UINT64_MAX, false);
 
 	cJSON *jso_listeners = cJSON_GetObjectItem(jso, "listeners");
 	if (jso_listeners) {

--- a/src/supplemental/nanolib/dbtree_test.c
+++ b/src/supplemental/nanolib/dbtree_test.c
@@ -219,7 +219,7 @@ static void
 test_search_client()
 {
 	puts("================test search client==============");
-	uint32_t *uv = dbtree_find_clients(db, topic0);
+	uint64_t *uv = dbtree_find_clients(db, topic0);
 	if (uv) {
 		cvector_free(uv);
 	}
@@ -231,7 +231,7 @@ test_search_shared_client()
 {
 	puts("================test search shared client==============");
 	for (int i = 0; i < 20; i++) {
-		uint32_t *v = dbtree_find_shared_clients(db, topic0);
+		uint64_t *v = dbtree_find_shared_clients(db, topic0);
 
 		if (v) {
 			cvector_free(v);

--- a/src/supplemental/nanolib/hash_table.c
+++ b/src/supplemental/nanolib/hash_table.c
@@ -20,7 +20,7 @@
 		nni_rwlock_init(&lock);  \
 	}
 
-static dbhash_atpair_t *dbhash_atpair_alloc(uint32_t alias, const char *topic);
+static dbhash_atpair_t *dbhash_atpair_alloc(uint64_t alias, const char *topic);
 static void             dbhash_atpair_free(dbhash_atpair_t *atpair);
 
 KHASH_MAP_INIT_INT(alias_table, dbhash_atpair_t **)
@@ -34,7 +34,7 @@ dbhash_init_alias_table(void)
 }
 
 static dbhash_atpair_t **
-find_atpair_vec(uint32_t p)
+find_atpair_vec(uint64_t p)
 {
 	khint_t k = kh_get(alias_table, ah, p);
 	if (k == kh_end(ah)) {
@@ -45,7 +45,7 @@ find_atpair_vec(uint32_t p)
 }
 
 void
-dbhash_insert_atpair(uint32_t p, uint32_t a, const char *t)
+dbhash_insert_atpair(uint64_t p, uint64_t a, const char *t)
 {
 	int               absent;
 	dbhash_atpair_t * atpair = dbhash_atpair_alloc(a, t);
@@ -84,7 +84,7 @@ dbhash_insert_atpair(uint32_t p, uint32_t a, const char *t)
 }
 
 const char *
-dbhash_find_atpair(uint32_t p, uint32_t a)
+dbhash_find_atpair(uint64_t p, uint64_t a)
 {
 	nni_rwlock_rdlock(&alias_lock);
 	const char *t = NULL;
@@ -106,7 +106,7 @@ dbhash_find_atpair(uint32_t p, uint32_t a)
 }
 
 void
-dbhash_del_atpair_queue(uint32_t p)
+dbhash_del_atpair_queue(uint64_t p)
 {
 	nni_rwlock_wrlock(&alias_lock);
 
@@ -159,7 +159,7 @@ dbhash_destroy_pipe_table(void)
 }
 
 dbhash_ptpair_t *
-dbhash_ptpair_alloc(uint32_t p, char *t)
+dbhash_ptpair_alloc(uint64_t p, char *t)
 {
 	dbhash_ptpair_t *pt =
 	    (dbhash_ptpair_t *) nni_zalloc(sizeof(dbhash_ptpair_t));
@@ -367,7 +367,7 @@ delete_topic_queue(struct topic_queue *tq)
 // TODO If we have same topic to same id,
 // how to deal with ?
 void
-dbhash_insert_topic(uint32_t id, char *val, uint8_t qos)
+dbhash_insert_topic(uint64_t id, char *val, uint8_t qos)
 {
 	struct topic_queue *ntq = new_topic_queue(val, qos);
 	struct topic_queue *tq  = NULL;
@@ -398,7 +398,7 @@ dbhash_insert_topic(uint32_t id, char *val, uint8_t qos)
  */
 
 bool
-dbhash_check_topic(uint32_t id, char *val)
+dbhash_check_topic(uint64_t id, char *val)
 {
 
 	// dbhash_check_init(pipe_table, ph, pipe_lock);
@@ -427,7 +427,7 @@ dbhash_check_topic(uint32_t id, char *val)
 }
 
 char *
-dbhash_get_first_topic(uint32_t id)
+dbhash_get_first_topic(uint64_t id)
 {
 	char *topic = NULL;
 	nni_rwlock_wrlock(&pipe_lock);
@@ -449,7 +449,7 @@ dbhash_get_first_topic(uint32_t id)
  */
 
 struct topic_queue *
-dbhash_get_topic_queue(uint32_t id)
+dbhash_get_topic_queue(uint64_t id)
 {
 
 	// dbhash_check_init(pipe_table, ph, pipe_lock);
@@ -466,7 +466,7 @@ dbhash_get_topic_queue(uint32_t id)
 }
 
 struct topic_queue *
-dbhash_copy_topic_queue(uint32_t id)
+dbhash_copy_topic_queue(uint64_t id)
 {
 	struct topic_queue *head = NULL;
 	struct topic_queue **tail = &head;
@@ -512,7 +512,7 @@ dbhash_copy_topic_queue(uint32_t id)
 
 // TODO
 void
-dbhash_del_topic(uint32_t id, char *topic)
+dbhash_del_topic(uint64_t id, char *topic)
 {
 	// dbhash_check_init(pipe_table, ph, pipe_lock);
 	struct topic_queue *tt = NULL;
@@ -574,7 +574,7 @@ dbhash_del_topic(uint32_t id, char *topic)
  */
 
 void *
-del_topic_queue(uint32_t id, void *(*cb)(void *, char *), void *args)
+del_topic_queue(uint64_t id, void *(*cb)(void *, char *), void *args)
 {
 	struct topic_queue *tq = NULL;
 	khint_t             k  = kh_get(pipe_table, ph, id);
@@ -605,7 +605,7 @@ del_topic_queue(uint32_t id, void *(*cb)(void *, char *), void *args)
  */
 
 void *
-dbhash_del_topic_queue(uint32_t id, void *(*cb)(void *, char *), void *args)
+dbhash_del_topic_queue(uint64_t id, void *(*cb)(void *, char *), void *args)
 {
 	void *rv = NULL;
 	nni_rwlock_wrlock(&pipe_lock);
@@ -620,7 +620,7 @@ dbhash_del_topic_queue(uint32_t id, void *(*cb)(void *, char *), void *args)
  */
 
 static bool
-check_id(uint32_t id)
+check_id(uint64_t id)
 {
 	bool    ret = false;
 	khint_t k   = kh_get(pipe_table, ph, id);
@@ -635,7 +635,7 @@ check_id(uint32_t id)
  */
 
 bool
-dbhash_check_id(uint32_t id)
+dbhash_check_id(uint64_t id)
 {
 	bool ret = false;
 	nni_rwlock_rdlock(&pipe_lock);
@@ -645,7 +645,7 @@ dbhash_check_id(uint32_t id)
 }
 
 void *
-dbhash_check_id_and_do(uint32_t id, void *(*cb)(void *), void *arg)
+dbhash_check_id_and_do(uint64_t id, void *(*cb)(void *), void *arg)
 {
 	void *ret = NULL;
 	nni_rwlock_wrlock(&pipe_lock);
@@ -662,7 +662,7 @@ dbhash_check_id_and_do(uint32_t id, void *(*cb)(void *), void *arg)
  */
 
 void
-dbhash_print_topic_queue(uint32_t id)
+dbhash_print_topic_queue(uint64_t id)
 {
 	// dbhash_check_init(pipe_table, ph, pipe_lock);
 	struct topic_queue *tq = NULL;
@@ -681,13 +681,6 @@ dbhash_print_topic_queue(uint32_t id)
 	nni_rwlock_unlock(&pipe_lock);
 }
 
-/*
- * @obj. _cached_topic_hash.
- * @key. (DJBhashed) client_id.
- * @val. cached_topic_queue.
- */
-
-// mqtt_hash<uint32_t, topic_queue *> _cached_topic_hash;
 KHASH_MAP_INIT_INT(_cached_topic_hash, topic_queue *)
 static khash_t(_cached_topic_hash) *ch = NULL;
 static nni_rwlock cached_lock;
@@ -706,7 +699,7 @@ dbhash_destroy_cached_table(void)
 }
 
 static bool
-cached_check_id(uint32_t key)
+cached_check_id(uint64_t key)
 {
 	khint_t k = kh_get(_cached_topic_hash, ch, key);
 	if (k != kh_end(ch)) {
@@ -736,7 +729,7 @@ delete_cached_topic_one(struct topic_queue *ctq)
 }
 
 void
-del_cached_topic_all(uint32_t cid)
+del_cached_topic_all(uint64_t cid)
 {
 	struct topic_queue *ctq = NULL;
 	khint_t             k   = kh_get(_cached_topic_hash, ch, cid);
@@ -762,7 +755,7 @@ del_cached_topic_all(uint32_t cid)
  */
 
 void
-dbhash_cache_topic_all(uint32_t pid, uint32_t cid)
+dbhash_cache_topic_all(uint64_t pid, uint64_t cid)
 {
 	struct topic_queue *tq_in_topic_hash = NULL;
 	nni_rwlock_wrlock(&pipe_lock);
@@ -796,7 +789,7 @@ dbhash_cache_topic_all(uint32_t pid, uint32_t cid)
  */
 
 void
-dbhash_restore_topic_all(uint32_t cid, uint32_t pid)
+dbhash_restore_topic_all(uint64_t cid, uint64_t pid)
 {
 	struct topic_queue *tq_in_cached = NULL;
 	nni_rwlock_wrlock(&cached_lock);
@@ -830,7 +823,7 @@ dbhash_restore_topic_all(uint32_t cid, uint32_t pid)
 
 // FIXME Return pointer of topic_queue directly is not safe.
 struct topic_queue *
-dbhash_get_cached_topic(uint32_t cid)
+dbhash_get_cached_topic(uint64_t cid)
 {
 	struct topic_queue *ctq = NULL;
 	nni_rwlock_wrlock(&cached_lock);
@@ -848,7 +841,7 @@ dbhash_get_cached_topic(uint32_t cid)
  */
 
 void
-dbhash_del_cached_topic_all(uint32_t cid)
+dbhash_del_cached_topic_all(uint64_t cid)
 {
 	struct topic_queue *ctq = NULL;
 	nni_rwlock_wrlock(&cached_lock);
@@ -874,7 +867,7 @@ dbhash_del_cached_topic_all(uint32_t cid)
  */
 
 bool
-dbhash_cached_check_id(uint32_t key)
+dbhash_cached_check_id(uint64_t key)
 {
 	bool ret = false;
 	nni_rwlock_rdlock(&cached_lock);
@@ -884,7 +877,7 @@ dbhash_cached_check_id(uint32_t key)
 }
 
 dbhash_atpair_t *
-dbhash_atpair_alloc(uint32_t alias, const char *topic)
+dbhash_atpair_alloc(uint64_t alias, const char *topic)
 {
 	if (topic == NULL) {
 		log_error("Topic should not be NULL");

--- a/src/supplemental/nanolib/log.c
+++ b/src/supplemental/nanolib/log.c
@@ -1,3 +1,4 @@
+#include <sys/un.h>
 #include "nng/supplemental/nanolib/log.h"
 #include "nng/supplemental/nanolib/conf.h"
 #include "nng/supplemental/nanolib/file.h"

--- a/src/supplemental/nanolib/mqtt_db.c
+++ b/src/supplemental/nanolib/mqtt_db.c
@@ -30,7 +30,7 @@ struct dbtree_node {
 	int      plus;
 	int      well;
 	nng_msg *retain;
-	cvector(uint32_t) clients;
+	cvector(uint64_t) clients;
 	cvector(dbtree_node *) child;
 	nni_rwlock rwlock;
 };
@@ -62,7 +62,7 @@ node_cmp(void *x_, void *y_)
  * @return 0, minus or plus, based on strcmp
  */
 static inline int
-ids_cmp(uint32_t x, uint32_t y)
+ids_cmp(uint64_t x, uint64_t y)
 {
 	return y - x;
 }
@@ -73,7 +73,7 @@ ids_cmp(uint32_t x, uint32_t y)
  * @return void
  */
 static void
-print_client(uint32_t *v)
+print_client(uint64_t *v)
 {
 #ifdef NOLOG
 	NNI_ARG_UNUSED(v);
@@ -181,7 +181,7 @@ topic_queue_free(char **topic_queue)
 }
 
 void ***
-dbtree_get_tree(dbtree *db, void *(*cb)(uint32_t pipe_id))
+dbtree_get_tree(dbtree *db, void *(*cb)(uint64_t pipe_id))
 {
 	if (db == NULL) {
 		return NULL;
@@ -505,14 +505,14 @@ insert_client_cb(dbtree_node *node, void *pipe_id)
 	nni_rwlock_wrlock(&(node->rwlock));
 	size_t index = 0;
 	if (false ==
-	    binary_search_uint32(
-	        node->clients, 0, &index, *(uint32_t *) pipe_id, ids_cmp)) {
+	    binary_search_uint64(
+	        node->clients, 0, &index, *(uint64_t *) pipe_id, ids_cmp)) {
 		if (index == cvector_size(node->clients)) {
 			cvector_push_back(
-			    node->clients, *(uint32_t *) pipe_id);
+			    node->clients, *(uint64_t *) pipe_id);
 		} else {
 			cvector_insert(
-			    node->clients, index, *(uint32_t *) pipe_id);
+			    node->clients, index, *(uint64_t *) pipe_id);
 		}
 	}
 	nni_rwlock_unlock(&(node->rwlock));
@@ -705,7 +705,7 @@ search_insert_node(dbtree *db, char *topic, void *args,
 }
 
 void *
-dbtree_insert_client(dbtree *db, char *topic, uint32_t pipe_id)
+dbtree_insert_client(dbtree *db, char *topic, uint64_t pipe_id)
 {
 	return search_insert_node(
 	    db, topic, (void *) &pipe_id, insert_client_cb);
@@ -720,8 +720,8 @@ dbtree_insert_client(dbtree *db, char *topic, uint32_t pipe_id)
  * @param node_index - current topic level (traversal depth)
  * @return all clients on lots of nodes
  */
-static uint32_t **
-collect_clients(uint32_t **vec, dbtree_node **nodes, dbtree_node ***nodes_t,
+static uint64_t **
+collect_clients(uint64_t **vec, dbtree_node **nodes, dbtree_node ***nodes_t,
     char **topic_queue, int node_index)
 {
 	// TODO insert sort for clients
@@ -816,10 +816,10 @@ collect_clients(uint32_t **vec, dbtree_node **nodes, dbtree_node ***nodes_t,
  * @param v - client
  * @return pipe id vector
  */
-static uint32_t *
-iterate_client(uint32_t **v)
+static uint64_t *
+iterate_client(uint64_t **v)
 {
-	cvector(uint32_t) ids = NULL;
+	cvector(uint64_t) ids = NULL;
 
 	if (v) {
 		for (size_t i = 0; i < cvector_size(v); ++i) {
@@ -828,7 +828,7 @@ iterate_client(uint32_t **v)
 				size_t index = 0;
 
 				if (false ==
-				    binary_search_uint32(
+				    binary_search_uint64(
 				        ids, 0, &index, v[i][j], ids_cmp)) {
 					if (cvector_empty(ids) ||
 					    index == cvector_size(ids)) {
@@ -846,7 +846,7 @@ iterate_client(uint32_t **v)
 	return ids;
 }
 
-uint32_t *
+uint64_t *
 search_client(dbtree *db, char *topic)
 {
 	if (db == NULL || topic == NULL) {
@@ -856,12 +856,12 @@ search_client(dbtree *db, char *topic)
 
 	char **   topic_queue = topic_parse(topic);
 	char **   for_free    = topic_queue;
-	uint32_t *ret         = NULL;
+	uint64_t *ret         = NULL;
 
 	nni_rwlock_rdlock(&(db->rwlock));
 
 	dbtree_node *node              = db->root;
-	cvector(uint32_t *) pipe_ids   = NULL;
+	cvector(uint64_t *) pipe_ids   = NULL;
 	cvector(dbtree_node *) nodes   = NULL;
 	cvector(dbtree_node *) nodes_t = NULL;
 
@@ -896,7 +896,7 @@ search_client(dbtree *db, char *topic)
 	return ret;
 }
 
-uint32_t *
+uint64_t *
 dbtree_find_clients(dbtree *db, char *topic)
 {
 	return search_client(db, topic);
@@ -910,14 +910,14 @@ dbtree_find_clients(dbtree *db, char *topic)
  * @return
  */
 static void *
-delete_dbtree_client(dbtree_node *node, uint32_t pipe_id)
+delete_dbtree_client(dbtree_node *node, uint64_t pipe_id)
 {
 	size_t index = 0;
 	void * ctxt  = NULL;
 
 	nni_rwlock_wrlock(&(node->rwlock));
 	if (true ==
-	    binary_search_uint32(node->clients, 0, &index, pipe_id, ids_cmp)) {
+	    binary_search_uint64(node->clients, 0, &index, pipe_id, ids_cmp)) {
 		cvector_erase(node->clients, (size_t) index);
 		print_client(node->clients);
 
@@ -991,7 +991,7 @@ delete_dbtree_node(dbtree_node *node, size_t index)
 }
 
 void *
-dbtree_delete_client(dbtree *db, char *topic, uint32_t pipe_id)
+dbtree_delete_client(dbtree *db, char *topic, uint64_t pipe_id)
 {
 	if (db == NULL || topic == NULL) {
 		log_error("db or topic is NULL");
@@ -1366,10 +1366,10 @@ mem_free:
 }
 
 // TODO only use one of vector
-static uint32_t *
-iterate_shared_client(uint32_t **v)
+static uint64_t *
+iterate_shared_client(uint64_t **v)
 {
-	cvector(uint32_t) ids = NULL;
+	cvector(uint64_t) ids = NULL;
 
 	if (v) {
 		for (size_t i = 0; i < cvector_size(v); ++i) {
@@ -1386,7 +1386,7 @@ iterate_shared_client(uint32_t **v)
 			index = 0;
 			// Deduplicate id.
 			if (false ==
-			    binary_search_uint32(
+			    binary_search_uint64(
 			        ids, 0, &index, v[i][j], ids_cmp)) {
 				if (cvector_empty(ids) ||
 				    (size_t) index == cvector_size(ids)) {
@@ -1405,10 +1405,10 @@ iterate_shared_client(uint32_t **v)
 	return ids;
 }
 
-uint32_t *
+uint64_t *
 dbtree_find_shared_clients(dbtree *db, char *topic)
 {
-	cvector(uint32_t *) ids        = NULL;
+	cvector(uint64_t *) ids        = NULL;
 	cvector(dbtree_node *) nodes_p = NULL;
 	cvector(dbtree_node *) nodes_q = NULL;
 	bool   equal                   = false;
@@ -1463,7 +1463,7 @@ dbtree_find_shared_clients(dbtree *db, char *topic)
 		node_index++;
 	}
 
-	uint32_t *ret = iterate_shared_client(ids);
+	uint64_t *ret = iterate_shared_client(ids);
 	nni_rwlock_unlock(&(db->rwlock));
 	topic_queue_free(for_free);
 	cvector_free(nodes_p);

--- a/src/supplemental/nanolib/mqtt_db.c
+++ b/src/supplemental/nanolib/mqtt_db.c
@@ -64,7 +64,11 @@ node_cmp(void *x_, void *y_)
 static inline int
 ids_cmp(uint64_t x, uint64_t y)
 {
-	return y - x;
+	if (y < x)
+		return -1;
+	if (y > x)
+		return 1;
+	return 0;
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * MQTT identifier handling is now 64-bit across sessions, pipes, and related databases.
  * Hashing for MQTT client identifiers uses a 64-bit FNV-1a based key for better distribution.
  * Statistics and scope reporting now support 64-bit identifier values.
* **Bug Fixes**
  * Correctly reads the MQTT V5 “Maximum Packet Size” property when setting the client’s max packet size.
* **Compatibility**
  * Updated public MQTT/QoS database APIs and pipe/message “pipe” identifiers to use 64-bit types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->