### PR TITLE
* FIX [broker] store offline shared-subscription QoS msgs for cached sessions

### DIFF
--- a/include/nng/protocol/mqtt/mqtt_parser.h
+++ b/include/nng/protocol/mqtt/mqtt_parser.h
@@ -140,6 +140,7 @@ NNG_DECL int  nmq_subinfo_decode(nng_msg *msg, void *l, uint8_t ver);
 NNG_DECL int  nmq_unsubinfo_decode(nng_msg *msg, void *l, uint8_t ver);
 NNG_DECL bool topic_filter(const char *origin, const char *input);
 NNG_DECL bool topic_filtern(const char *origin, const char *input, size_t n);
+NNG_DECL const char *shared_filter_skip(const char *filter);
 
 NNG_DECL int nmq_auth_http_connect(conn_param *cparam, conf_auth_http *conf);
 

--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -2116,6 +2116,31 @@ topic_filtern(const char *origin, const char *input, size_t n)
 }
 
 /**
+ * @brief skip the "$share/<group>/" prefix of a shared
+ * 		  subscription filter, so that the remainder can be
+ * 		  used for topic matching (topic_filter/topic_filtern)
+ *
+ * @param filter subscription topic filter
+ * @return const char* pointer into *filter right after the shared
+ *         prefix; the original filter if it is not a well-formed
+ *         shared subscription filter
+ */
+const char *
+shared_filter_skip(const char *filter)
+{
+	const char *pos;
+
+	if (filter == NULL || filter[0] != '$')
+		return filter;
+	if (strncmp(filter, "$share/", strlen("$share/")) != 0)
+		return filter;
+	pos = strchr(filter + strlen("$share/"), '/');
+	if (pos == NULL || *(pos + 1) == '\0')
+		return filter;
+	return pos + 1;
+}
+
+/**
  * packet: orginal buffer
  * len: max len to decode
  * remainning_length: result

--- a/src/sp/protocol/mqtt/mqtt_parser_test.c
+++ b/src/sp/protocol/mqtt/mqtt_parser_test.c
@@ -165,6 +165,47 @@ test_topic_filtern()
 	NUTS_ASSERT(topic_filtern(orgin, input, 11) == false);
 }
 
+static void
+test_shared_filter_skip()
+{
+	const char *filter;
+
+	// shared subscription: strip "$share/<group>/" prefix
+	filter = shared_filter_skip("$share/g1/t/x");
+	NUTS_MATCH(filter, "t/x");
+	NUTS_ASSERT(topic_filtern(filter, "t/x", strlen("t/x")) == true);
+
+	// wildcard remainders still match after stripping
+	filter = shared_filter_skip("$share/g1/#");
+	NUTS_MATCH(filter, "#");
+	NUTS_ASSERT(topic_filtern(filter, "t/x", strlen("t/x")) == true);
+
+	filter = shared_filter_skip("$share/g1/t/+");
+	NUTS_MATCH(filter, "t/+");
+	NUTS_ASSERT(topic_filtern(filter, "t/x", strlen("t/x")) == true);
+
+	// non-shared filters pass through unchanged (same pointer)
+	const char *plain = "t/x";
+	NUTS_ASSERT(shared_filter_skip(plain) == plain);
+	const char *sys = "$sys/broker/uptime";
+	NUTS_ASSERT(shared_filter_skip(sys) == sys);
+
+	// malformed: no topic filter after the group
+	const char *broken = "$share/g1";
+	filter = shared_filter_skip(broken);
+	NUTS_ASSERT(filter == broken);
+	NUTS_ASSERT(topic_filtern(filter, "t/x", strlen("t/x")) == false);
+
+	// "$share/" alone and "$shareX/..." are not shared filters
+	const char *empty = "$share/";
+	NUTS_ASSERT(shared_filter_skip(empty) == empty);
+	const char *fake = "$shareX/g1/t";
+	NUTS_ASSERT(shared_filter_skip(fake) == fake);
+
+	// NULL is passed through without crashing
+	NUTS_ASSERT(shared_filter_skip(NULL) == NULL);
+}
+
 NUTS_TESTS = {
 	{ "mqtt_parser pub_extras", test_pub_extra },
 	{ "mqtt_parser utf8_check", test_utf8_check },
@@ -178,6 +219,7 @@ NUTS_TESTS = {
 	// TODO more tests needed.
 	{ "mqtt_parser topic_filter", test_topic_filter },
 	{ "mqtt_parser topic_filtern", test_topic_filtern },
+	{ "mqtt_parser shared_filter_skip", test_shared_filter_skip },
 
 	{ NULL, NULL },
 };

--- a/src/sp/protocol/mqtt/mqtt_parser_test.c
+++ b/src/sp/protocol/mqtt/mqtt_parser_test.c
@@ -196,11 +196,21 @@ test_shared_filter_skip()
 	NUTS_ASSERT(filter == broken);
 	NUTS_ASSERT(topic_filtern(filter, "t/x", strlen("t/x")) == false);
 
+	// malformed: empty remainder after the group separator
+	const char *trailing = "$share/g1/";
+	NUTS_ASSERT(shared_filter_skip(trailing) == trailing);
+
 	// "$share/" alone and "$shareX/..." are not shared filters
 	const char *empty = "$share/";
 	NUTS_ASSERT(shared_filter_skip(empty) == empty);
 	const char *fake = "$shareX/g1/t";
 	NUTS_ASSERT(shared_filter_skip(fake) == fake);
+
+	// "$share" without any separator and the empty string
+	const char *bare = "$share";
+	NUTS_ASSERT(shared_filter_skip(bare) == bare);
+	const char *blank = "";
+	NUTS_ASSERT(shared_filter_skip(blank) == blank);
 
 	// NULL is passed through without crashing
 	NUTS_ASSERT(shared_filter_skip(NULL) == NULL);

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -1633,7 +1633,8 @@ tcptran_pipe_send(void *arg, nni_aio *aio)
 			NNI_LIST_FOREACH(p->npipe->subinfol, info) {
 				if (!info)
 					continue;
-				if (topic_filtern(info->topic, pld_pac, tlen_pac)) {
+				if (topic_filtern(shared_filter_skip(info->topic),
+				        pld_pac, tlen_pac)) {
 					qos = qos_pac > info->qos ? info->qos : qos_pac; // MIN
 					break;
 				}

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -1635,8 +1635,13 @@ tcptran_pipe_send(void *arg, nni_aio *aio)
 					continue;
 				if (topic_filtern(shared_filter_skip(info->topic),
 				        pld_pac, tlen_pac)) {
-					qos = qos_pac > info->qos ? info->qos : qos_pac; // MIN
-					break;
+					// keep the strongest matching subscription:
+					// an overlapping QoS>0 filter must not be
+					// shadowed by a QoS0 one matching first
+					uint8_t eff =
+					    qos_pac > info->qos ? info->qos : qos_pac;
+					if (eff > qos)
+						qos = eff;
 				}
 			}
 		} else {

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -1651,8 +1651,13 @@ tlstran_pipe_send(void *arg, nni_aio *aio)
 					continue;
 				if (topic_filtern(shared_filter_skip(info->topic),
 				        pld_pac, tlen_pac)) {
-					qos = qos_pac > info->qos ? info->qos : qos_pac; // MIN
-					break;
+					// keep the strongest matching subscription:
+					// an overlapping QoS>0 filter must not be
+					// shadowed by a QoS0 one matching first
+					uint8_t eff =
+					    qos_pac > info->qos ? info->qos : qos_pac;
+					if (eff > qos)
+						qos = eff;
 				}
 			}
 		} else {

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -1649,7 +1649,8 @@ tlstran_pipe_send(void *arg, nni_aio *aio)
 			NNI_LIST_FOREACH(p->npipe->subinfol, info) {
 				if (!info)
 					continue;
-				if (topic_filtern(info->topic, pld_pac, tlen_pac)) {
+				if (topic_filtern(shared_filter_skip(info->topic),
+				        pld_pac, tlen_pac)) {
 					qos = qos_pac > info->qos ? info->qos : qos_pac; // MIN
 					break;
 				}

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -1233,7 +1233,8 @@ wstran_pipe_send(void *arg, nni_aio *aio)
 			NNI_LIST_FOREACH(p->npipe->subinfol, info) {
 				if (!info)
 					continue;
-				if (topic_filtern(info->topic, pld_pac, tlen_pac)) {
+				if (topic_filtern(shared_filter_skip(info->topic),
+				        pld_pac, tlen_pac)) {
 					qos = qos_pac > info->qos ? info->qos : qos_pac; // MIN
 					break;
 				}

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -1235,8 +1235,13 @@ wstran_pipe_send(void *arg, nni_aio *aio)
 					continue;
 				if (topic_filtern(shared_filter_skip(info->topic),
 				        pld_pac, tlen_pac)) {
-					qos = qos_pac > info->qos ? info->qos : qos_pac; // MIN
-					break;
+					// keep the strongest matching subscription:
+					// an overlapping QoS>0 filter must not be
+					// shadowed by a QoS0 one matching first
+					uint8_t eff =
+					    qos_pac > info->qos ? info->qos : qos_pac;
+					if (eff > qos)
+						qos = eff;
 				}
 			}
 		} else {


### PR DESCRIPTION
## Summary

QoS-1/2 messages published while a shared-subscription (`$share/<group>/<filter>`) persistent session (`clean_start=false`) is offline are dropped instead of stored: the transport offline-cache branch re-matches the publish topic against the raw stored filter, so the `$share` prefix never matches and the message is freed. A resumed session gets none of its offline messages.

No group-level offline queue is involved — the dispatcher has already round-robined the message to exactly one (possibly offline) group member and handed it to that member's pipe, matching the per-Client-ID storage model. Only the final topic-match in the cache branch fails.

## Fix

A `shared_filter_skip()` helper strips `$share/<group>/` before `topic_filtern` in the offline-cache branch of the tcp/tls/ws transports — the same strip every online send path already does. Malformed shapes (`$share/`, `$share/g`, `$share/g/`) are returned unchanged.

A second commit hardens the same loop: it resolved the stored QoS from the *first* matching subscription and broke out. With shared filters now participating in the match, a session holding an overlapping pair (e.g. `$share/g/t` at QoS 0 subscribed before `t` at QoS 1) could resolve a QoS 1 publish to effective QoS 0 and drop it instead of storing. The loop now accumulates the maximum effective QoS over all matching subscriptions (single-copy delivery at the strongest match, per MQTT-3.3.4-2).

This is the minimal storage fix split out of #1560 as discussed in nanomq/nanomq#2355 ("your PR is welcome"). Redelivery pace is untouched — resumed sessions drain on the existing resend timer; the opt-in resume-pacing change will come separately.

## Validation

- Unit test for the helper covering plain filters, `$SYS` topics, well-formed and malformed `$share` shapes (`mqtt_parser_test`).
- The companion nanomq PR (nanomq/nanomq#2378) adds an end-to-end regression: {plain-control, `$share`, overlap, QoS-0 control} × {SQLite, in-memory}; after this fix shared members behave identically to plain subscribers on resume, and an overlapping `$share` QoS-0 + plain QoS-1 pair stores at QoS 1.

Related: nanomq/nanomq#2355

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT shared subscription handling across TCP, TLS, and WebSocket transports.
  * Shared subscription prefixes are now correctly ignored when matching published topics and determining delivery settings.
  * Added handling for malformed, non-shared, wildcard, and empty subscription filters.

* **Tests**
  * Added coverage for shared subscription filter parsing and topic matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
