### PR TITLE
Fix SQLite compatiblity with qos msg cache

### DIFF
--- a/src/core/message.c
+++ b/src/core/message.c
@@ -793,16 +793,23 @@ uint16_t
 nni_msg_get_pub_pid(nni_msg *m)
 {
 	uint16_t pid;
-	uint8_t *pos, len;
+	uint16_t len;
+	uint8_t *pos;
+	size_t   msg_len = nni_msg_len(m);
+
+	if (msg_len < 2) {
+		return 0;
+	}
 
 	pos = nni_msg_body(m);
 	NNI_GET16(pos, len);
-	if (len > nni_msg_len(m) - 2)
+
+	if (msg_len < (size_t)len + 4) {
 		return 0;
-	else {
-		NNI_GET16(pos + len + 2, pid);
-		return pid;
 	}
+
+	NNI_GET16(pos + len + 2, pid);
+	return pid;
 }
 
 /**

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -411,7 +411,7 @@ nano_ctx_send(void *arg, nni_aio *aio)
 		nni_mtx_unlock(&s->lk);
 		nni_aio_set_msg(aio, NULL);
 		if (qos_db == NULL) {
-			log_warn("pipe id %ld is gone, pub failed", pipe);
+			log_warn("pipe id %u is gone, pub failed", pipe);
 		}
 		nni_msg_free(msg);
 		return;

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -402,7 +402,7 @@ nano_ctx_send(void *arg, nni_aio *aio)
 				nni_qos_db_set(is_sqlite, qos_db,
 				    pipe, tmp_id, msg);
 				tmp_id ++;
-				log_debug("msg cached for preset session %d", pipe);
+				log_info("msg cached for preset session %u", pipe);
 			}
 		}
 		// Pipe is gone.  Make this look like a good send to avoid
@@ -410,7 +410,9 @@ nano_ctx_send(void *arg, nni_aio *aio)
 		// lost interest in our reply.
 		nni_mtx_unlock(&s->lk);
 		nni_aio_set_msg(aio, NULL);
-		log_warn("pipe id %ld is gone, pub failed", pipe);
+		if (qos_db == NULL) {
+			log_warn("pipe id %ld is gone, pub failed", pipe);
+		}
 		nni_msg_free(msg);
 		return;
 	}
@@ -900,7 +902,7 @@ nano_pipe_close(void *arg)
 				// also cache kicked session
 				// merging 2 pipes together in pipe start
 			}
-			log_info("session stored %d", npipe->p_id);
+			log_info("session stored %u", npipe->p_id);
 			nni_id_set(&s->cached_sessions, npipe->p_id, p);
 			// set event to false avoid of sending the disconnecting msg
 			p->event     = false;

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -1783,10 +1783,6 @@ tcptran_pipe_getopt(
 				    is_sqlite, p->npipe->nano_qos_db, rmsg);
 				nni_qos_db_remove(is_sqlite,
 				    p->npipe->nano_qos_db, p->npipe->p_id, pid);
-
-				if (is_sqlite) {
-					nni_msg_free(rmsg);
-				}
 				continue;
 
 			} else if ((ntime - mtime) >= (long unsigned) qos_duration * 1250) {

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -1744,16 +1744,16 @@ tcptran_pipe_getopt(
 		if (buf == NULL || szp == NULL || *szp < sizeof(nmq_req)) {
 			return NNG_EINVAL;
 		}
-		nmq_req *req = (nmq_req *)buf;
-		nni_msg *msg = NULL;
-		uint16_t pid = req->packet_id;
-		bool is_sqlite = false;
+		nmq_req *req       = (nmq_req *) buf;
+		nni_msg *msg       = NULL;
+		uint16_t pid       = req->packet_id;
+		bool     is_sqlite = false;
 
 		nni_mtx_lock(&p->mtx);
-		is_sqlite = p->conf->sqlite.enable;
+		is_sqlite             = p->conf->sqlite.enable;
 		uint32_t qos_duration = p->conf->qos_duration;
 		msg = nni_qos_db_get_one(p->conf->sqlite.enable,
-			p->npipe->nano_qos_db, p->npipe->p_id, &pid);
+		    p->npipe->nano_qos_db, p->npipe->p_id, &pid);
 
 		if (msg != NULL) {
 			nni_msg       *rmsg = msg;
@@ -1768,19 +1768,29 @@ tcptran_pipe_getopt(
 			}
 			nni_time ntime = nni_clock();
 			nni_time mtime = nni_msg_get_timestamp(rmsg);
-			if (data && ntime > mtime + (nni_time)((uint64_t)data->p_value.u32 * 1000)) {
-				log_info("QoS msg id %u of pipe %u expired!", pid, p->npipe->p_id);
-				// remove expired msg from qos db
+
+			if (data && ntime > mtime + (nni_time) ((uint64_t) data->p_value.u32 * 1000)) {
+				log_info("QoS msg id %u of pipe %u expired!",
+				    pid, p->npipe->p_id);
 				nni_qos_db_remove_msg(
 				    is_sqlite, p->npipe->nano_qos_db, rmsg);
 				nni_qos_db_remove(is_sqlite,
 				    p->npipe->nano_qos_db, p->npipe->p_id, pid);
+				if (is_sqlite) {
+					nni_msg_free(rmsg);
+				}
 			} else if ((ntime - mtime) >= (long unsigned) qos_duration * 1250) {
-				nni_msg_clone(msg);
-				req->msg = msg;
+				if (!is_sqlite) {
+					nni_msg_clone(msg);
+				}
+				req->msg       = msg;
 				req->packet_id = pid;
 				nni_mtx_unlock(&p->mtx);
 				return 0;
+			} else {
+				if (is_sqlite) {
+					nni_msg_free(msg);
+				}
 			}
 		}
 		nni_mtx_unlock(&p->mtx);

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -1752,13 +1752,20 @@ tcptran_pipe_getopt(
 		nni_mtx_lock(&p->mtx);
 		is_sqlite             = p->conf->sqlite.enable;
 		uint32_t qos_duration = p->conf->qos_duration;
-		msg = nni_qos_db_get_one(p->conf->sqlite.enable,
-		    p->npipe->nano_qos_db, p->npipe->p_id, &pid);
 
-		if (msg != NULL) {
+		while (1) {
+			msg = nni_qos_db_get_one(is_sqlite,
+			    p->npipe->nano_qos_db, p->npipe->p_id, &pid);
+
+			if (msg == NULL) {
+				break;
+			}
+
 			nni_msg       *rmsg = msg;
 			property      *prop = NULL;
 			property_data *data = NULL;
+
+			// p->ws_param->pro_ver
 			if (p->tcp_cparam->pro_ver == MQTT_PROTOCOL_VERSION_v5) {
 				if (nni_msg_get_proto_data(rmsg) != NULL)
 					prop = nni_mqtt_msg_get_publish_property(rmsg);
@@ -1776,9 +1783,12 @@ tcptran_pipe_getopt(
 				    is_sqlite, p->npipe->nano_qos_db, rmsg);
 				nni_qos_db_remove(is_sqlite,
 				    p->npipe->nano_qos_db, p->npipe->p_id, pid);
+
 				if (is_sqlite) {
 					nni_msg_free(rmsg);
 				}
+				continue;
+
 			} else if ((ntime - mtime) >= (long unsigned) qos_duration * 1250) {
 				if (!is_sqlite) {
 					nni_msg_clone(msg);
@@ -1787,12 +1797,15 @@ tcptran_pipe_getopt(
 				req->packet_id = pid;
 				nni_mtx_unlock(&p->mtx);
 				return 0;
+
 			} else {
 				if (is_sqlite) {
 					nni_msg_free(msg);
 				}
+				break;
 			}
 		}
+
 		nni_mtx_unlock(&p->mtx);
 		return NNG_ENOENT;
 	}

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -1750,6 +1750,7 @@ tlstran_pipe_recv(void *arg, nni_aio *aio)
 	}
 	nni_mtx_unlock(&p->mtx);
 }
+
 static int
 tlstran_pipe_getopt(
     void *arg, const char *name, void *buf, size_t *szp, nni_type t)
@@ -1767,13 +1768,20 @@ tlstran_pipe_getopt(
 		nni_mtx_lock(&p->mtx);
 		is_sqlite             = p->conf->sqlite.enable;
 		uint32_t qos_duration = p->conf->qos_duration;
-		msg = nni_qos_db_get_one(p->conf->sqlite.enable,
-		    p->npipe->nano_qos_db, p->npipe->p_id, &pid);
 
-		if (msg != NULL) {
+		while (1) {
+			msg = nni_qos_db_get_one(is_sqlite,
+			    p->npipe->nano_qos_db, p->npipe->p_id, &pid);
+
+			if (msg == NULL) {
+				break;
+			}
+
 			nni_msg       *rmsg = msg;
 			property      *prop = NULL;
 			property_data *data = NULL;
+
+			// p->ws_param->pro_ver
 			if (p->tcp_cparam->pro_ver == MQTT_PROTOCOL_VERSION_v5) {
 				if (nni_msg_get_proto_data(rmsg) != NULL)
 					prop = nni_mqtt_msg_get_publish_property(rmsg);
@@ -1791,9 +1799,12 @@ tlstran_pipe_getopt(
 				    is_sqlite, p->npipe->nano_qos_db, rmsg);
 				nni_qos_db_remove(is_sqlite,
 				    p->npipe->nano_qos_db, p->npipe->p_id, pid);
+
 				if (is_sqlite) {
 					nni_msg_free(rmsg);
 				}
+				continue;
+
 			} else if ((ntime - mtime) >= (long unsigned) qos_duration * 1250) {
 				if (!is_sqlite) {
 					nni_msg_clone(msg);
@@ -1802,12 +1813,15 @@ tlstran_pipe_getopt(
 				req->packet_id = pid;
 				nni_mtx_unlock(&p->mtx);
 				return 0;
+
 			} else {
 				if (is_sqlite) {
 					nni_msg_free(msg);
 				}
+				break;
 			}
 		}
+
 		nni_mtx_unlock(&p->mtx);
 		return NNG_ENOENT;
 	}

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -1799,10 +1799,6 @@ tlstran_pipe_getopt(
 				    is_sqlite, p->npipe->nano_qos_db, rmsg);
 				nni_qos_db_remove(is_sqlite,
 				    p->npipe->nano_qos_db, p->npipe->p_id, pid);
-
-				if (is_sqlite) {
-					nni_msg_free(rmsg);
-				}
 				continue;
 
 			} else if ((ntime - mtime) >= (long unsigned) qos_duration * 1250) {

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -1750,7 +1750,6 @@ tlstran_pipe_recv(void *arg, nni_aio *aio)
 	}
 	nni_mtx_unlock(&p->mtx);
 }
-
 static int
 tlstran_pipe_getopt(
     void *arg, const char *name, void *buf, size_t *szp, nni_type t)
@@ -1760,15 +1759,16 @@ tlstran_pipe_getopt(
 		if (buf == NULL || szp == NULL || *szp < sizeof(nmq_req)) {
 			return NNG_EINVAL;
 		}
-		nmq_req *req = (nmq_req *)buf;
-		nni_msg *msg = NULL;
-		uint16_t pid = req->packet_id;
-		bool is_sqlite = false;
+		nmq_req *req       = (nmq_req *) buf;
+		nni_msg *msg       = NULL;
+		uint16_t pid       = req->packet_id;
+		bool     is_sqlite = false;
 
 		nni_mtx_lock(&p->mtx);
-		is_sqlite = p->conf->sqlite.enable;
+		is_sqlite             = p->conf->sqlite.enable;
 		uint32_t qos_duration = p->conf->qos_duration;
-		msg = nni_qos_db_get_one(p->conf->sqlite.enable, p->npipe->nano_qos_db, p->npipe->p_id, &pid);
+		msg = nni_qos_db_get_one(p->conf->sqlite.enable,
+		    p->npipe->nano_qos_db, p->npipe->p_id, &pid);
 
 		if (msg != NULL) {
 			nni_msg       *rmsg = msg;
@@ -1783,19 +1783,29 @@ tlstran_pipe_getopt(
 			}
 			nni_time ntime = nni_clock();
 			nni_time mtime = nni_msg_get_timestamp(rmsg);
-			if (data && ntime > mtime + (nni_time)((uint64_t)data->p_value.u32 * 1000)) {
-				log_info("QoS msg id %u of pipe %u expired!", pid, p->npipe->p_id);
-				// remove expired msg from qos db
+
+			if (data && ntime > mtime + (nni_time) ((uint64_t) data->p_value.u32 * 1000)) {
+				log_info("QoS msg id %u of pipe %u expired!",
+				    pid, p->npipe->p_id);
 				nni_qos_db_remove_msg(
 				    is_sqlite, p->npipe->nano_qos_db, rmsg);
 				nni_qos_db_remove(is_sqlite,
 				    p->npipe->nano_qos_db, p->npipe->p_id, pid);
+				if (is_sqlite) {
+					nni_msg_free(rmsg);
+				}
 			} else if ((ntime - mtime) >= (long unsigned) qos_duration * 1250) {
-				nni_msg_clone(msg);
-				req->msg = msg;
+				if (!is_sqlite) {
+					nni_msg_clone(msg);
+				}
+				req->msg       = msg;
 				req->packet_id = pid;
 				nni_mtx_unlock(&p->mtx);
 				return 0;
+			} else {
+				if (is_sqlite) {
+					nni_msg_free(msg);
+				}
 			}
 		}
 		nni_mtx_unlock(&p->mtx);

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -870,6 +870,7 @@ wstran_pipe_send_start_v4(ws_pipe *p, nni_msg *msg, nni_aio *aio)
 				    smsg, iov[i].iov_buf, iov[i].iov_len);
 			}
 			niov = 0;
+			qlength = 0;
 		}
 	}
 
@@ -1114,6 +1115,7 @@ wstran_pipe_send_start_v5(ws_pipe *p, nni_msg *msg, nni_aio *aio)
 				    smsg, iov[i].iov_buf, iov[i].iov_len);
 			}
 			niov = 0;
+			qlength = 0;
 		}
 	}
 

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -1601,9 +1601,6 @@ wstran_pipe_getopt(void *arg, const char *name, void *buf, size_t *szp, nni_type
 				log_info("QoS msg id %u of pipe %u expired!", pid, p->npipe->p_id);
 				nni_qos_db_remove_msg(is_sqlite, p->npipe->nano_qos_db, rmsg);
 				nni_qos_db_remove(is_sqlite, p->npipe->nano_qos_db, p->npipe->p_id, pid);
-				if (is_sqlite) {
-					nni_msg_free(rmsg);
-				}
 				continue;
 			} else if ((ntime - mtime) >= (long unsigned) qos_duration * 1250) {
 				if (!is_sqlite) {

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -1557,13 +1557,12 @@ static const nni_option ws_pipe_options[] = {
 	    .o_name = NULL,
 	}
 };
-
 static int
-wstran_pipe_getopt(
-    void *arg, const char *name, void *buf, size_t *szp, nni_type t)
+wstran_pipe_getopt(void *arg, const char *name, void *buf, size_t *szp, nni_type t)
 {
 	ws_pipe *p = arg;
 	int      rv;
+
 	if (strcmp(name, NMQ_OPT_MQTT_GET_QOS_RESEND) == 0) {
 		if (buf == NULL || szp == NULL || *szp < sizeof(nmq_req)) {
 			return NNG_EINVAL;
@@ -1576,12 +1575,19 @@ wstran_pipe_getopt(
 		nni_mtx_lock(&p->mtx);
 		is_sqlite = p->conf->sqlite.enable;
 		uint32_t qos_duration = p->conf->qos_duration;
-		msg = nni_qos_db_get_one(p->conf->sqlite.enable, p->npipe->nano_qos_db, p->npipe->p_id, &pid);
 
-		if (msg != NULL) {
+		while (1) {
+			msg = nni_qos_db_get_one(is_sqlite,
+			    p->npipe->nano_qos_db, p->npipe->p_id, &pid);
+
+			if (msg == NULL) {
+				break;
+			}
+
 			nni_msg       *rmsg = msg;
 			property      *prop = NULL;
 			property_data *data = NULL;
+
 			if (p->ws_param->pro_ver == MQTT_PROTOCOL_VERSION_v5) {
 				if (nni_msg_get_proto_data(rmsg) != NULL)
 					prop = nni_mqtt_msg_get_publish_property(rmsg);
@@ -1592,23 +1598,32 @@ wstran_pipe_getopt(
 			nni_time ntime = nni_clock();
 			nni_time mtime = nni_msg_get_timestamp(rmsg);
 			if (data && ntime > mtime + (nni_time)((uint64_t)data->p_value.u32 * 1000)) {
-				log_info("QoS msg id %d of pipe %u expired!", pid, p->npipe->p_id);
-				// remove expired msg from qos db
-				nni_qos_db_remove_msg(
-				    is_sqlite, p->npipe->nano_qos_db, rmsg);
-				nni_qos_db_remove(is_sqlite,
-				    p->npipe->nano_qos_db, p->npipe->p_id, pid);
+				log_info("QoS msg id %u of pipe %u expired!", pid, p->npipe->p_id);
+				nni_qos_db_remove_msg(is_sqlite, p->npipe->nano_qos_db, rmsg);
+				nni_qos_db_remove(is_sqlite, p->npipe->nano_qos_db, p->npipe->p_id, pid);
+				if (is_sqlite) {
+					nni_msg_free(rmsg);
+				}
+				continue;
 			} else if ((ntime - mtime) >= (long unsigned) qos_duration * 1250) {
-				nni_msg_clone(msg);
+				if (!is_sqlite) {
+					nni_msg_clone(msg);
+				}
 				req->msg = msg;
 				req->packet_id = pid;
 				nni_mtx_unlock(&p->mtx);
 				return 0;
+			} else {
+				if (is_sqlite) {
+					nni_msg_free(msg);
+				}
+				break;
 			}
 		}
 		nni_mtx_unlock(&p->mtx);
 		return NNG_ENOENT;
 	}
+
 	if ((rv = nni_stream_get(p->ws, name, buf, szp, t)) == NNG_ENOTSUP) {
 		rv = nni_getopt(ws_pipe_options, name, p, buf, szp, t);
 	}

--- a/src/supplemental/mqtt/mqtt_qos_db.c
+++ b/src/supplemental/mqtt/mqtt_qos_db.c
@@ -312,7 +312,7 @@ get_id_by_p_id(sqlite3 *db, int64_t p_id, uint16_t packet_id, uint8_t *out_qos,
 	sqlite3_reset(stmt);
 
 	sqlite3_bind_int64(stmt, 1, p_id);
-	sqlite3_bind_int(stmt, 2, packet_id);
+	sqlite3_bind_int64(stmt, 2, packet_id);
 	if (SQLITE_ROW == sqlite3_step(stmt)) {
 		id        = sqlite3_column_int64(stmt, 0);
 		*out_qos  = sqlite3_column_int(stmt, 1);
@@ -335,7 +335,7 @@ insert_main(
 	sqlite3_prepare_v2(db, sql, strlen(sql), &stmt, 0);
 	sqlite3_reset(stmt);
 	sqlite3_bind_int64(stmt, 1, p_id);
-	sqlite3_bind_int(stmt, 2, packet_id);
+	sqlite3_bind_int64(stmt, 2, packet_id);
 	sqlite3_bind_int(stmt, 3, qos);
 	sqlite3_bind_int64(stmt, 4, m_id);
 	sqlite3_step(stmt);
@@ -356,7 +356,7 @@ update_main(
 	sqlite3_bind_int(stmt, 1, qos);
 	sqlite3_bind_int64(stmt, 2, m_id);
 	sqlite3_bind_int64(stmt, 3, p_id);
-	sqlite3_bind_int(stmt, 4, packet_id);
+	sqlite3_bind_int64(stmt, 4, packet_id);
 	sqlite3_step(stmt);
 	sqlite3_finalize(stmt);
 	return sqlite3_exec(db, "COMMIT;", 0, 0, 0);
@@ -655,7 +655,7 @@ nni_mqtt_qos_db_get_one(sqlite3 *db, uint32_t pipe_id, uint16_t *packet_id)
 	sqlite3_exec(db, "BEGIN;", 0, 0, 0);
 	sqlite3_prepare_v2(db, sql, strlen(sql), &stmt, 0);
 	sqlite3_reset(stmt);
-	sqlite3_bind_int(stmt, 1, pipe_id);
+	sqlite3_bind_int64(stmt, 1, pipe_id);
 
 	if (SQLITE_ROW == sqlite3_step(stmt)) {
 		*packet_id     = sqlite3_column_int64(stmt, 0);
@@ -685,8 +685,8 @@ nni_mqtt_qos_db_remove(sqlite3 *db, uint32_t pipe_id, uint16_t packet_id)
 	sqlite3_prepare_v2(db, sql, strlen(sql), &stmt, 0);
 	sqlite3_reset(stmt);
 
-	sqlite3_bind_int(stmt, 1, pipe_id);
-	sqlite3_bind_int(stmt, 2, packet_id);
+	sqlite3_bind_int64(stmt, 1, pipe_id);
+	sqlite3_bind_int64(stmt, 2, packet_id);
 	sqlite3_step(stmt);
 
 	sqlite3_finalize(stmt);
@@ -704,7 +704,7 @@ nni_mqtt_qos_db_remove_by_pipe(sqlite3 *db, uint32_t pipe_id)
 	sqlite3_prepare_v2(db, sql, strlen(sql), &stmt, 0);
 	sqlite3_reset(stmt);
 
-	sqlite3_bind_int(stmt, 1, pipe_id);
+	sqlite3_bind_int64(stmt, 1, pipe_id);
 	sqlite3_step(stmt);
 
 	sqlite3_finalize(stmt);
@@ -918,7 +918,7 @@ nni_mqtt_qos_db_set_client_msg(sqlite3 *db, uint32_t pipe_id,
 	sqlite3_exec(db, "BEGIN;", 0, 0, 0);
 	sqlite3_prepare_v2(db, sql, strlen(sql), &stmt, 0);
 	sqlite3_reset(stmt);
-	sqlite3_bind_int(stmt, 1, pipe_id);
+	sqlite3_bind_int64(stmt, 1, pipe_id);
 	sqlite3_bind_int64(stmt, 2, packet_id);
 	sqlite3_bind_blob64(stmt, 3, blob, len, SQLITE_TRANSIENT);
 	sqlite3_bind_int(stmt, 4, proto_ver);
@@ -947,7 +947,7 @@ nni_mqtt_qos_db_get_client_msg(
 	sqlite3_prepare_v2(db, sql, strlen(sql), &stmt, 0);
 	sqlite3_reset(stmt);
 	sqlite3_bind_int64(stmt, 1, pipe_id);
-	sqlite3_bind_int(stmt, 2, packet_id);
+	sqlite3_bind_int64(stmt, 2, packet_id);
 	sqlite3_bind_text(
 	    stmt, 3, config_name, strlen(config_name), SQLITE_TRANSIENT);
 
@@ -982,7 +982,7 @@ nni_mqtt_qos_db_remove_client_msg(
 	sqlite3_prepare_v2(db, sql, strlen(sql), &stmt, 0);
 	sqlite3_reset(stmt);
 	sqlite3_bind_int64(stmt, 1, pipe_id);
-	sqlite3_bind_int(stmt, 2, packet_id);
+	sqlite3_bind_int64(stmt, 2, packet_id);
 	sqlite3_bind_text(
 	    stmt, 3, config_name, strlen(config_name), SQLITE_TRANSIENT);
 	sqlite3_step(stmt);

--- a/src/supplemental/nanolib/conf.c
+++ b/src/supplemental/nanolib/conf.c
@@ -4049,6 +4049,8 @@ get_size(const char *str, uint64_t *size)
 		} else {
 			return -1;
 		}
+	} else if (res == 1) {
+		num *= 1;
 	} else {
 		return -1;
 	}

--- a/src/supplemental/nanolib/conf_test.c
+++ b/src/supplemental/nanolib/conf_test.c
@@ -116,8 +116,8 @@ test_get_size_edge_cases(void)
 	NUTS_PASS(get_size(str_mixed, &size));
 	NUTS_TRUE(size == 10 * 1024 * 1024);
 
-	// Test number without unit
-	NUTS_FAIL(get_size(str_no_unit, &size), -1);
+	NUTS_PASS(get_size(str_no_unit, &size));
+	NUTS_TRUE(size == 100);
 }
 
 void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened publish-PID extraction by adding safer bounds checks when reading message contents.
  * Improved MQTT QoS resend selection across TCP, TLS, and WebSocket by iterating cached candidates, skipping expired entries, and retrying until an eligible message is found.
  * Fixed WebSocket publish segment construction to prevent queued-length carryover between subscriptions.
  * Updated config size parsing to accept plain numeric values (bytes) without unit suffixes.
  * Improved clarity of MQTT-related logging output and switched SQLite QoS DB bindings to use 64-bit integers for packet/pipe IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->