### PR TITLE
* FIX [broker] free expired sqlite QoS msg in resend getopt loop

### DIFF
--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -1790,6 +1790,12 @@ tcptran_pipe_getopt(
 				    is_sqlite, p->npipe->nano_qos_db, rmsg);
 				nni_qos_db_remove(is_sqlite,
 				    p->npipe->nano_qos_db, p->npipe->p_id, pid);
+				// sqlite get_one returns a solely-owned deserialized
+				// msg; free it on the expired path like the sibling
+				// branch below does, otherwise it leaks
+				if (is_sqlite) {
+					nni_msg_free(rmsg);
+				}
 				continue;
 
 			} else if ((ntime - mtime) >= (long unsigned) qos_duration * 1250) {

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -1806,6 +1806,12 @@ tlstran_pipe_getopt(
 				    is_sqlite, p->npipe->nano_qos_db, rmsg);
 				nni_qos_db_remove(is_sqlite,
 				    p->npipe->nano_qos_db, p->npipe->p_id, pid);
+				// sqlite get_one returns a solely-owned deserialized
+				// msg; free it on the expired path like the sibling
+				// branch below does, otherwise it leaks
+				if (is_sqlite) {
+					nni_msg_free(rmsg);
+				}
 				continue;
 
 			} else if ((ntime - mtime) >= (long unsigned) qos_duration * 1250) {

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -1608,6 +1608,12 @@ wstran_pipe_getopt(void *arg, const char *name, void *buf, size_t *szp, nni_type
 				log_info("QoS msg id %u of pipe %u expired!", pid, p->npipe->p_id);
 				nni_qos_db_remove_msg(is_sqlite, p->npipe->nano_qos_db, rmsg);
 				nni_qos_db_remove(is_sqlite, p->npipe->nano_qos_db, p->npipe->p_id, pid);
+				// sqlite get_one returns a solely-owned deserialized
+				// msg; free it on the expired path like the sibling
+				// branch below does, otherwise it leaks
+				if (is_sqlite) {
+					nni_msg_free(rmsg);
+				}
 				continue;
 			} else if ((ntime - mtime) >= (long unsigned) qos_duration * 1250) {
 				if (!is_sqlite) {


### PR DESCRIPTION
## Summary

The QoS resend getopt loop in all three broker transports (tcp/tls/ws) leaks one `nni_msg` per expired offline QoS message on the sqlite backend.

## Details

In `{tcp,tls,ws}tran_pipe_getopt` (`NMQ_OPT_MQTT_GET_QOS_RESEND`), `nni_mqtt_qos_db_get_one` returns a freshly deserialized, solely-owned `nni_msg` for the sqlite backend. The expired-message branch removes the row and `continue`s without freeing that msg:

```c
nni_qos_db_remove_msg(is_sqlite, ..., rmsg); // only serializes rmsg to build the DELETE key; does not free it
nni_qos_db_remove(is_sqlite, ..., pid);
continue;                                     // rmsg leaks (sqlite)
```

The sibling too-young branch already frees it (`if (is_sqlite) nni_msg_free(msg)`), so this is an asymmetry: every expired offline QoS row leaks one deserialized msg. The in-memory backend is unaffected (the id-map owns the msg).

## Fix

Free `rmsg` on the expired path in all three transports, mirroring the sibling branch.

## Validation

Builds clean with `-DNNG_ENABLE_SQLITE=ON -DNNG_ENABLE_TLS=ON` across all three transports. Independent of the offline-QoS redelivery work in #1560 (the leak predates it on `main`).