### PR TITLE
* FIX [http] do not exit the process when conn fini races a canceled aio

### DIFF
--- a/src/core/reap.c
+++ b/src/core/reap.c
@@ -110,6 +110,7 @@ nni_reap_sys_init(void)
 	if ((rv = nni_thr_init(&reap_thr, reap_worker, NULL)) != 0) {
 		return (rv);
 	}
+	reap_exit = false; // may be left set by a prior nni_reap_sys_fini
 	nni_thr_run(&reap_thr);
 	return (0);
 }

--- a/src/supplemental/http/http_conn.c
+++ b/src/supplemental/http/http_conn.c
@@ -712,14 +712,29 @@ nni_http_conn_setopt(nni_http_conn *conn, const char *name, const void *buf,
 void
 nni_http_conn_fini(nni_http_conn *conn)
 {
+	nni_aio *fe = NULL;
+
 	nni_mtx_lock(&conn->mtx);
-	if ((nni_aio_schedule(conn->wr_aio, nng_wr_fr_cb, conn)) != 0) {
-		log_error("Non recoverable error, aio schedule failed!");
-		exit(EXIT_FAILURE);
+	// If the aio carries a latched abort (a user operation was canceled
+	// while the internal aio was idle) or was already stopped, schedule
+	// fails.  No operation is in flight in that case, so simply mark
+	// that side finished instead of treating it as fatal.
+	if (nni_aio_schedule(conn->wr_aio, nng_wr_fr_cb, conn) != 0) {
+		log_debug("conn %p fini: wr_aio aborted/stopped, "
+		          "finishing write side directly", conn);
+		conn->wr_close = true;
 	}
-	if ((nni_aio_schedule(conn->rd_aio, nng_rd_fr_cb, conn)) != 0) {
-		log_error("Non recoverable error, aio schedule failed!");
-		exit(EXIT_FAILURE);
+	if (nni_aio_schedule(conn->rd_aio, nng_rd_fr_cb, conn) != 0) {
+		log_debug("conn %p fini: rd_aio aborted/stopped, "
+		          "finishing read side directly", conn);
+		conn->rd_close = true;
+	}
+	if (conn->wr_close && conn->rd_close && (conn->fe_aio != NULL)) {
+		// Neither free callback will fire, so the final free is on
+		// us.  Reap fe_aio only after we are done touching conn --
+		// its callback frees the conn.
+		fe           = conn->fe_aio;
+		conn->fe_aio = NULL;
 	}
 	conn->free = true;
 	http_close(conn);
@@ -731,6 +746,9 @@ nni_http_conn_fini(nni_http_conn *conn)
 	} else {
 		nni_aio_reap(conn->wr_aio);
 		nni_aio_reap(conn->rd_aio);
+	}
+	if (fe != NULL) {
+		nni_aio_reap(fe);
 	}
 }
 

--- a/src/supplemental/http/http_conn.c
+++ b/src/supplemental/http/http_conn.c
@@ -279,13 +279,19 @@ nng_wr_fr_cb(nng_aio *aio, void *arg, int rv)
 	NNI_ARG_UNUSED(aio);
 	NNI_ARG_UNUSED(rv);
 	nni_http_conn *conn = arg;
+	nni_aio       *fe   = NULL;
 	nni_mtx_lock(&conn->mtx);
 	conn->wr_close = true;
 	if (conn->rd_close) {
-		nni_aio_reap(conn->fe_aio);
+		fe           = conn->fe_aio;
 		conn->fe_aio = NULL;
 	}
 	nni_mtx_unlock(&conn->mtx);
+	// Reaping fe_aio frees the conn (nng_http_fr_cb), so do it only
+	// after we are done touching conn.
+	if (fe != NULL) {
+		nni_aio_reap(fe);
+	}
 }
 
 void
@@ -294,13 +300,19 @@ nng_rd_fr_cb(nng_aio *aio, void *arg, int rv)
 	NNI_ARG_UNUSED(aio);
 	NNI_ARG_UNUSED(rv);
 	nni_http_conn *conn = arg;
+	nni_aio       *fe   = NULL;
 	nni_mtx_lock(&conn->mtx);
 	conn->rd_close = true;
 	if (conn->wr_close) {
-		nni_aio_reap(conn->fe_aio);
+		fe           = conn->fe_aio;
 		conn->fe_aio = NULL;
 	}
 	nni_mtx_unlock(&conn->mtx);
+	// Reaping fe_aio frees the conn (nng_http_fr_cb), so do it only
+	// after we are done touching conn.
+	if (fe != NULL) {
+		nni_aio_reap(fe);
+	}
 }
 
 void
@@ -713,6 +725,8 @@ void
 nni_http_conn_fini(nni_http_conn *conn)
 {
 	nni_aio *fe = NULL;
+	nni_aio *waio;
+	nni_aio *raio;
 
 	nni_mtx_lock(&conn->mtx);
 	// If the aio carries a latched abort (a user operation was canceled
@@ -737,15 +751,20 @@ nni_http_conn_fini(nni_http_conn *conn)
 		conn->fe_aio = NULL;
 	}
 	conn->free = true;
+	waio       = conn->wr_aio;
+	raio       = conn->rd_aio;
 	http_close(conn);
 	nni_mtx_unlock(&conn->mtx);
 
-	if (!nni_aio_busy(conn->rd_aio) && !nni_aio_busy(conn->wr_aio)) {
-		nni_aio_free(conn->wr_aio);
-		nni_aio_free(conn->rd_aio);
+	// Once either aio below is freed or reaped, its free callback may
+	// run and (via fe_aio) free the conn, so past this point only the
+	// local copies may be touched.
+	if (!nni_aio_busy(raio) && !nni_aio_busy(waio)) {
+		nni_aio_free(waio);
+		nni_aio_free(raio);
 	} else {
-		nni_aio_reap(conn->wr_aio);
-		nni_aio_reap(conn->rd_aio);
+		nni_aio_reap(waio);
+		nni_aio_reap(raio);
 	}
 	if (fe != NULL) {
 		nni_aio_reap(fe);


### PR DESCRIPTION
## Summary

The `linux` CI job fails intermittently on main and on unrelated PR branches, always in the websocket family:

- `nng.supplemental.websocket_test` — `***Timeout 180s`, hung mid test;
- `nng.ws` / `nng.wss` — `Assertion Failed (Given transport)` at `tests/trantest.h:227` (`tt->tran != NULL`), i.e. `nni_sp_tran_find()` suddenly returning NULL for a scheme that resolved fine moments earlier in the same process.

I suspect the flakiness comes from `nni_http_conn_fini`, which treats a failed `nni_aio_schedule` as non-recoverable and calls `exit(EXIT_FAILURE)`. The failure is actually a routine teardown race: when a user operation pending on the conn is canceled (e.g. the websocket layer closing its tx/rx aio during pipe teardown) while the internal `rd_aio`/`wr_aio` happens to be idle, `http_rd_cancel`/`http_wr_cancel` latch an abort on the internal aio (`a_abort`/`a_result`). Only `nni_aio_begin` clears that latch, and fini schedules the free callbacks without begin — so the next schedule returns the latched `NNG_ECLOSED`, and the process dies from a library thread. The preceding `log_error` is invisible in tests because nothing calls `log_init`, which is why the failures look so mysterious in CI.

The `exit()` also explains both CI shapes. Test binaries link the test library, which registers `atexit(nng_fini)`: when `exit()` runs on the reap thread, `nni_fini` first empties the sp transport registry (the convey main thread then re-runs `trantest_init` and trips `tt->tran != NULL`), and then blocks in `nni_reap_drain` waiting for the reap thread — the very thread that called exit — so the process hangs until ctest kills it at 180s.

While reproducing this I hit a second, related teardown bug: `reap.c`'s static `reap_exit` is set by `nni_reap_sys_fini` and never cleared, so after an `nng_fini`/`nng_init` cycle in one process the new reap worker exits immediately and the next `nng_fini` hangs forever in `nni_reap_drain`.

## Fix

- `nni_http_conn_fini`: a failed schedule means the aio was stopped or carries a latched abort, so no operation can be in flight — mark that side of the connection finished and continue the normal deferred-free sequence instead of exiting. If both sides are already finished, the final free is on us; the `fe_aio` reap is deferred to the end of fini because its callback frees the conn. The fatal branches now emit `log_debug` breadcrumbs instead of `log_error`+`exit`.
- `nni_reap_sys_init`: reset `reap_exit`.

## Validation

Reproduced locally on main (`d1c73d6`) by stressing `tests/ws`, `tests/wss` and `websocket_test` concurrently so their teardown paths race: an instrumented build (abort instead of exit) fires exactly at the suspected branch with rv=`NNG_ECLOSED`, on the reap thread inside `ws_fini → nni_http_conn_fini`, and a registry dump at the failing `trantest_init` shows the transport list cleanly emptied — both matching the CI signatures. After the fix, the same stress produces zero occurrences of either signature (several hundred iterations), `websocket_test` runs clean, and the full ctest suite matches the unpatched baseline. A deterministic variant (running multiple test cases in one process, which exercises the fini/init cycle) hung on every run before the reap fix and passes 40/40 after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service restart reliability by correctly resetting shutdown state during startup.
  * Prevented certain connection shutdown conditions from causing fatal application exits.
  * Improved cleanup handling for connections with already-stopped or aborted operations.
  * Reduced the risk of resource cleanup issues during HTTP connection teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->