### PR TITLE
mqtt: limit logging on saturated broker queues

### DIFF
--- a/include/nng/protocol/mqtt/nmq_mqtt.h
+++ b/include/nng/protocol/mqtt/nmq_mqtt.h
@@ -27,6 +27,9 @@ NNG_DECL int nng_nmq_tcp0_open(nng_socket *);
 
 #define NMQ_OPT_MQTT_PIPES "mqtt-clients-pipes"
 #define NMQ_OPT_MQTT_QOS_DB "mqtt-clients-qos-db"
+#define NMQ_OPT_MQTT_MSGS_DROPPED "mqtt-messages-dropped"
+#define NMQ_OPT_MQTT_MSGS_SENT "mqtt-messages-sent"
+#define NMQ_OPT_MQTT_LOG_DROPS "mqtt-log-drops"
 
 #ifdef __cplusplus
 }

--- a/include/nng/supplemental/nanolib/conf.h
+++ b/include/nng/supplemental/nanolib/conf.h
@@ -648,6 +648,7 @@ struct conf {
 	char      *conf_file;		// config path
 	char      *url;
 	bool       enable;
+	bool       log_dropped_messages;
 	size_t     property_size;
 	size_t     msq_len;
     uint16_t   max_topic_alias;

--- a/src/sp/protocol/mqtt/CMakeLists.txt
+++ b/src/sp/protocol/mqtt/CMakeLists.txt
@@ -8,6 +8,7 @@ if (NNG_PROTO_MQTT_BROKER)
     nng_sources_if(NNG_PROTO_MQTT_BROKER mqtt_parser.c nmq_mqtt.c auth_http.c)
     nng_headers_if(NNG_PROTO_MQTT_BROKER nng/protocol/mqtt/mqtt_parser.h nng/protocol/mqtt/nmq_mqtt.h)
     nng_defines_if(NNG_PROTO_MQTT_BROKER NNG_HAVE_MQTT_BROKER)
+    nng_test(nmq_mqtt_test)
 endif ()
 
 nng_test(mqtt_parser_test)

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -37,7 +37,6 @@ static int         nano_pipe_close(void *);
 static inline void close_pipe(nano_pipe *p);
 
 static uint16_t tmp_id = 1000;
-static uint32_t rotate = 0;
 // huge context/ dynamic context?
 struct nano_ctx {
 	nano_sock *sock;
@@ -55,6 +54,10 @@ struct nano_sock {
 	nni_mtx        lk;
 	nni_msg       *pingmsg;
 	nni_atomic_int ttl;
+	nni_atomic_u64 msgs_dropped;
+	nni_atomic_u64 msgs_sent;
+	nni_atomic_bool log_drops;
+	bool           no_ctx_warned;
 	nni_id_map     pipes;
 	nni_id_map     cached_sessions;
 	nni_lmq        waitlmq;   // this is for receving
@@ -78,12 +81,14 @@ struct nano_pipe {
 	conn_param *conn_param;
 	nni_lmq     rlmq; // only for sending cache
 	uint8_t     reason_code;
+	uint8_t     send_cmd;
 	uint32_t    id;  // pipe id of nni_pipe
 	uint16_t    rid; // index of packet ID for resending
 	uint16_t    keepalive;
 	uint16_t 	ka_refresh; // ka_refresh count how many times the keepalive
 	                     	// timer has been triggered
 	bool          busy;
+	bool          queue_full_warned;
 	bool          event; // indicates if exposure disconnect event is valid
 	void         *tree;  // root node of db tree
 	void         *nano_qos_db; // 'sqlite' or 'nni_id_hash_map'
@@ -273,6 +278,7 @@ nano_pipe_timer_cb(void *arg)
 			nni_aio_set_prov_data(
 			    &p->aio_send, (void *) (uintptr_t) real_pid);
 			nni_aio_set_msg(&p->aio_send, rmsg);
+			p->send_cmd = nni_msg_get_type(rmsg);
 			log_info("resending qos msg id %u to pipe %u",
 				pid, p->id);
 			nni_pipe_send(p->pipe, &p->aio_send);
@@ -358,6 +364,7 @@ nano_ctx_send(void *arg, nni_aio *aio)
 	nano_pipe *p;
 	nni_msg   *msg;
 	int        rv;
+	bool       warn_queue_full = false;
 	uint32_t   pipe = 0;
 	uint32_t  *pipeid;
 
@@ -411,7 +418,8 @@ nano_ctx_send(void *arg, nni_aio *aio)
 		nni_mtx_unlock(&s->lk);
 		nni_aio_set_msg(aio, NULL);
 		if (qos_db == NULL) {
-			log_warn("pipe id %u is gone, pub failed", pipe);
+			nni_atomic_inc64(&s->msgs_dropped);
+			log_debug("pipe id %u is gone, pub dropped", pipe);
 		}
 		nni_msg_free(msg);
 		return;
@@ -424,6 +432,7 @@ nano_ctx_send(void *arg, nni_aio *aio)
 	if (!p->busy) {
 		p->busy = true;
 		nni_aio_set_msg(&p->aio_send, msg);
+		p->send_cmd = nni_msg_get_type(msg);
 		nni_pipe_send(p->pipe, &p->aio_send);
 		nni_mtx_unlock(&p->lk);
 		nni_aio_set_msg(aio, NULL);
@@ -442,17 +451,25 @@ nano_ctx_send(void *arg, nni_aio *aio)
 		if (nni_lmq_cap(&p->rlmq) <= NANO_MAX_QOS_PACKET) {
 			if ((rv = nano_nni_lmq_resize(
 			         &p->rlmq, nni_lmq_cap(&p->rlmq) * 2)) != 0) {
-				log_warn("warning msg dropped!");
 				nni_msg *old;
 				nni_lmq_get(&p->rlmq, &old);
 				nni_msg_free(old);
+				nni_atomic_inc64(&s->msgs_dropped);
+				warn_queue_full = nni_atomic_get_bool(&s->log_drops) &&
+				    !p->queue_full_warned;
+				p->queue_full_warned = true;
 			}
 		} else {
-			// Warning msg lost due to reach the limit of lmq
-			log_warn(
-			    "Warning: msg lost due to reach the limit of lmq");
-			nni_msg_free(msg);
+			bool warn = nni_atomic_get_bool(&s->log_drops) &&
+			    !p->queue_full_warned;
+			p->queue_full_warned = true;
+			nni_atomic_inc64(&s->msgs_dropped);
 			nni_mtx_unlock(&p->lk);
+			if (warn) {
+				log_warn("pipe %u egress queue is full; "
+				         "subsequent drops will not be logged", pipe);
+			}
+			nni_msg_free(msg);
 			nni_aio_set_msg(aio, NULL);
 			return;
 		}
@@ -461,6 +478,10 @@ nano_ctx_send(void *arg, nni_aio *aio)
 	nni_lmq_put(&p->rlmq, msg);
 
 	nni_mtx_unlock(&p->lk);
+	if (warn_queue_full) {
+		log_warn("pipe %u egress queue resize failed; "
+		         "subsequent drops will not be logged", pipe);
+	}
 	nni_aio_set_msg(aio, NULL);
 	return;
 }
@@ -505,6 +526,11 @@ nano_sock_init(void *arg, nni_sock *sock)
 
 	nni_atomic_init(&s->ttl);
 	nni_atomic_set(&s->ttl, 8);
+	nni_atomic_init64(&s->msgs_dropped);
+	nni_atomic_init64(&s->msgs_sent);
+	nni_atomic_init_bool(&s->log_drops);
+	nni_atomic_set_bool(&s->log_drops, true);
+	s->no_ctx_warned = false;
 
 	(void) nano_ctx_init(&s->ctx, s);
 
@@ -614,9 +640,11 @@ nano_pipe_init(void *arg, nni_pipe *pipe, void *s)
 	p->rid         = 1;
 	p->pipe        = pipe;
 	p->reason_code = 0x00;
+	p->send_cmd    = 0;
 	p->broker      = s;
 	p->ka_refresh  = 0;
 	p->event       = true;
+	p->queue_full_warned = false;
 	p->tree        = sock->db;
 	if (p->conn_param != NULL)
 		p->keepalive   = p->conn_param->keepalive_mqtt;
@@ -1005,10 +1033,14 @@ nano_pipe_send_cb(void *arg)
 		return;
 	}
 	nni_mtx_lock(&p->lk);
+	if (p->send_cmd == CMD_PUBLISH && nni_aio_count(&p->aio_send) > 0) {
+		nni_atomic_inc64(&p->broker->msgs_sent);
+	}
 
 	nni_aio_set_prov_data(&p->aio_send, 0);
 	if (nni_lmq_get(&p->rlmq, &msg) == 0) {
 		nni_aio_set_msg(&p->aio_send, msg);
+		p->send_cmd = nni_msg_get_type(msg);
 		log_trace("rlmq msg resending! %ld msgs left\n",
 		    nni_lmq_len(&p->rlmq));
 		nni_pipe_send(p->pipe, &p->aio_send);
@@ -1201,6 +1233,7 @@ nano_pipe_recv_cb(void *arg)
 		if (!p->busy) {
 			p->busy = true;
 			nni_aio_set_msg(&p->aio_send, s->pingmsg);
+			p->send_cmd = nni_msg_get_type(s->pingmsg);
 			nni_pipe_send(p->pipe, &p->aio_send);
 		} else {
 			if (nni_lmq_put(&p->rlmq, s->pingmsg) != 0) {
@@ -1227,6 +1260,9 @@ nano_pipe_recv_cb(void *arg)
 	}
 
 	if ((ctx = nni_list_first(&s->recvq)) == NULL) {
+		bool warn = nni_atomic_get_bool(&s->log_drops) &&
+		    !s->no_ctx_warned;
+		s->no_ctx_warned = true;
 		// No one waiting to receive yet, holding pattern.
 		// Dont use waitlmq cache, cause back-pressure.
 		if (!nni_list_active(&s->recvpipes, p)) {
@@ -1240,11 +1276,8 @@ nano_pipe_recv_cb(void *arg)
 				conn_param_free(cparam);
 		}
 		nni_mtx_unlock(&s->lk);
-		// this gonna cause broker lagging, so we reduce outputs 1 in 256
-		rotate ++;
-		if (rotate >>8 & 0x01) {
+		if (warn) {
 			log_warn("no ctx found!! create more ctxs!");
-			rotate  = rotate >> 8 ;
 		}
 		return;
 	}
@@ -1300,6 +1333,47 @@ nano_sock_get_idmap(void *arg, void *buf, size_t *szp, nni_opt_type t)
 	nano_sock *s = arg;
 
 	return (nni_copyout_ptr(&s->pipes, buf, szp, t));
+}
+
+static int
+nano_sock_get_msgs_dropped(void *arg, void *buf, size_t *szp, nni_opt_type t)
+{
+	nano_sock *s = arg;
+
+	return (nni_copyout_u64(
+	    nni_atomic_get64(&s->msgs_dropped), buf, szp, t));
+}
+
+static int
+nano_sock_get_msgs_sent(void *arg, void *buf, size_t *szp, nni_opt_type t)
+{
+	nano_sock *s = arg;
+
+	return (nni_copyout_u64(
+	    nni_atomic_get64(&s->msgs_sent), buf, szp, t));
+}
+
+static int
+nano_sock_get_log_drops(void *arg, void *buf, size_t *szp, nni_opt_type t)
+{
+	nano_sock *s = arg;
+
+	return (nni_copyout_bool(
+	    nni_atomic_get_bool(&s->log_drops), buf, szp, t));
+}
+
+static int
+nano_sock_set_log_drops(
+    void *arg, const void *buf, size_t sz, nni_opt_type t)
+{
+	nano_sock *s = arg;
+	bool       enabled;
+	int        rv;
+
+	if ((rv = nni_copyin_bool(&enabled, buf, sz, t)) == 0) {
+		nni_atomic_set_bool(&s->log_drops, enabled);
+	}
+	return (rv);
 }
 
 #if defined(NNG_SUPP_SQLITE)
@@ -1431,6 +1505,19 @@ static nni_option nano_sock_options[] = {
 	{
 	    .o_name = NMQ_OPT_MQTT_PIPES,
 	    .o_get  = nano_sock_get_idmap,
+	},
+	{
+	    .o_name = NMQ_OPT_MQTT_MSGS_DROPPED,
+	    .o_get  = nano_sock_get_msgs_dropped,
+	},
+	{
+	    .o_name = NMQ_OPT_MQTT_MSGS_SENT,
+	    .o_get  = nano_sock_get_msgs_sent,
+	},
+	{
+	    .o_name = NMQ_OPT_MQTT_LOG_DROPS,
+	    .o_get  = nano_sock_get_log_drops,
+	    .o_set  = nano_sock_set_log_drops,
 	},
 #if defined(NNG_SUPP_SQLITE)
 	{

--- a/src/sp/protocol/mqtt/nmq_mqtt_test.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt_test.c
@@ -1,0 +1,41 @@
+#include <nuts.h>
+
+#include "nng/protocol/mqtt/nmq_mqtt.h"
+#include "nng/supplemental/nanolib/conf.h"
+
+static void
+test_dropped_messages_option(void)
+{
+	conf      *config = nng_zalloc(sizeof(*config));
+	nng_socket socket = { 0 };
+	uint64_t   dropped = UINT64_MAX;
+	uint64_t   sent = UINT64_MAX;
+	bool       log_drops;
+
+	NUTS_TRUE(config != NULL);
+	conf_init(config);
+	socket.data = config;
+	NUTS_PASS(nng_nmq_tcp0_open(&socket));
+	NUTS_PASS(nng_socket_get_uint64(
+	    socket, NMQ_OPT_MQTT_MSGS_DROPPED, &dropped));
+	NUTS_ASSERT(dropped == 0);
+	NUTS_PASS(nng_socket_get_uint64(
+	    socket, NMQ_OPT_MQTT_MSGS_SENT, &sent));
+	NUTS_ASSERT(sent == 0);
+	NUTS_FAIL(nng_socket_set_uint64(
+	              socket, NMQ_OPT_MQTT_MSGS_DROPPED, 1),
+	    NNG_EREADONLY);
+	NUTS_PASS(nng_socket_get_bool(
+	    socket, NMQ_OPT_MQTT_LOG_DROPS, &log_drops));
+	NUTS_TRUE(log_drops);
+	NUTS_PASS(nng_socket_set_bool(socket, NMQ_OPT_MQTT_LOG_DROPS, false));
+	NUTS_PASS(nng_socket_get_bool(
+	    socket, NMQ_OPT_MQTT_LOG_DROPS, &log_drops));
+	NUTS_ASSERT(!log_drops);
+	NUTS_PASS(nng_close(socket));
+}
+
+NUTS_TESTS = {
+	{ "nmq mqtt dropped messages option", test_dropped_messages_option },
+	{ NULL, NULL },
+};

--- a/src/supplemental/nanolib/conf.c
+++ b/src/supplemental/nanolib/conf.c
@@ -918,6 +918,7 @@ conf_init(conf *nanomq_conf)
 	nanomq_conf->await_rel_timeout = 10;
 
 	nanomq_conf->allow_anonymous = true;
+	nanomq_conf->log_dropped_messages = true;
 	nanomq_conf->ipc_internal    = true;
 
 #ifdef ACL_SUPP
@@ -1363,6 +1364,8 @@ print_conf(conf *nanomq_conf)
 	log_info("client_max_packet_size:   %d",
 	    nanomq_conf->client_max_packet_size);
 	log_info("max_mqueue_len:           %d", nanomq_conf->msq_len);
+	log_info("log_dropped_messages:     %s",
+	    nanomq_conf->log_dropped_messages ? "true" : "false");
 	log_info("max_inflight_window:      %d", nanomq_conf->max_inflight_window);
 	log_info("max_awaiting_rel:         %ds", nanomq_conf->max_awaiting_rel);
 	log_info("await_rel_timeout:        %ds", nanomq_conf->await_rel_timeout);

--- a/src/supplemental/nanolib/conf_test.c
+++ b/src/supplemental/nanolib/conf_test.c
@@ -95,6 +95,7 @@ test_conf_parse_ver2(void)
 	NUTS_TRUE(conf != NULL);
 	conf_parse_ver2(conf);
 	NUTS_TRUE(strncmp(conf->url, "nmq-tcp://0.0.0.0:1883", 22) == 0);
+	NUTS_TRUE(!conf->log_dropped_messages);
 
 	print_conf(conf);
 
@@ -242,6 +243,7 @@ test_conf_init(void)
 	NUTS_TRUE(nmq_conf->enable == true);
 	NUTS_TRUE(nmq_conf->parallel > 0);
 	NUTS_TRUE(nmq_conf->property_size > 0);
+	NUTS_TRUE(nmq_conf->log_dropped_messages);
 
 	conf_fini(nmq_conf);
 }

--- a/src/supplemental/nanolib/conf_ver2.c
+++ b/src/supplemental/nanolib/conf_ver2.c
@@ -340,6 +340,7 @@ conf_basic_parse_ver2(conf *config, cJSON *jso)
 		config->client_max_packet_size = config->max_packet_size;
 		hocon_read_num_base(
 		    config, msq_len, "max_mqueue_len", jso_mqtt);
+		hocon_read_bool(config, log_dropped_messages, jso_mqtt);
 		hocon_read_num_base(
 		    config, max_topic_alias, "max_topic_alias", jso_mqtt);
 		hocon_read_time_base(

--- a/src/supplemental/nanolib/test_conf/nmq_test.conf
+++ b/src/supplemental/nanolib/test_conf/nmq_test.conf
@@ -39,6 +39,7 @@ mqtt {
 	# # Hot updatable
 	# # Value: 1-infinity
 	max_mqueue_len = 2048
+	log_dropped_messages = false
 	
 	# # Unsupported now
 	max_inflight_window = 2048


### PR DESCRIPTION
fixes #1567 MQTT egress warnings can amplify queue saturation

## Context

In a fan-in setup where one MQTT subscriber cannot drain its egress queue fast
enough, the current path appears to emit one warning for every dropped QoS 0
message. The warning and the message free also appear to happen while the pipe
lock is held.

On a two-core, 48k msg/s fan-in reproduction, this correlated with about 2.5k
msg/s received at `warn` and 528k warnings, compared with roughly 13k msg/s at
`error`. This suggests that synchronous warning output may amplify normal
overload into a much larger throughput cliff.

The `no ctx found` warning seems to have a similar pattern: its global rotate
counter is racy and can produce long warning bursts. A destination pipe that
disappears during publication also looks like an expected drop race rather than
an operator warning.

## Proposed change

This patch would:

- keep warning output enabled by default, but limit queue-full output to one
  warning per affected connection;
- expose `NMQ_OPT_MQTT_LOG_DROPS` so an embedding application could disable
  drop warnings without disabling accounting;
- move queue-full logging and message destruction out of the pipe lock;
- limit the no-context warning once per socket;
- lower the disappeared-pipe message to debug level;
- expose read-only transport sent/drop counters. Sends would be counted only
  after successful PUBLISH transport completion; drops would include full
  queues, disappeared pipes without a QoS database, and resize failures.

The existing FIFO behavior and QoS 0 drop policy would remain unchanged.

## Validation

I first bisected the hot path with 48k msg/s offered:

| Variant | Receive rate |
| --- | ---: |
| stock, warning enabled | ~2.5k msg/s |
| queue-full log disabled only | 17.6–18.5k msg/s |
| log/free moved outside the lock only | 8.0–9.4k msg/s |
| both changes | 13.8–18.6k msg/s |

With this patch and a 65,535-message queue, the QoS 0 fan-in runs reached
15,998, 23,896, and 31,905–31,948 msg/s for 16k, 24k, and 32k offered. The 32k
`warn` and `error` results were effectively the same, and a warning run emitted
one saturation warning. A 1-to-32 fan-out control reached 31,999 msg/s.

As a configuration-path control at 96k offered, enabling/disabling
`log_dropped_messages` resulted in 15,172/14,980 msg/s respectively, while the
warning count changed from one to zero. This would suggest that disabling the
warning changes observability rather than the drop mechanism.

At loads above 32k, a remaining single-pipe drain limit is still visible and
results are more variable. This patch is therefore intended to make overload
observable and to avoid warning amplification; it would not attempt to change
backpressure or queueing policy.

Release and ASAN builds passed. Tests cover the socket options, read-only
counters, configuration parsing, and public send completion; the MQTT test was
also repeated 20 times under ASAN.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MQTT metrics for tracking sent and dropped messages.
  - Added an MQTT option to enable or disable dropped-message logging.
  - Added the `log_dropped_messages` configuration setting, enabled by default.
- **Bug Fixes**
  - Improved handling of messages dropped when delivery queues are unavailable or full.
  - Reduced repetitive warnings by limiting duplicate drop and connection-context logs.
- **Configuration**
  - Added support for configuring dropped-message logging through MQTT settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
