### PR TITLE
FIX [mqtt_ws] complete recv/send aio on cancel so pipe reaping can't wedge

### DIFF
--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -604,6 +604,12 @@ done:
 	// Return the first msg this time
 	nni_aio_set_msg(uaio, smsg);
 skip:
+	// Release ownership of the user recv aio before finishing it, so a
+	// concurrent wstran_pipe_recv_cancel sees user_rxaio != aio and does
+	// not finish it a second time (mirrors wstran_pipe_send_cb).
+	if (uaio == p->user_rxaio) {
+		p->user_rxaio = NULL;
+	}
 	nni_aio_set_output(uaio, 0, p);
 	nni_aio_finish(uaio, p->err_code, 0);
 	nni_mtx_unlock(&p->mtx);
@@ -627,6 +633,9 @@ reset:
 		rv = NNG_ECONNABORTED;
 		nni_aio_finish_error(p->ep_aio, rv);
 	} else if (uaio != NULL) {
+		if (uaio == p->user_rxaio) {
+			p->user_rxaio = NULL;
+		}
 		nni_aio_set_msg(uaio, NULL);
 		nni_aio_finish_error(uaio,
 		    p->err_code == MQTT_SUCCESS ? rv : (int) p->err_code);
@@ -659,8 +668,13 @@ wstran_pipe_recv_cancel(nni_aio *aio, void *arg, int rv)
 	}
 	p->user_rxaio = NULL;
 	nni_aio_abort(p->rxaio, rv);
-	// nni_aio_finish_error(aio, rv);
 	nni_mtx_unlock(&p->mtx);
+	// The rxaio-completion path finishes the user recv aio only while
+	// p->user_rxaio still points at it; we just cleared it, so complete it
+	// here.  Otherwise its task_busy never drains and a later
+	// nni_aio_stop(&p->aio_recv) during pipe teardown -- run on the single
+	// nng reap thread -- blocks forever, halting all pipe reaping.
+	nni_aio_finish_error(aio, rv);
 }
 
 static void
@@ -707,6 +721,10 @@ wstran_pipe_send_cancel(nni_aio *aio, void *arg, int rv)
 	p->user_txaio = NULL;
 	nni_aio_abort(p->txaio, rv);
 	nni_mtx_unlock(&p->mtx);
+	// See wstran_pipe_recv_cancel: the send-completion path only finishes
+	// the user tx aio while p->user_txaio still points at it, so finish it
+	// here now that we cleared it, otherwise nni_aio_stop() on it hangs.
+	nni_aio_finish_error(aio, rv);
 }
 
 static inline void

--- a/src/supplemental/http/http_conn.c
+++ b/src/supplemental/http/http_conn.c
@@ -713,13 +713,15 @@ void
 nni_http_conn_fini(nni_http_conn *conn)
 {
 	nni_mtx_lock(&conn->mtx);
+	// A stopped aio (the peer connection is being torn down concurrently)
+	// makes nni_aio_schedule fail; that is not fatal here -- the aio is then
+	// not busy and is freed directly below.  Killing the whole broker on a
+	// routine teardown race is wrong, so log and continue.
 	if ((nni_aio_schedule(conn->wr_aio, nng_wr_fr_cb, conn)) != 0) {
-		log_error("Non recoverable error, aio schedule failed!");
-		exit(EXIT_FAILURE);
+		log_warn("wr_aio schedule failed during http conn fini");
 	}
 	if ((nni_aio_schedule(conn->rd_aio, nng_rd_fr_cb, conn)) != 0) {
-		log_error("Non recoverable error, aio schedule failed!");
-		exit(EXIT_FAILURE);
+		log_warn("rd_aio schedule failed during http conn fini");
 	}
 	conn->free = true;
 	http_close(conn);


### PR DESCRIPTION
## What

Fixes the intermittent **WebSocket-listener wedge** in nanomq/nanomq#2388: under
sustained load the ws listener keeps accepting TCP connections but stops
completing WebSocket upgrades, and the broker's memory grows without bound.

## Root cause (stack-backed)

`wstran_pipe_recv_cancel` clears `p->user_rxaio` and aborts the internal
`rxaio`, but never completes the user recv aio itself — the direct finish was
left commented out:

```c
p->user_rxaio = NULL;
nni_aio_abort(p->rxaio, rv);
// nni_aio_finish_error(aio, rv);   <-- disabled
```

Once `user_rxaio` is cleared, the `rxaio`-completion path in
`wstran_pipe_recv_cb` also skips finishing it. So when a ws recv is in flight at
teardown, the recv aio is never completed and its `task_busy` never drains.
`nano_pipe_stop` then blocks permanently:

```
nng:reap2
  nni_cv_wait / nni_task_wait          core/taskq.c
  nni_aio_stop  &p->aio_recv           core/aio.c
  nano_pipe_stop                       sp/protocol/mqtt/nmq_mqtt.c
  pipe_destroy                         core/pipe.c
  reap_worker                          core/reap.c
```

Pipe reaping is single-threaded, so one stuck ws pipe halts **all** pipe
teardown: every closed ws pipe leaks, RSS climbs steadily, the broker pegs a
core in the ws recv path, and eventually it OOMs or stops servicing new ws
upgrades (the wedge). `wstran_pipe_send_cancel` has the identical latent defect.

## Fix

1. `wstran_pipe_recv_cancel` / `wstran_pipe_send_cancel`: finish the user aio
   after aborting the internal aio, so `task_busy` always drains.
2. `wstran_pipe_recv_cb`: release `p->user_rxaio` before finishing it (as
   `wstran_pipe_send_cb` already does for `user_txaio`), so a concurrent cancel
   sees `user_rxaio != aio` and cannot double-finish it.
3. `nni_http_conn_fini`: completing the recv aio slightly reorders teardown,
   which exposed a second latent bug — the function called `exit(EXIT_FAILURE)`
   if it could not reschedule the http conn's `wr_aio`/`rd_aio`, killing the
   whole broker on a routine concurrent-teardown race. A failed reschedule just
   means the aio is not busy and is freed directly below, so it now logs and
   continues.

## Validation

Local ASAN + DEBUG build, broker pinned to 2 cores, driven by same-clientid ws
takeover churn plus malformed MQTT-over-ws floods and cached-session
(`clean_start=0`) takeover:

| | before | after |
|---|---|---|
| reap thread | deadlocked in `nano_pipe_stop -> nni_aio_stop` | cycles normally |
| RSS under load | climbs ~22 MB/s to OOM | flat (~440 MB) |
| new ws upgrade | eventually wedges | completes in ~1 s throughout |
| broker | OOM / `exit(EXIT_FAILURE)` | stays up, no panic |

Pairs with nanomq/NanoNNG#1577 (a separate qsaio double-finish crash in the same
transport); the two changes are independent and touch different functions.


---
↩︎ Upstream context: this is the "third broker bug" (ws-listener wedge) that nanomq/nanomq#2388 worked around with the `run_bounded()` guard rail on the ws stages.
