### PR TITLE
* FIX [auth_http] #2341

### DIFF
--- a/include/nng/protocol/mqtt/mqtt_parser.h
+++ b/include/nng/protocol/mqtt/mqtt_parser.h
@@ -150,5 +150,6 @@ NNG_DECL int mqtt_get_remaining_length(uint8_t *, uint32_t, uint32_t *, uint8_t 
 
 NNG_DECL nng_msg *nng_sub0_msg_adapter(
     nng_msg *origin, conf_nng_sub_node *snode, char *default_topic);
+NNG_DECL size_t str_append(char **dest, const char *str);
 
 #endif // NNG_MQTT_H

--- a/include/nng/supplemental/nanolib/conf.h
+++ b/include/nng/supplemental/nanolib/conf.h
@@ -733,6 +733,8 @@ NNG_DECL void conf_update_var2(const char *fpath, const char *key1,
 NNG_DECL const char* conf_get_vin(void); 
 NNG_DECL void conf_free_vin();
 
+NNG_DECL void nmq_acl_cache_reset_cb(void *k, void *v, void *arg);
+
 #define conf_update_int(path, key, var) \
 	conf_update_var(path, key, 0, (void *) &(var))
 #define conf_update_u8(path, key, var) \

--- a/src/sp/protocol/mqtt/auth_http.c
+++ b/src/sp/protocol/mqtt/auth_http.c
@@ -53,25 +53,6 @@ url_encode(const char *str)
 	return encoded;
 }
 
-static size_t
-str_append(char **dest, const char *str)
-{
-	char *old_str = *dest == NULL ? "" : (*dest);
-	char *new_str =
-	    calloc(strlen(old_str) + (str ? strlen(str) : 0) + 1, sizeof(char));
-
-	strcat(new_str, old_str);
-	if (str) {
-		strcat(new_str, str);
-	}
-
-	if (*dest) {
-		free(*dest);
-	}
-	*dest = new_str;
-	return strlen(new_str);
-}
-
 static void
 set_data(
     nng_http_req *req, conf_auth_http_req *req_conf, auth_http_params *params)

--- a/src/sp/protocol/mqtt/auth_http.c
+++ b/src/sp/protocol/mqtt/auth_http.c
@@ -25,15 +25,45 @@ struct auth_http_params {
 
 typedef struct auth_http_params auth_http_params;
 
+static char *
+url_encode(const char *str)
+{
+	if (str == NULL) {
+		return NULL;
+	}
+	const char *hex = "0123456789ABCDEF";
+	size_t len = strlen(str);
+	// turn every char to "%XX" + '\0'
+	char *encoded = calloc(len * 3 + 1, sizeof(char));
+	if (encoded == NULL) {
+		return NULL;
+	}
+	char *p = encoded;
+	for (size_t i = 0; i < len; i++) {
+		unsigned char c = (unsigned char)str[i];
+		if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+			*p++ = c;
+		} else {
+			*p++ = '%';
+			*p++ = hex[c >> 4];
+			*p++ = hex[c & 15];
+		}
+	}
+	*p = '\0';
+	return encoded;
+}
+
 static size_t
 str_append(char **dest, const char *str)
 {
 	char *old_str = *dest == NULL ? "" : (*dest);
 	char *new_str =
-	    calloc(strlen(old_str) + strlen(str) + 1, sizeof(char));
+	    calloc(strlen(old_str) + (str ? strlen(str) : 0) + 1, sizeof(char));
 
 	strcat(new_str, old_str);
-	strcat(new_str, str == NULL ? "" : str);
+	if (str) {
+		strcat(new_str, str);
+	}
 
 	if (*dest) {
 		free(*dest);
@@ -128,107 +158,55 @@ set_data(
 		cJSON_Delete(obj);
 	} else {
 		for (size_t i = 0; i < req_conf->param_count; i++) {
+			const char *val = NULL;
+
 			switch (req_conf->params[i]->type) {
 			case ACCESS:
-				if (params->access) {
-					str_append(&req_data,
-					    req_conf->params[i]->name);
-					str_append(&req_data, "=");
-					str_append(&req_data, params->access);
-					str_append(&req_data, "&");
-				}
+				val = params->access;
 				break;
 			case USERNAME:
-				if (params->username) {
-					str_append(&req_data,
-					    req_conf->params[i]->name);
-					str_append(&req_data, "=");
-					str_append(
-					    &req_data, params->username);
-					str_append(&req_data, "&");
-				}
+				val = params->username;
 				break;
 			case CLIENTID:
-				if (params->clientid) {
-					str_append(&req_data,
-					    req_conf->params[i]->name);
-					str_append(&req_data, "=");
-					str_append(
-					    &req_data, params->clientid);
-					str_append(&req_data, "&");
-				}
+				val = params->clientid;
 				break;
 			case IPADDRESS:
-				if (params->ipaddress) {
-					str_append(&req_data,
-					    req_conf->params[i]->name);
-					str_append(&req_data, "=");
-					str_append(
-					    &req_data, params->ipaddress);
-					str_append(&req_data, "&");
-				}
+				val = params->ipaddress;
 				break;
 			case PROTOCOL:
-				if (params->protocol) {
-					str_append(&req_data,
-					    req_conf->params[i]->name);
-					str_append(&req_data, "=");
-					str_append(
-					    &req_data, params->protocol);
-					str_append(&req_data, "&");
-				}
+				val = params->protocol;
 				break;
 			case PASSWORD:
-				if (params->password) {
-					str_append(&req_data,
-					    req_conf->params[i]->name);
-					str_append(&req_data, "=");
-					str_append(
-					    &req_data, params->password);
-					str_append(&req_data, "&");
-				}
+				val = params->password;
 				break;
 			case SOCKPORT:
-				if (params->sockport) {
-					str_append(&req_data,
-					    req_conf->params[i]->name);
-					str_append(&req_data, "=");
-					str_append(
-					    &req_data, params->sockport);
-					str_append(&req_data, "&");
-				}
+				val = params->sockport;
 				break;
 			case COMMON_NAME:
-				if (params->common) {
-					str_append(&req_data,
-					    req_conf->params[i]->name);
-					str_append(&req_data, "=");
-					str_append(&req_data, params->common);
-					str_append(&req_data, "&");
-				}
+				val = params->common;
 				break;
 			case SUBJECT:
-				if (params->subject) {
-					str_append(&req_data,
-					    req_conf->params[i]->name);
-					str_append(&req_data, "=");
-					str_append(&req_data, params->subject);
-					str_append(&req_data, "&");
-				}
+				val = params->subject;
 				break;
 			case TOPIC:
-				if (params->topic) {
-					str_append(&req_data,
-					    req_conf->params[i]->name);
-					str_append(&req_data, "=");
-					str_append(&req_data, params->topic);
-					str_append(&req_data, "&");
-				}
+				val = params->topic;
 				break;
 			default:
 				break;
 			}
+
+			if (val) {
+				char *encoded_val = url_encode(val);
+				if (encoded_val) {
+					str_append(&req_data, req_conf->params[i]->name);
+					str_append(&req_data, "=");
+					str_append(&req_data, encoded_val);
+					str_append(&req_data, "&");
+					free(encoded_val);
+				}
+			}
 		}
+
 		if (req_data != NULL &&
 		    req_data[strlen(req_data) - 1] == '&') {
 			req_data[strlen(req_data) - 1] = '\0';
@@ -387,16 +365,16 @@ char *parse_topics(topic_queue *head)
 	}
 	int total_length = 0;
 	topic_queue *current = head;
-	if (current->topic == NULL || strlen(current->topic) == 0) {
-		log_error("topic is empty");
-		return NULL;
-	}
 	while (current != NULL) {
+		if (current->topic == NULL || strlen(current->topic) == 0) {
+			log_error("topic is empty");
+			return NULL;
+		}
 	    total_length += strlen(current->topic);
 		total_length += 1; // for ','
 	    current = current->next;
 	}
-	char *result = (char *)malloc(total_length + 1);
+	char *result = (char *)nni_alloc(total_length + 1);
 	if (result == NULL) {
 		log_error("malloc failed");
 		return NULL;

--- a/src/sp/protocol/mqtt/auth_http.c
+++ b/src/sp/protocol/mqtt/auth_http.c
@@ -344,16 +344,20 @@ char *parse_topics(topic_queue *head)
 	if (head == NULL) {
 	    return NULL;
 	}
-	int total_length = 0;
+	size_t total_length = 0;
 	topic_queue *current = head;
 	while (current != NULL) {
 		if (current->topic == NULL || strlen(current->topic) == 0) {
 			log_error("topic is empty");
 			return NULL;
 		}
-	    total_length += strlen(current->topic);
-		total_length += 1; // for ','
-	    current = current->next;
+		size_t tlen = strlen(current->topic);
+		if (tlen > SIZE_MAX - total_length - 1) {
+			log_error("topic list too long");
+			return NULL;
+		}
+		total_length += tlen + 1; // for ','
+		current = current->next;
 	}
 	char *result = (char *)nni_alloc(total_length + 1);
 	if (result == NULL) {
@@ -385,7 +389,7 @@ nmq_auth_http_sub_pub(
 	char *topic_str = parse_topics(topics);
 	if (topic_str == NULL) {
 		log_warn("Parsing topic failed for ACL");
-		return SUCCESS;
+		return NOT_AUTHORIZED;
 	}
 
 	auth_http_params auth_params = {

--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -225,6 +225,27 @@ get_utf8_str(char **dest, const uint8_t *src, uint32_t *pos, size_t max)
 	return (int32_t) str_len;
 }
 
+size_t
+str_append(char **dest, const char *str)
+{
+	char *old_str = *dest == NULL ? "" : (*dest);
+	char *new_str =
+	    calloc(strlen(old_str) + (str ? strlen(str) : 0) + 1, sizeof(char));
+	if (new_str == NULL) {
+		return *dest ? strlen(*dest) : 0;
+	}
+	strcat(new_str, old_str);
+	if (str) {
+		strcat(new_str, str);
+	}
+
+	if (*dest) {
+		free(*dest);
+	}
+	*dest = new_str;
+	return strlen(new_str);
+}
+
 /**
  * @brief safe copy limit size of src data to dest
  * 	  return null and -1 strlen if buffer overflow

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -641,6 +641,7 @@ nano_pipe_start(void *arg)
 	log_trace(" ########## nano_pipe_start ########## ");
 
 	nni_msg_alloc(&msg, 0);
+	conn_param_clone(p->conn_param);
 	nni_mtx_lock(&s->lk);
 
 #ifdef NNG_SUPP_SQLITE
@@ -701,8 +702,8 @@ nano_pipe_start(void *arg)
 	log_debug("client connected! addr [%s port [%d]\n",
 	    p->conn_param->ip_addr_v4, addr.s_in.sa_port);
 auth_verify:
-	conn_param_clone(p->conn_param);
 	rv = verify_connect(p->conn_param, s->conf);
+	// TODO Avoid holding s->lk across HTTP authentication.
 	if (rv == SUCCESS) {
 		if (s->conf->auth_http.enable) {
 			log_debug("HTTP Authentication start!");
@@ -711,7 +712,6 @@ auth_verify:
 		}
 	}
 	nmq_connack_encode(msg, s->conf, p->conn_param, rv);
-	conn_param_free(p->conn_param);
 	if (rv != 0) {
 		// send connack with reason code 0x05
 		log_warn("Invalid auth info or authentication denied");
@@ -725,6 +725,7 @@ auth_verify:
 	if (!clientid) {
 		log_warn("NULL clientid found when try to restore session.");
 		nni_mtx_unlock(&s->lk);
+		conn_param_free(p->conn_param);
 		return NNG_ECONNSHUT;
 	}
 	if (p->conn_param->clean_start == 0) {
@@ -816,6 +817,7 @@ out:
 		nmq_connack_session(msg, true);
 	}
 	nni_msg_set_conn_param(msg, p->conn_param);
+	conn_param_free(p->conn_param);
 	// There is no need to check the  state of aio_recv
 	// Since pipe_start is definetly the first cb to be excuted of pipe.
 	nni_aio_set_msg(&p->aio_recv, msg);

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -676,14 +676,14 @@ nano_pipe_start(void *arg)
 		}
 		p->conn_param->tls_subject = peer_subject;
 	}
-	rv = nng_pipe_get_addr(nng_pipe, NNG_OPT_REMADDR, &addr);
 
+	int addr_rv = nng_pipe_get_addr(nng_pipe, NNG_OPT_REMADDR, &addr);
+	if (addr_rv != 0) {
+		log_warn("Fail to get remote addr from client pipe: %s", nng_strerror(addr_rv));
+		goto auth_verify;
+	}
 	if (addr.s_family == NNG_AF_INET) {
 		arr = (uint8_t *) &addr.s_in.sa_addr;
-		if (arr == NULL) {
-			log_warn("Fail to get IP addr from client pipe!");
-			goto auth_verify;
-		}
 		sprintf(p->conn_param->ip_addr_v4, "%d.%d.%d.%d", arr[0],
 		    arr[1], arr[2], arr[3]);
 		// Get local listening port (server side) for HTTP auth %p
@@ -790,7 +790,7 @@ auth_verify:
 		p->pipe->nano_qos_db = qos_db;
 		nng_id_remove(s->conf->ext_qos_db, p->pipe->p_id);
 	}
-
+out:
 	// close old one (bool to prevent disconnect_ev)
 	// check if pointer is different later
 	if (old) {
@@ -806,7 +806,7 @@ auth_verify:
 	} else {
 		nni_mtx_unlock(&s->lk);
 	}
-out:
+
 	if (rv == 0) {
 		nni_sleep_aio(s->conf->qos_duration * 1500, &p->aio_timer);
 	}

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -390,10 +390,15 @@ nano_ctx_send(void *arg, nni_aio *aio)
 		if (s->conf->ext_qos_db) {
 			qos_db = nng_id_get(s->conf->ext_qos_db, pipe);
 		}
+#ifdef NNG_SUPP_SQLITE
+		if (is_sqlite && s->sqlite_db != NULL) {
+			qos_db = s->sqlite_db;
+		}
+#endif
 		if (qos_db != NULL) {
 			if (nni_msg_get_type(msg) == CMD_PUBLISH &&
 			    nni_msg_get_pub_qos(msg) > 0) {
-				nni_msg_clone(msg); // for line 422
+				nni_msg_clone(msg);
 				nni_qos_db_set(is_sqlite, qos_db,
 				    pipe, tmp_id, msg);
 				tmp_id ++;
@@ -1375,8 +1380,9 @@ nano_sock_setdb(void *arg, void *data)
 #ifdef NNG_SUPP_SQLITE
 			nni_qos_db_set_pipe(s->conf->sqlite.enable,
 				s->sqlite_db, hashn, node->clientid);
-#endif
+			nng_id_set(nano_conf->ext_qos_db, hashn, s->sqlite_db);
 			log_warn("Not recommend to use Preset session with SQLite ");
+#endif
 		}
 	}
 

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -710,6 +710,7 @@ auth_verify:
 	if (rv != 0) {
 		// send connack with reason code 0x05
 		log_warn("Invalid auth info or authentication denied");
+		conn_param_set_will_flag(p->conn_param, 0);
 		goto out;
 	}
 

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -715,11 +715,10 @@ auth_verify:
 	if (rv != 0) {
 		// send connack with reason code 0x05
 		log_warn("Invalid auth info or authentication denied");
-		conn_param_set_will_flag(p->conn_param, 0);
+		p->conn_param->will_flag = 0;
 		goto out;
 	}
 
-session_keeping:
 	// Clientid should not be NULL since broker will assign one
 	// TODO use p_id
 	clientid = (char *) conn_param_get_clientid(p->conn_param);

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -650,29 +650,6 @@ nano_pipe_start(void *arg)
 	nng_pipe     nng_pipe;
 	nng_pipe.id = npipe->p_id;
 
-	rv = nng_pipe_get_addr(nng_pipe, NNG_OPT_REMADDR, &addr);
-	// TODO: addr.s_in.sa_port
-	if (addr.s_family == NNG_AF_INET) {
-		arr = (uint8_t *) &addr.s_in.sa_addr;
-		if (arr == NULL) {
-			log_warn("Fail to get IP addr from client pipe!");
-			goto session_keeping;
-		}
-		sprintf(p->conn_param->ip_addr_v4, "%d.%d.%d.%d", arr[0],
-		    arr[1], arr[2], arr[3]);
-		// Get local listening port (server side) for HTTP auth %p
-		snprintf(p->conn_param->server_port,
-		    sizeof(p->conn_param->server_port), "%u",
-		    nano_pipe_get_local_port(nng_pipe));
-
-	} else if (addr.s_family == NNG_AF_INET6) {
-		arr = (uint8_t *) &addr.s_in6.sa_addr;
-		log_warn("IPv6 address is not supported in event msg & ACL yet");
-		snprintf(p->conn_param->server_port,
-		    sizeof(p->conn_param->server_port), "%u",
-		    nano_pipe_get_local_port6(nng_pipe));
-	}
-
 	// Get TLS client certificate common name for HTTP auth %C
 	char *peer_cn = NULL;
 	if (nng_pipe_get_string(
@@ -694,9 +671,47 @@ nano_pipe_start(void *arg)
 		}
 		p->conn_param->tls_subject = peer_subject;
 	}
+	rv = nng_pipe_get_addr(nng_pipe, NNG_OPT_REMADDR, &addr);
 
+	if (addr.s_family == NNG_AF_INET) {
+		arr = (uint8_t *) &addr.s_in.sa_addr;
+		if (arr == NULL) {
+			log_warn("Fail to get IP addr from client pipe!");
+			goto auth_verify;
+		}
+		sprintf(p->conn_param->ip_addr_v4, "%d.%d.%d.%d", arr[0],
+		    arr[1], arr[2], arr[3]);
+		// Get local listening port (server side) for HTTP auth %p
+		snprintf(p->conn_param->server_port,
+		    sizeof(p->conn_param->server_port), "%u",
+		    nano_pipe_get_local_port(nng_pipe));
+
+	} else if (addr.s_family == NNG_AF_INET6) {
+		arr = (uint8_t *) &addr.s_in6.sa_addr;
+		log_warn("IPv6 address is not supported in event msg & ACL yet");
+		snprintf(p->conn_param->server_port,
+		    sizeof(p->conn_param->server_port), "%u",
+		    nano_pipe_get_local_port6(nng_pipe));
+	}
 	log_debug("client connected! addr [%s port [%d]\n",
 	    p->conn_param->ip_addr_v4, addr.s_in.sa_port);
+auth_verify:
+	conn_param_clone(p->conn_param);
+	rv = verify_connect(p->conn_param, s->conf);
+	if (rv == SUCCESS) {
+		if (s->conf->auth_http.enable) {
+			log_debug("HTTP Authentication start!");
+			rv = nmq_auth_http_connect(		// potential dead lock if HTTP fails
+			    p->conn_param, &s->conf->auth_http);
+		}
+	}
+	nmq_connack_encode(msg, s->conf, p->conn_param, rv);
+	conn_param_free(p->conn_param);
+	if (rv != 0) {
+		// send connack with reason code 0x05
+		log_warn("Invalid auth info or authentication denied");
+		goto out;
+	}
 
 session_keeping:
 	// Clientid should not be NULL since broker will assign one
@@ -756,22 +771,6 @@ session_keeping:
 	p->conn_param->nano_qos_db = p->pipe->nano_qos_db;
 	p->nano_qos_db             = p->pipe->nano_qos_db;
 
-	conn_param_clone(p->conn_param);
-	rv = verify_connect(p->conn_param, s->conf);
-	if (rv == SUCCESS) {
-		if (s->conf->auth_http.enable) {
-			log_debug("HTTP Authentication start!");
-			rv = nmq_auth_http_connect(		// potential dead lock if HTTP fails
-			    p->conn_param, &s->conf->auth_http);
-		}
-	}
-	nmq_connack_encode(msg, s->conf, p->conn_param, rv);
-	conn_param_free(p->conn_param);
-	if (rv != 0) {
-		// send connack with reason code 0x05
-		log_warn("Invalid auth info.");
-	}
-
 	// Recover preset sessions
 	void *qos_db = NULL;
 	if (s->conf->ext_qos_db)
@@ -802,7 +801,7 @@ session_keeping:
 	} else {
 		nni_mtx_unlock(&s->lk);
 	}
-	// TODO MQTT V5 check return code
+out:
 	if (rv == 0) {
 		nni_sleep_aio(s->conf->qos_duration * 1500, &p->aio_timer);
 	}

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -642,7 +642,6 @@ nano_pipe_start(void *arg)
 
 	nni_msg_alloc(&msg, 0);
 	conn_param_clone(p->conn_param);
-	nni_mtx_lock(&s->lk);
 
 #ifdef NNG_SUPP_SQLITE
 	if (is_sqlite) {
@@ -716,9 +715,10 @@ auth_verify:
 		// send connack with reason code 0x05
 		log_warn("Invalid auth info or authentication denied");
 		p->conn_param->will_flag = 0;
-		goto out;
+		goto end;
 	}
 
+	nni_mtx_lock(&s->lk);
 	// Clientid should not be NULL since broker will assign one
 	// TODO use p_id
 	clientid = (char *) conn_param_get_clientid(p->conn_param);
@@ -791,7 +791,7 @@ auth_verify:
 		p->pipe->nano_qos_db = qos_db;
 		nng_id_remove(s->conf->ext_qos_db, p->pipe->p_id);
 	}
-out:
+
 	// close old one (bool to prevent disconnect_ev)
 	// check if pointer is different later
 	if (old) {
@@ -807,7 +807,7 @@ out:
 	} else {
 		nni_mtx_unlock(&s->lk);
 	}
-
+end:
 	if (rv == 0) {
 		nni_sleep_aio(s->conf->qos_duration * 1500, &p->aio_timer);
 	}

--- a/src/supplemental/mqtt/mqtt_qos_db.c
+++ b/src/supplemental/mqtt/mqtt_qos_db.c
@@ -824,25 +824,33 @@ nni_mqtt_qos_db_find_retain(sqlite3 *db, const char *topic_pattern)
 		}
 	}
 
-	char sql[] = "SELECT msg, proto_ver FROM " table_retain " WHERE topic GLOB ";
-
-	size_t full_sql_sz = strlen(sql) + strlen(topic_str) + 10;
-	char * full_sql    = nni_zalloc(full_sql_sz);
-	snprintf(full_sql, full_sql_sz, "%s '%s'", sql, topic_str);
+	char sql[] = "SELECT msg, proto_ver FROM " table_retain " WHERE topic GLOB ?";
 
 	sqlite3_stmt *stmt;
 
 	sqlite3_exec(db, "BEGIN;", 0, 0, 0);
-	sqlite3_prepare_v2(db, full_sql,
-	    strlen(full_sql), &stmt, 0);
-	sqlite3_reset(stmt);
+
+	int rc = sqlite3_prepare_v2(db, sql, strlen(sql), &stmt, 0);
+	if (rc != SQLITE_OK) {
+		sqlite3_exec(db, "ROLLBACK;", 0, 0, 0);
+		nng_strfree(topic_str);
+		return NULL;
+	}
+
+	sqlite3_bind_text(stmt, 1, topic_str, strlen(topic_str), SQLITE_TRANSIENT);
 
 	while (SQLITE_ROW == sqlite3_step(stmt)) {
 		size_t   nbyte = (size_t) sqlite3_column_bytes16(stmt, 0);
 		uint8_t *bytes = sqlite3_malloc(nbyte);
 		memcpy(bytes, sqlite3_column_blob(stmt, 0), nbyte);
+		
 		msg = nni_msg_deserialize(bytes, nbyte);
 		sqlite3_free(bytes);
+
+		if (msg == NULL) {
+			continue;
+		}
+
 		uint8_t proto_ver = sqlite3_column_int(stmt, 1);
 		nni_mqtt_msg_proto_data_alloc(msg);
 		if(proto_ver == MQTT_PROTOCOL_VERSION_v5) {
@@ -856,8 +864,8 @@ nni_mqtt_qos_db_find_retain(sqlite3 *db, const char *topic_pattern)
 
 	sqlite3_finalize(stmt);
 	sqlite3_exec(db, "COMMIT;", 0, 0, 0);
+	
 	nng_strfree(topic_str);
-	nng_free(full_sql, full_sql_sz);
 
 	return msg_vec;
 }

--- a/src/supplemental/mqtt/mqtt_qos_db.c
+++ b/src/supplemental/mqtt/mqtt_qos_db.c
@@ -839,6 +839,7 @@ nni_mqtt_qos_db_find_retain(sqlite3 *db, const char *topic_pattern)
 
 	rc = sqlite3_bind_text(stmt, 1, topic_str, strlen(topic_str), SQLITE_TRANSIENT);
 	if (rc != SQLITE_OK) {
+		sqlite3_exec(db, "ROLLBACK;", 0, 0, 0);
 		sqlite3_finalize(stmt);
 		nng_strfree(topic_str);
 		return NULL;

--- a/src/supplemental/mqtt/mqtt_qos_db.c
+++ b/src/supplemental/mqtt/mqtt_qos_db.c
@@ -837,13 +837,23 @@ nni_mqtt_qos_db_find_retain(sqlite3 *db, const char *topic_pattern)
 		return NULL;
 	}
 
-	sqlite3_bind_text(stmt, 1, topic_str, strlen(topic_str), SQLITE_TRANSIENT);
-
+	rc = sqlite3_bind_text(stmt, 1, topic_str, strlen(topic_str), SQLITE_TRANSIENT);
+	if (rc != SQLITE_OK) {
+		sqlite3_finalize(stmt);
+		nng_strfree(topic_str);
+		return NULL;
+	}
 	while (SQLITE_ROW == sqlite3_step(stmt)) {
-		size_t   nbyte = (size_t) sqlite3_column_bytes16(stmt, 0);
+		size_t      nbyte = (size_t) sqlite3_column_bytes16(stmt, 0);
+		const void *blob  = sqlite3_column_blob(stmt, 0);
+		if (nbyte > 0 && blob == NULL) {
+			continue;
+		}
 		uint8_t *bytes = sqlite3_malloc(nbyte);
-		memcpy(bytes, sqlite3_column_blob(stmt, 0), nbyte);
-		
+		if (bytes == NULL) {
+			continue;
+		}
+		memcpy(bytes, blob, nbyte);
 		msg = nni_msg_deserialize(bytes, nbyte);
 		sqlite3_free(bytes);
 

--- a/src/supplemental/nanolib/conf.c
+++ b/src/supplemental/nanolib/conf.c
@@ -4571,22 +4571,16 @@ nmq_acl_cache_reset_cb(void *k, void *v, void *arg)
 static void
 conf_auth_http_acl_cache_destroy(conf_auth_http *conf)
 {
-	if (conf->acl_cache_reset_aio) {
-		nng_aio_stop(conf->acl_cache_reset_aio);
-	}
-	if (conf->acl_cache_mtx && conf->acl_cache_map) {
-		nng_mtx_lock(conf->acl_cache_mtx);
-		if (nng_id_count(conf->acl_cache_map) > 0) {
-			nng_id_map_foreach2(conf->acl_cache_map, nmq_acl_cache_reset_cb, conf);
-		}
-		nng_mtx_unlock(conf->acl_cache_mtx);
+	nng_aio_stop(conf->acl_cache_reset_aio);
+	
+	nng_mtx_lock(conf->acl_cache_mtx);
+	if (conf->acl_cache_map) {
 		nng_id_map_free(conf->acl_cache_map);
 		conf->acl_cache_map = NULL;
 	}
-	if (conf->acl_cache_reset_aio) {
-		nng_aio_free(conf->acl_cache_reset_aio);
-		conf->acl_cache_reset_aio = NULL;
-	}
+	nng_mtx_unlock(conf->acl_cache_mtx);
+
+	nng_aio_free(conf->acl_cache_reset_aio);
 }
 
 void

--- a/src/supplemental/nanolib/conf.c
+++ b/src/supplemental/nanolib/conf.c
@@ -4571,15 +4571,22 @@ nmq_acl_cache_reset_cb(void *k, void *v, void *arg)
 static void
 conf_auth_http_acl_cache_destroy(conf_auth_http *conf)
 {
-	nng_aio_stop(conf->acl_cache_reset_aio);
-	nng_mtx_lock(conf->acl_cache_mtx);
-	if (nng_id_count(conf->acl_cache_map) > 0) {
-		nng_id_map_foreach2(conf->acl_cache_map, nmq_acl_cache_reset_cb, conf);
+	if (conf->acl_cache_reset_aio) {
+		nng_aio_stop(conf->acl_cache_reset_aio);
 	}
-	nng_mtx_unlock(conf->acl_cache_mtx);
-	nng_id_map_free(conf->acl_cache_map);
-
-	nng_aio_free(conf->acl_cache_reset_aio);
+	if (conf->acl_cache_mtx && conf->acl_cache_map) {
+		nng_mtx_lock(conf->acl_cache_mtx);
+		if (nng_id_count(conf->acl_cache_map) > 0) {
+			nng_id_map_foreach2(conf->acl_cache_map, nmq_acl_cache_reset_cb, conf);
+		}
+		nng_mtx_unlock(conf->acl_cache_mtx);
+		nng_id_map_free(conf->acl_cache_map);
+		conf->acl_cache_map = NULL;
+	}
+	if (conf->acl_cache_reset_aio) {
+		nng_aio_free(conf->acl_cache_reset_aio);
+		conf->acl_cache_reset_aio = NULL;
+	}
 }
 
 void

--- a/src/supplemental/nanolib/conf.c
+++ b/src/supplemental/nanolib/conf.c
@@ -4561,6 +4561,28 @@ conf_parquet_destroy(conf_parquet *parquet)
 #endif
 
 void
+nmq_acl_cache_reset_cb(void *k, void *v, void *arg)
+{
+	conf_auth_http *conf = arg;
+	uint64_t key = *(uint64_t *)k;
+	nng_id_remove(conf->acl_cache_map, key);
+}
+
+static void
+conf_auth_http_acl_cache_destroy(conf_auth_http *conf)
+{
+	nng_aio_stop(conf->acl_cache_reset_aio);
+	nng_mtx_lock(conf->acl_cache_mtx);
+	if (nng_id_count(conf->acl_cache_map) > 0) {
+		nng_id_map_foreach2(conf->acl_cache_map, nmq_acl_cache_reset_cb, conf);
+	}
+	nng_mtx_unlock(conf->acl_cache_mtx);
+	nng_id_map_free(conf->acl_cache_map);
+
+	nng_aio_free(conf->acl_cache_reset_aio);
+}
+
+void
 conf_fini(conf *nanomq_conf)
 {
 	if (nanomq_conf == NULL) {
@@ -4589,6 +4611,7 @@ conf_fini(conf *nanomq_conf)
 	conf_bridge_destroy(&nanomq_conf->bridge);
 	conf_bridge_destroy(&nanomq_conf->aws_bridge);
 	conf_web_hook_destroy(&nanomq_conf->web_hook);
+	conf_auth_http_acl_cache_destroy(&nanomq_conf->auth_http);
 	conf_auth_http_destroy(&nanomq_conf->auth_http);
 	conf_auth_destroy(&nanomq_conf->auths);
 	conf_exchange_destroy(&nanomq_conf->exchange);
@@ -4606,7 +4629,6 @@ conf_fini(conf *nanomq_conf)
 #if defined(SUPP_PARQUET)
 	conf_parquet_destroy(&nanomq_conf->parquet);
 #endif
-
 	nng_atomic_free(nanomq_conf->lc);
 	free(nanomq_conf);
 }

--- a/src/supplemental/nanolib/env_test.c
+++ b/src/supplemental/nanolib/env_test.c
@@ -7,7 +7,7 @@ test_env(void)
 {
 	conf *conf_test = NULL;
 	NUTS_TRUE((conf_test = nng_zalloc(sizeof(conf))) != NULL);
-
+	conf_init(conf_test);
 	read_env_conf(conf_test);
 	conf_fini(conf_test);
 }

--- a/tests/wss.c
+++ b/tests/wss.c
@@ -238,7 +238,7 @@ TestMain("WebSocket Secure (TLS) Transport", {
 	if (strcmp(nng_tls_engine_name(), "none") == 0) {
 		Skip("TLS not enabled");
 	}
-
+	nng_wss_register();
 	tt.dialer_init   = init_dialer_wss;
 	tt.listener_init = init_listener_wss;
 	tt.tmpl          = "wss://localhost:";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Percent-encode HTTP authentication form values and generate request parameters more robustly when optional fields are missing.
  * Improve MQTT topic parsing by rejecting invalid/empty entries, adding size-safety, and handling authentication denials consistently.
  * Ensure preset-session QoS paths use the SQLite-backed database when SQLite is enabled.
  * Harden SQLite retain-topic lookups with safer querying and more defensive message decoding.
  * Add proper ACL HTTP cache cleanup during shutdown.
* **Tests**
  * Register WebSocket Secure (TLS) transport before running the TLS-based test block.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->