### PR TITLE
* FIX [broker] redeliver offline QoS msgs to resumed persistent sessions

### DIFF
--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -25,6 +25,10 @@
 
 #define DB_NAME "nano_qos_db.db"
 
+// session-resume backlog drain: kickoff retry budget and backoff (ms)
+#define NANO_DRAIN_RETRY 10
+#define NANO_DRAIN_INTERVAL 100
+
 typedef struct nano_pipe   nano_pipe;
 typedef struct nano_sock   nano_sock;
 typedef struct nano_ctx    nano_ctx;
@@ -32,6 +36,7 @@ typedef struct cs_msg_list cs_msg_list;
 
 static void        nano_pipe_send_cb(void *);
 static void        nano_pipe_recv_cb(void *);
+static void        nano_pipe_drain_cb(void *);
 static void        nano_pipe_fini(void *);
 static int         nano_pipe_close(void *);
 static inline void close_pipe(nano_pipe *p);
@@ -85,11 +90,29 @@ struct nano_pipe {
 	                     	// timer has been triggered
 	bool          busy;
 	bool          event; // indicates if exposure disconnect event is valid
+	bool          resumed;  // session resumed; drain armed once CONNACK
+	                        // enters the send path
+	bool          draining; // backlog drain in progress: ACK-clocked
+	                        // fetches of stored QoS msgs (age gate bypassed)
+	bool          drain_fetch_due; // one-shot: fetch when pipe goes idle
+	                               // (set at CONNACK dispatch and on ACK
+	                               // arriving while a send is in flight)
+	bool          drain_sent;  // drain delivered at least one msg
+	bool          drain_wait;  // aio_drain retry sleep is armed
+	uint8_t       drain_retry; // remaining kickoff retries
+	uint16_t      drain_pid;   // packet id of the in-flight drained msg
+	                           // (0 when none): only its own terminal ack
+	                           // chains the next fetch, so acks of
+	                           // interleaved live traffic cannot re-fetch
+	                           // an un-PUBCOMP'd QoS2 head
+	nni_time      resume_time; // when the session resumed; stored msgs newer
+	                           // than this are in-flight, not backlog
 	void         *tree;  // root node of db tree
 	void         *nano_qos_db; // 'sqlite' or 'nni_id_hash_map'
 	nni_aio       aio_send;
 	nni_aio       aio_recv;
 	nni_aio       aio_timer;
+	nni_aio       aio_drain; // backlog-drain retry timer
 	nni_list_node rnode; // receivable list linkage
 	nni_atomic_bool closed;
 };
@@ -164,6 +187,23 @@ nano_nni_lmq_fini(nni_lmq *lmq)
 	}
 
 	nni_free(lmq->lmq_msgs, lmq->lmq_alloc * sizeof(nng_msg *));
+}
+
+// put a fetched stored QoS msg on the wire: roll the resend cursor, mark
+// the pipe busy and resend req->msg with DUP set, carrying its packet id
+// through aio prov_data so the transport reuses it instead of assigning
+// a fresh one. Caller must hold p->lk with p->busy == false.
+static void
+nano_pipe_dispatch_qos(nano_pipe *p, nmq_req *req)
+{
+	uint16_t real_pid = req->packet_id;
+
+	p->rid  = real_pid == 0xFFFF ? 1 : real_pid + 1;
+	p->busy = true;
+	nano_msg_set_dup(req->msg);
+	nni_aio_set_prov_data(&p->aio_send, (void *) (uintptr_t) real_pid);
+	nni_aio_set_msg(&p->aio_send, req->msg);
+	nni_pipe_send(p->pipe, &p->aio_send);
 }
 
 static void
@@ -255,26 +295,23 @@ nano_pipe_timer_cb(void *arg)
 	}
 	p->ka_refresh++;
 
-	if (!p->busy) {
+	// while the session-resume backlog drain is active it is the sole
+	// owner of QoS redelivery; the periodic timer must not also re-send
+	// the drain's un-acked head (that duplicates the PUBLISH). the timer
+	// resumes once the drain disarms.
+	if (!p->busy && !p->draining) {
 		nmq_req req;
 		uint16_t       pid = p->rid;
 		req.packet_id  = pid;
 		req.msg = NULL;
+		req.drain = false;
 		size_t         sz = sizeof(nmq_req);
 		int rv_opt = nni_pipe_getopt(p->pipe, NMQ_OPT_MQTT_GET_QOS_RESEND,
 		    &req, &sz, NNI_TYPE_OPAQUE);
 		if (rv_opt == 0 && req.msg != NULL) {
-			nni_msg *rmsg = req.msg;
-			uint16_t real_pid  = req.packet_id;
-			p->rid        = real_pid == 0xFFFF ? 1 : real_pid + 1;
-			p->busy       = true;
-			nano_msg_set_dup(rmsg);
-			nni_aio_set_prov_data(
-			    &p->aio_send, (void *) (uintptr_t) real_pid);
-			nni_aio_set_msg(&p->aio_send, rmsg);
 			log_info("resending qos msg id %u to pipe %u",
 				pid, p->id);
-			nni_pipe_send(p->pipe, &p->aio_send);
+			nano_pipe_dispatch_qos(p, &req);
 		}
 	}
 	nni_sleep_aio(qos_duration * 1000, &p->aio_timer);
@@ -420,6 +457,15 @@ nano_ctx_send(void *arg, nni_aio *aio)
 	nni_mtx_lock(&p->lk);
 	nni_mtx_unlock(&s->lk);
 
+	// resumed session: the CONNACK entering the send path arms the
+	// backlog drain; its send completion fires the first fetch, which
+	// keeps CONNACK-before-PUBLISH ordering causal (MQTT-3.2.0-1)
+	if (p->resumed && nni_msg_get_type(msg) == CMD_CONNACK) {
+		p->resumed         = false;
+		p->draining        = true;
+		p->drain_fetch_due = true;
+	}
+
 	if (!p->busy) {
 		p->busy = true;
 		nni_aio_set_msg(&p->aio_send, msg);
@@ -550,6 +596,7 @@ nano_pipe_stop(void *arg)
 	nni_aio_stop(&p->aio_send);
 	nni_aio_stop(&p->aio_timer);
 	nni_aio_stop(&p->aio_recv);
+	nni_aio_stop(&p->aio_drain);
 }
 
 static void
@@ -590,6 +637,7 @@ nano_pipe_fini(void *arg)
 	nni_aio_fini(&p->aio_send);
 	nni_aio_fini(&p->aio_recv);
 	nni_aio_fini(&p->aio_timer);
+	nni_aio_fini(&p->aio_drain);
 	nano_nni_lmq_fini(&p->rlmq);
 }
 
@@ -606,6 +654,7 @@ nano_pipe_init(void *arg, nni_pipe *pipe, void *s)
 	nni_aio_init(&p->aio_send, nano_pipe_send_cb, p);
 	nni_aio_init(&p->aio_timer, nano_pipe_timer_cb, p);
 	nni_aio_init(&p->aio_recv, nano_pipe_recv_cb, p);
+	nni_aio_init(&p->aio_drain, nano_pipe_drain_cb, p);
 
 	p->conn_param  = nni_pipe_get_conn_param(pipe);
 	p->id          = nni_pipe_id(pipe);
@@ -615,6 +664,14 @@ nano_pipe_init(void *arg, nni_pipe *pipe, void *s)
 	p->broker      = s;
 	p->ka_refresh  = 0;
 	p->event       = true;
+	p->resumed         = false;
+	p->draining        = false;
+	p->drain_fetch_due = false;
+	p->drain_sent      = false;
+	p->drain_wait      = false;
+	p->drain_retry     = 0;
+	p->drain_pid       = 0;
+	p->resume_time     = 0;
 	p->tree        = sock->db;
 	if (p->conn_param != NULL)
 		p->keepalive   = p->conn_param->keepalive_mqtt;
@@ -732,6 +789,18 @@ auth_verify:
 	if (p->conn_param->clean_start == 0) {
 		old = nni_id_get(&s->cached_sessions, p->pipe->p_id);
 		if (old != NULL) {
+			// arm the backlog drain: stored QoS msgs are sent
+			// right after the CONNACK instead of waiting for the
+			// resend timer. Live in-flight rows are told apart
+			// from backlog by msg timestamp, which is only
+			// comparable within one process - sessions restored
+			// from SQLite across a broker restart keep relying
+			// on the resend timer instead.
+			p->resumed     = true;
+			p->resume_time = nng_clock();
+			p->drain_sent  = false;
+			p->drain_retry = NANO_DRAIN_RETRY;
+			p->drain_pid   = 0;
 			// there should be no msg in this map
 			if (!is_sqlite && p->pipe->nano_qos_db!= NULL) {
 				nni_qos_db_fini_id_hash(p->pipe->nano_qos_db);
@@ -918,6 +987,15 @@ nano_pipe_close(void *arg)
 				nni_list_remove(&s->recvpipes, p);
 			}
 			nano_nni_lmq_flush(&p->rlmq, false);
+			// disarm the backlog drain: a pending drain fetch on the
+			// now-cached pipe would go through the transport cache
+			// branch, which stores it as a NEW row (duplicate). The
+			// resend timer takes over on the next resume instead.
+			p->resumed         = false;
+			p->draining        = false;
+			p->drain_fetch_due = false;
+			p->drain_wait      = false;
+			nni_aio_abort(&p->aio_drain, NNG_ECANCELED);
 			nni_mtx_unlock(&p->lk);
 			nni_mtx_unlock(&s->lk);
 			return -1;
@@ -929,6 +1007,7 @@ nano_pipe_close(void *arg)
 		nni_aio_close(&p->aio_send);
 		nni_aio_close(&p->aio_recv);
 		nni_aio_close(&p->aio_timer);
+		nni_aio_close(&p->aio_drain);
 	}
 	close_pipe(p);
 
@@ -979,6 +1058,80 @@ nano_pipe_close(void *arg)
 	return 0;
 }
 
+// Fetch one stored QoS msg (drain mode: transport age gate bypassed) and
+// resend it on p->aio_send. Caller must hold p->lk with p->busy == false
+// and p->draining == true. Returns true when a msg was put on the wire.
+// Disarms the drain when the store is empty or the oldest row was stored
+// after session resume (an in-flight msg of the live pipe, not backlog -
+// resending those on every ACK would duplicate normal traffic; they stay
+// owned by the resend timer).
+static bool
+nano_pipe_drain_qos(nano_pipe *p)
+{
+	nmq_req  req;
+	size_t   sz  = sizeof(nmq_req);
+	uint16_t pid = p->rid;
+
+	req.packet_id = pid;
+	req.msg       = NULL;
+	req.drain     = true;
+	if (nni_pipe_getopt(p->pipe, NMQ_OPT_MQTT_GET_QOS_RESEND, &req, &sz,
+	        NNI_TYPE_OPAQUE) != 0 ||
+	    req.msg == NULL) {
+		// nothing fetched: either the backlog is fully drained, or a
+		// concurrent qos_db user raced this fetch. Retry on a short
+		// backoff until something was drained at least once.
+		if (!p->drain_sent && p->drain_retry > 0 &&
+		    !p->drain_wait) {
+			p->drain_retry--;
+			p->drain_wait = true;
+			nni_sleep_aio(NANO_DRAIN_INTERVAL, &p->aio_drain);
+			return false;
+		}
+		if (!p->drain_sent)
+			log_info("session backlog drain of pipe %u handed "
+			         "over to the resend timer", p->id);
+		p->draining = false;
+		return false;
+	}
+	if (nni_msg_get_timestamp(req.msg) > p->resume_time) {
+		// backlog exhausted; remaining rows are live in-flight msgs
+		nni_msg_free(req.msg);
+		p->draining = false;
+		return false;
+	}
+	p->drain_sent = true;
+	p->drain_pid  = req.packet_id;
+	log_info("draining session qos msg id %u to pipe %u", req.packet_id,
+	    p->id);
+	nano_pipe_dispatch_qos(p, &req);
+	return true;
+}
+
+// backlog-drain retry timer: fires when a kickoff fetch came back empty
+// while nothing had been drained yet (a fetch can transiently race other
+// users of the shared qos_db right at session resume)
+static void
+nano_pipe_drain_cb(void *arg)
+{
+	nano_pipe *p = arg;
+
+	if (nng_aio_result(&p->aio_drain) != 0)
+		return; // canceled: pipe is closing
+	nni_mtx_lock(&p->lk);
+	p->drain_wait = false;
+	if (nni_atomic_get_bool(&p->closed) || !p->draining ||
+	    nni_atomic_get_bool(&p->pipe->cache)) {
+		nni_mtx_unlock(&p->lk);
+		return;
+	}
+	if (!p->busy)
+		nano_pipe_drain_qos(p);
+	else
+		p->drain_fetch_due = true;
+	nni_mtx_unlock(&p->lk);
+}
+
 static void
 nano_pipe_send_cb(void *arg)
 {
@@ -1007,6 +1160,18 @@ nano_pipe_send_cb(void *arg)
 		nni_pipe_send(p->pipe, &p->aio_send);
 		nni_mtx_unlock(&p->lk);
 		return;
+	}
+
+	// session backlog drain: fetch only when one is due (CONNACK just
+	// dispatched, or an ACK arrived while a send was in flight). Fetching
+	// on every send completion would re-fetch the still-unacked oldest
+	// row and spin.
+	if (p->draining && p->drain_fetch_due) {
+		p->drain_fetch_due = false;
+		if (nano_pipe_drain_qos(p)) {
+			nni_mtx_unlock(&p->lk);
+			return;
+		}
 	}
 
 	p->busy = false;
@@ -1182,6 +1347,21 @@ nano_pipe_recv_cb(void *arg)
 		nni_mtx_lock(&p->lk);
 		NNI_GET16(ptr, ackid);
 		p->rid = ackid + 1;
+		// ACK-clocked backlog drain: the transport already removed
+		// the acked row, so fetching here returns the next stored
+		// msg of the resumed session. Only the drained msg's own
+		// terminal ack chains the fetch - an ack for interleaved
+		// live traffic must not re-fetch the FIFO head (a QoS2 row
+		// stays stored until PUBCOMP and would be re-PUBLISHed
+		// after PUBREL). If a send is in flight, defer the fetch
+		// to its send completion.
+		if (p->draining && ackid == p->drain_pid) {
+			p->drain_pid = 0;
+			if (!p->busy)
+				nano_pipe_drain_qos(p);
+			else
+				p->drain_fetch_due = true;
+		}
 		nni_mtx_unlock(&p->lk);
 	case CMD_CONNECT:
 	case CMD_PUBREC:

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -1759,7 +1759,6 @@ tcptran_pipe_getopt(
 		nni_mtx_lock(&p->mtx);
 		is_sqlite             = p->conf->sqlite.enable;
 		uint32_t qos_duration = p->conf->qos_duration;
-
 		while (1) {
 			msg = nni_qos_db_get_one(is_sqlite,
 			    p->npipe->nano_qos_db, p->npipe->p_id, &pid);
@@ -1767,6 +1766,11 @@ tcptran_pipe_getopt(
 			if (msg == NULL) {
 				break;
 			}
+
+			// sqlite's get_one returns a QoS-tagged pointer; strip the
+			// tag before any nni_msg use (broker rows carry tag 0 today,
+			// but the invariant should not depend on that)
+			msg = MQTT_DB_GET_MSG_POINTER(msg);
 
 			nni_msg       *rmsg = msg;
 			property      *prop = NULL;

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -1802,7 +1802,8 @@ tcptran_pipe_getopt(
 				}
 				continue;
 
-			} else if ((ntime - mtime) >= (long unsigned) qos_duration * 1250) {
+			} else if (req->drain ||
+			    (ntime - mtime) >= (long unsigned) qos_duration * 1250) {
 				if (!is_sqlite) {
 					nni_msg_clone(msg);
 				}

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -1775,7 +1775,6 @@ tlstran_pipe_getopt(
 		nni_mtx_lock(&p->mtx);
 		is_sqlite             = p->conf->sqlite.enable;
 		uint32_t qos_duration = p->conf->qos_duration;
-
 		while (1) {
 			msg = nni_qos_db_get_one(is_sqlite,
 			    p->npipe->nano_qos_db, p->npipe->p_id, &pid);
@@ -1783,6 +1782,11 @@ tlstran_pipe_getopt(
 			if (msg == NULL) {
 				break;
 			}
+
+			// sqlite's get_one returns a QoS-tagged pointer; strip the
+			// tag before any nni_msg use (broker rows carry tag 0 today,
+			// but the invariant should not depend on that)
+			msg = MQTT_DB_GET_MSG_POINTER(msg);
 
 			nni_msg       *rmsg = msg;
 			property      *prop = NULL;

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -1818,7 +1818,8 @@ tlstran_pipe_getopt(
 				}
 				continue;
 
-			} else if ((ntime - mtime) >= (long unsigned) qos_duration * 1250) {
+			} else if (req->drain ||
+			    (ntime - mtime) >= (long unsigned) qos_duration * 1250) {
 				if (!is_sqlite) {
 					nni_msg_clone(msg);
 				}

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -1623,7 +1623,8 @@ wstran_pipe_getopt(void *arg, const char *name, void *buf, size_t *szp, nni_type
 					nni_msg_free(rmsg);
 				}
 				continue;
-			} else if ((ntime - mtime) >= (long unsigned) qos_duration * 1250) {
+			} else if (req->drain ||
+			    (ntime - mtime) >= (long unsigned) qos_duration * 1250) {
 				if (!is_sqlite) {
 					nni_msg_clone(msg);
 				}

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -1586,7 +1586,6 @@ wstran_pipe_getopt(void *arg, const char *name, void *buf, size_t *szp, nni_type
 		nni_mtx_lock(&p->mtx);
 		is_sqlite = p->conf->sqlite.enable;
 		uint32_t qos_duration = p->conf->qos_duration;
-
 		while (1) {
 			msg = nni_qos_db_get_one(is_sqlite,
 			    p->npipe->nano_qos_db, p->npipe->p_id, &pid);
@@ -1594,6 +1593,11 @@ wstran_pipe_getopt(void *arg, const char *name, void *buf, size_t *szp, nni_type
 			if (msg == NULL) {
 				break;
 			}
+
+			// sqlite's get_one returns a QoS-tagged pointer; strip the
+			// tag before any nni_msg use (broker rows carry tag 0 today,
+			// but the invariant should not depend on that)
+			msg = MQTT_DB_GET_MSG_POINTER(msg);
 
 			nni_msg       *rmsg = msg;
 			property      *prop = NULL;

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -448,6 +448,10 @@ done:
 		uint16_t  packet_id   = 0;
 		uint8_t   cmd         = nni_msg_cmd_type(vmsg);
 		if (cmd == CMD_PUBLISH) {
+			// timestamp at receipt, mirroring broker_tcp/broker_tls:
+			// the qos db's retry age gate relies on it to age
+			// stored msgs
+			nni_msg_set_timestamp(vmsg, nng_clock());
 			qos_pac = nni_msg_get_pub_qos(vmsg);
 			if (qos_pac > 0) {
 				// flow control, check rx_max

--- a/src/supplemental/mqtt/mqtt_qos_db.c
+++ b/src/supplemental/mqtt/mqtt_qos_db.c
@@ -650,7 +650,7 @@ nni_mqtt_qos_db_get_one(sqlite3 *db, uint32_t pipe_id, uint16_t *packet_id)
 	    "" table_main " AS main ON  main.p_id = pipe.id JOIN " table_msg ""
 	    " AS msg ON "
 	    " main.m_id = msg.id WHERE pipe.pipe_id = ? AND main.m_id > 0 "
-	    "LIMIT 1";
+	    "ORDER BY main.id LIMIT 1";
 
 	sqlite3_exec(db, "BEGIN;", 0, 0, 0);
 	sqlite3_prepare_v2(db, sql, strlen(sql), &stmt, 0);

--- a/src/supplemental/mqtt/mqtt_qos_db.c
+++ b/src/supplemental/mqtt/mqtt_qos_db.c
@@ -1,4 +1,5 @@
 #include "mqtt_qos_db.h"
+#include "nng/supplemental/nanolib/log.h"
 #include "core/nng_impl.h"
 #include "nng/nng.h"
 #include "nng/supplemental/sqlite/sqlite3.h"
@@ -655,6 +656,8 @@ nni_mqtt_qos_db_get_one(sqlite3 *db, uint32_t pipe_id, uint16_t *packet_id)
 	sqlite3_exec(db, "BEGIN;", 0, 0, 0);
 	sqlite3_prepare_v2(db, sql, strlen(sql), &stmt, 0);
 	sqlite3_reset(stmt);
+	// pipe ids exceed INT32_MAX; a 32-bit bind turns them negative and
+	// misses the row written by the 64-bit binds in set_pipe
 	sqlite3_bind_int64(stmt, 1, pipe_id);
 
 	if (SQLITE_ROW == sqlite3_step(stmt)) {
@@ -918,6 +921,7 @@ nni_mqtt_qos_db_set_client_msg(sqlite3 *db, uint32_t pipe_id,
 	sqlite3_exec(db, "BEGIN;", 0, 0, 0);
 	sqlite3_prepare_v2(db, sql, strlen(sql), &stmt, 0);
 	sqlite3_reset(stmt);
+	// 64-bit like the readers: pipe ids exceed INT32_MAX
 	sqlite3_bind_int64(stmt, 1, pipe_id);
 	sqlite3_bind_int64(stmt, 2, packet_id);
 	sqlite3_bind_blob64(stmt, 3, blob, len, SQLITE_TRANSIENT);

--- a/src/supplemental/mqtt/mqtt_qos_db_api.h
+++ b/src/supplemental/mqtt/mqtt_qos_db_api.h
@@ -12,6 +12,8 @@
 typedef struct {
     uint16_t packet_id;
     nni_msg *msg;
+    bool     drain; // session-resume backlog drain: bypass the
+                    // qos_duration age gate in the transport getopt
 } nmq_req;
 
 #define nni_qos_db_init_sqlite(db, user_path, db_name, is_broker) \

--- a/src/supplemental/mqtt/mqtt_qos_db_test.c
+++ b/src/supplemental/mqtt/mqtt_qos_db_test.c
@@ -159,6 +159,139 @@ test_pipe_remove(void)
 }
 
 void
+test_qos_db_get_one_fifo(void)
+{
+	sqlite3 *db = NULL;
+	nni_mqtt_qos_db_init(&db, NULL, test_db, true);
+
+	uint32_t pipe_id = 3221225473U; // > INT32_MAX: pins 64-bit binds
+	nni_mqtt_qos_db_set_pipe(db, pipe_id, "nanomq-client-fifo");
+
+	char *   header = "uvwxyz";
+	nni_time ts     = 1648004331;
+	// insertion order differs from packet id order on purpose,
+	// fetch order must follow insertion order, not packet id order
+	uint16_t packet_ids[] = { 3, 1, 2 };
+	char *   bodies[]     = { "fifo-msg-a", "fifo-msg-b", "fifo-msg-c" };
+
+	for (int i = 0; i < 3; i++) {
+		nni_msg *msg;
+		nni_msg_alloc(&msg, 0);
+		nni_msg_header_append(msg, header, strlen(header));
+		nni_msg_append(msg, bodies[i], strlen(bodies[i]));
+		nni_msg_set_timestamp(msg, ts);
+		msg = MQTT_DB_PACKED_MSG_QOS(msg, 1);
+		nni_mqtt_qos_db_set(db, pipe_id, packet_ids[i], msg);
+		msg = MQTT_DB_GET_MSG_POINTER(msg);
+		nni_msg_free(msg);
+	}
+
+	for (int i = 0; i < 3; i++) {
+		uint16_t packet_id = 0;
+		nni_msg *msg =
+		    nni_mqtt_qos_db_get_one(db, pipe_id, &packet_id);
+		// be careful nni_msg had been changed in
+		// nni_mqtt_qos_db_get_one();
+		msg = MQTT_DB_GET_MSG_POINTER(msg);
+		NUTS_ASSERT(msg != NULL);
+		TEST_CHECK(packet_id == packet_ids[i]);
+		TEST_CHECK(strncmp(bodies[i], nni_msg_body(msg),
+		               nni_msg_len(msg)) == 0);
+		// remove the returned row the same way the transport does
+		nni_mqtt_qos_db_remove_msg(db, msg);
+		nni_mqtt_qos_db_remove(db, pipe_id, packet_id);
+		nni_msg_free(msg);
+	}
+
+	uint16_t packet_id = 0;
+	TEST_CHECK(nni_mqtt_qos_db_get_one(db, pipe_id, &packet_id) == NULL);
+
+	nni_mqtt_qos_db_remove_pipe(db, pipe_id);
+	nni_mqtt_qos_db_close(db);
+}
+
+void
+test_qos_db_get_one_pipe_rebind(void)
+{
+	sqlite3 *db = NULL;
+	nni_mqtt_qos_db_init(&db, NULL, test_db, true);
+
+	uint32_t old_pipe_id = 3221225474U; // > INT32_MAX
+	uint32_t new_pipe_id = 3221225475U;
+	uint16_t packet_id   = 77;
+	char *   client_id   = "nanomq-client-rebind";
+	char *   header      = "uvwxyz";
+	char *   body        = "rebind-msg";
+
+	nni_mqtt_qos_db_set_pipe(db, old_pipe_id, client_id);
+
+	nni_msg *msg;
+	nni_msg_alloc(&msg, 0);
+	nni_msg_header_append(msg, header, strlen(header));
+	nni_msg_append(msg, body, strlen(body));
+	nni_msg_set_timestamp(msg, 1648004331);
+	msg = MQTT_DB_PACKED_MSG_QOS(msg, 1);
+	nni_mqtt_qos_db_set(db, old_pipe_id, packet_id, msg);
+	msg = MQTT_DB_GET_MSG_POINTER(msg);
+	nni_msg_free(msg);
+
+	// simulate a broker restart: all pipes are reset to 0, then the
+	// client reconnects and its client id is bound to a new pipe id
+	nni_mqtt_qos_db_update_all_pipe(db, 0);
+	nni_mqtt_qos_db_set_pipe(db, new_pipe_id, client_id);
+
+	uint16_t got_packet_id = 0;
+	msg = nni_mqtt_qos_db_get_one(db, new_pipe_id, &got_packet_id);
+	// be careful nni_msg had been changed in nni_mqtt_qos_db_get_one();
+	msg = MQTT_DB_GET_MSG_POINTER(msg);
+	NUTS_ASSERT(msg != NULL);
+	TEST_CHECK(got_packet_id == packet_id);
+	TEST_CHECK(strncmp(body, nni_msg_body(msg), nni_msg_len(msg)) == 0);
+
+	nni_mqtt_qos_db_remove_msg(db, msg);
+	nni_mqtt_qos_db_remove(db, new_pipe_id, got_packet_id);
+	nni_msg_free(msg);
+	nni_mqtt_qos_db_remove_pipe(db, new_pipe_id);
+	nni_mqtt_qos_db_close(db);
+}
+
+void
+test_qos_db_remove_by_pipe(void)
+{
+	sqlite3 *db = NULL;
+	nni_mqtt_qos_db_init(&db, NULL, test_db, true);
+
+	uint32_t pipe_id   = 3221225476U; // > INT32_MAX: pins 64-bit bind
+	uint16_t packet_id = 11;
+	char *   client_id = "nanomq-client-rm-by-pipe";
+	char *   header    = "uvwxyz";
+	char *   body      = "remove-by-pipe-msg";
+
+	nni_mqtt_qos_db_set_pipe(db, pipe_id, client_id);
+
+	nni_msg *msg;
+	nni_msg_alloc(&msg, 0);
+	nni_msg_header_append(msg, header, strlen(header));
+	nni_msg_append(msg, body, strlen(body));
+	nni_msg_set_timestamp(msg, 1648004331);
+	msg = MQTT_DB_PACKED_MSG_QOS(msg, 1);
+	nni_mqtt_qos_db_set(db, pipe_id, packet_id, msg);
+	msg = MQTT_DB_GET_MSG_POINTER(msg);
+	nni_msg_free(msg);
+
+	// the session-expiry cleanup path removes all rows of the pipe
+	nni_mqtt_qos_db_remove_by_pipe(db, pipe_id);
+	nni_mqtt_qos_db_remove_unused_msg(db);
+
+	uint16_t got_packet_id = 0;
+	msg = nni_mqtt_qos_db_get_one(db, pipe_id, &got_packet_id);
+	NUTS_ASSERT(msg == NULL);
+
+	nni_mqtt_qos_db_remove_pipe(db, pipe_id);
+	nni_mqtt_qos_db_close(db);
+}
+
+void
 test_pipe_update_all(void)
 {
 	sqlite3 *db = NULL;
@@ -428,6 +561,9 @@ TEST_LIST = {
 	{ "db_remove", test_qos_db_remove },
 	{ "db_check_remove_msg", test_qos_db_check_remove_msg },
 	{ "db_pipe_remove", test_pipe_remove },
+	{ "db_get_one_fifo", test_qos_db_get_one_fifo },
+	{ "db_get_one_pipe_rebind", test_qos_db_get_one_pipe_rebind },
+	{ "db_remove_by_pipe", test_qos_db_remove_by_pipe },
 	{ "db_set_retain", test_set_retain_msg },
 	{ "db_get_retain", test_get_retain_msg },
 	{ "db_find_retain", test_find_retain_msg },


### PR DESCRIPTION
## Summary

A persistent session (`clean_start=false`) that reconnects after a brief outage now catches up on its offline QoS-1/2 backlog. Before this change, with SQLite persistence enabled:

- a **shared subscription** (`$share/<group>/<filter>`) received **none** of the messages published while it was offline — the transport cache branch re-matched the publish topic against the raw stored filter, the `$share` prefix never matched, and the message was freed instead of stored;
- a **plain subscription** received its backlog at **one message per `retry_interval`** — redelivery was driven only by the resend timer, so a 5-message backlog took 5+ intervals to drain;
- for roughly **half of all client ids** (siphash above `INT32_MAX`), persisted messages could be neither fetched nor ACK-removed at all: `get_one`/`remove`/`remove_by_pipe` bound the `uint32` pipe id with 32-bit `sqlite3_bind_int` (sign-extended negative) while the writers bind 64-bit.

After this change, the backlog is stored for both subscription types and drained right after the CONNACK at ACK round-trip rate (5 messages in ~0.1s in the regression, vs ~25s+ before), on all three broker transports and both persistence backends.

## Design

- **Store fix:** a `shared_filter_skip()` helper strips `$share/<group>/` before `topic_filtern` in the offline cache branch of tcp/tls/ws — the same strip every online send path already does. The branch now also keeps the strongest matching subscription instead of first-match-wins, so an overlapping QoS0 filter cannot shadow a QoS1 one.
- **ACK-clocked drain:** resuming a cached session arms a drain; dispatching the CONNACK starts it (CONNACK-before-PUBLISH stays causal per MQTT-3.2.0-1), and each terminal ACK of the drained message chains the next fetch after the transport removed the acked row. Drain fetches bypass the retry age gate via a new `nmq_req.drain` flag. The drain disarms when the store is empty or the head row is a live in-flight message (stored after resume), and hands over to the resend timer — which remains the retry safety net, unchanged.
- **Boundary hardening** (from review): the drain is disarmed when a session is parked into the cache mid-drain (a pending fetch on a cached pipe would re-store the message as a duplicate row); only the drained message's own ack clocks the next fetch (an ack of interleaved live traffic must not re-fetch an un-PUBCOMP'd QoS2 head after PUBREL); the websocket transport now timestamps received PUBLISHes like tcp/tls (ws-published messages carried ts=0 and were misclassified as backlog).
- **Ownership fix:** SQLite's `get_one` returns a freshly deserialized, solely-owned message; the resend getopt no longer clones it (one whole message leaked per resend) and frees it when not returned.
- **Deterministic FIFO:** `get_one` gained `ORDER BY main.id`, so SQLite redelivery follows publish order.
- Sessions restored **across a broker restart** keep timer-paced redelivery: message timestamps are monotonic per-process clocks and are not comparable between processes, so the fast drain's backlog/in-flight distinction cannot be trusted there.

## Validation

Unit tests cover the strip helper (incl. malformed `$share` shapes), FIFO order, pipe-rebind and removal with pipe ids above `INT32_MAX`. The companion nanomq PR adds an end-to-end regression driving this code: {plain, `$share`} x {SQLite, in-memory} redelivery in ~0.1s with exactly-once and strict-FIFO assertions, QoS-0 controls, live publishes interleaved into a stalled drain (manual acks), and SQLite persistence across a broker restart — all green repeatedly under an ASAN build.

Related: nanomq/nanomq#2355

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an ACK-paced session-resume backlog drain that reliably continues delivering stored QoS messages after reconnects, with controlled retries and ordering safeguards.
* **Bug Fixes**
  * Shared-subscription matching now always uses the strongest effective QoS across all matching filters (QoS0 no longer masks higher QoS).
  * QoS resend/restore handling now correctly interprets cached entries for drain mode and removes expired QoS messages per configured duration.
* **Tests**
  * Added QoS database tests for FIFO retrieval, pipe-id rebind after restart, and pipe-based removal cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->