### PR TITLE
FIX [mqtt_ws] stop qsaio ack-send cb from double-finishing user tx aio

### DIFF
--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -154,18 +154,20 @@ wstran_pipe_qos_send_cb(void *arg)
 	nni_msg *qmsg;
 	ws_pipe *p     = arg;
 	nni_aio *qsaio = p->qsaio;
-	nni_aio *uaio  = p->user_txaio;
 
 	if ((rv = nni_aio_result(qsaio)) != 0) {
-		log_warn(" send aio error %s", nng_strerror(rv));
 		nni_msg *msg;
+		log_warn(" send aio error %s", nng_strerror(rv));
+		nni_mtx_lock(&p->mtx);
 		if ((msg = nni_aio_get_msg(p->qsaio)) != NULL) {
 			nni_msg_free(msg);
+			nni_aio_set_msg(p->qsaio, NULL);
 		}
-		if (uaio != NULL) {
-			nni_aio_finish_error(uaio, rv);
-		}
-		// wstran_pipe_close(p);
+		nni_mtx_unlock(&p->mtx);
+		// qsaio only ever carries broker-generated QoS ACKs, never a user
+		// send.  Finishing p->user_txaio here (unlocked) raced the locked
+		// finish in wstran_pipe_send_cb and double-dispatched the same
+		// aio's completion task -> nni_list_append panic / stuck task_busy.
 		return;
 	}
 


### PR DESCRIPTION
## What

Fix a data race in the MQTT-over-WebSocket transport where the QoS ACK-send
completion callback (`wstran_pipe_qos_send_cb`) finishes the user's downstream
tx aio (`p->user_txaio`) **without holding `p->mtx`**, on the ACK-send error path.

`p->qsaio` only ever carries broker-generated QoS ACK packets (PUBACK / PUBREC /
PUBREL / PUBCOMP). Completing `p->user_txaio` from that callback is both
semantically wrong (the user's publish is unrelated to an ACK send) and racy: it
runs concurrently with the lock-held finish of the same aio in
`wstran_pipe_send_cb`, so the user tx aio's completion **task gets dispatched
twice**.

## Impact

Under same-clientid WebSocket takeover churn (the CI `ws_test` pattern: one
clientid rapidly reconnecting so pipes collide on a single clientid-hash id and
continuously kick each other), the double dispatch corrupts the taskq list:

```
panic: appending node already on a list or not inited
  nni_list_append          core/list.c
  nni_task_dispatch        core/taskq.c
  nni_aio_finish_error     core/aio.c
  wstran_pipe_send_cb      sp/transport/mqttws/nmq_websocket.c
```

In builds compiled without that list assertion the same double dispatch leaves
the aio's `task_busy` counter stuck above zero, so a later
`nni_aio_stop(&p->aio_recv)` during pipe teardown never returns.

## Fix

Drop the unlocked `user_txaio` finish from the error path entirely (the tx path
already completes `user_txaio` on its own), and free the qsaio's own message
under `p->mtx`, matching the locking already used on the success path.

## Reproduction / validation

Local ASAN + DEBUG build (`-DDEBUG=ON -DASAN=ON -DNNG_ENABLE_TLS=ON
-DNNG_ENABLE_SQLITE=ON`), broker throttled to 2 cores, driven by a loop of
same-clientid `ws_test` websocket connect/sub/pub(QoS 0/1/2)/disconnect cycles:

- **Before:** panic above reproduces at ~12k churn cycles (~76 s).
- **After:** ran cleanly past 53k cycles (~150 s) with no panic.

## Related — still open

This fixes the crash/`task_busy` half of the WebSocket-listener wedge described
in nanomq/nanomq#2388, but not all of it. Under the same churn plus malformed
MQTT-over-ws floods, the single nng reap thread still deadlocks permanently
tearing down a ws pipe:

```
nng:reap2
  nni_task_wait          core/taskq.c
  nni_aio_stop  &p->aio_recv
  nano_pipe_stop         sp/protocol/mqtt/nmq_mqtt.c:552
  pipe_destroy           core/pipe.c
  reap_worker            core/reap.c
```

Because reaping is single-threaded, that stalls **all** pipe teardown: closed ws
pipes leak without bound (RSS climbs steadily, broker pegs ~150% CPU in the ws
recv path) until the broker OOMs or stops servicing new ws upgrades. That
recv-aio teardown path needs its own fix and is left for a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of MQTT WebSocket QoS acknowledgment send failures.
  * Prevented duplicate completion processing that could cause transmission tasks to become stuck or trigger runtime errors.
  * Improved synchronization when cleaning up failed acknowledgment messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
↩︎ Upstream context: surfaced while investigating the ws-listener wedge that nanomq/nanomq#2388 bounded with its `run_bounded()` guard rail — a related double-finish crash in the same transport under the CI churn.
