### PR TITLE
Add new field ex_lmq_size for caching parquet flush

### DIFF
--- a/include/nng/supplemental/nanolib/conf.h
+++ b/include/nng/supplemental/nanolib/conf.h
@@ -656,7 +656,9 @@ struct conf_web_hook {
 
 	nng_mtx  *ex_mtx; // mutex for saios
 	nng_aio  *ex_aio; // Await flush
+	nng_aio  *ex_midaio; // Forward flush reqs in ex_aio cb
 	nng_aio **saios;  // Aios for sending message
+	nng_lmq  *ex_lmq; // Lmq for await flush
 
 	// TODO not support yet
 	conf_tls tls;

--- a/include/nng/supplemental/nanolib/conf.h
+++ b/include/nng/supplemental/nanolib/conf.h
@@ -659,6 +659,7 @@ struct conf_web_hook {
 	nng_aio  *ex_midaio; // Forward flush reqs in ex_aio cb
 	nng_aio **saios;  // Aios for sending message
 	nng_lmq  *ex_lmq; // Lmq for await flush
+	size_t    ex_lmq_size; // Capacity of ex lmq
 
 	// TODO not support yet
 	conf_tls tls;

--- a/src/supplemental/nanolib/conf.c
+++ b/src/supplemental/nanolib/conf.c
@@ -1129,8 +1129,9 @@ conf_init(conf *nanomq_conf)
 	nanomq_conf->web_hook.header_count   = 0;
 	nanomq_conf->web_hook.rules          = NULL;
 	nanomq_conf->web_hook.rule_count     = 0;
-	nanomq_conf->web_hook.cancel_timeout 	 = (nng_duration) 5000;
+	nanomq_conf->web_hook.cancel_timeout = (nng_duration) 5000;
 	nanomq_conf->web_hook.saios          = NULL;
+	nanomq_conf->web_hook.ex_lmq_size    = 0;
 	conf_tls_init(&nanomq_conf->web_hook.tls);
 
 	nanomq_conf->exchange.count           = 0;
@@ -1359,6 +1360,7 @@ print_webhook_conf(conf_web_hook *webhook)
 			}
 		}
 	}
+	log_info("webhook ex lmq size: %zu", webhook->ex_lmq_size);
 }
 
 static void
@@ -4421,6 +4423,10 @@ conf_web_hook_parse(conf_web_hook *webhook, const char *path)
 		} else if ((value = get_conf_value(
 		                line, sz, "web.hook.pool_size")) != NULL) {
 			webhook->pool_size = (size_t) atol(value);
+			free(value);
+		} else if ((value = get_conf_value(
+		                line, sz, "web.hook.ex_lmq_size")) != NULL) {
+			webhook->ex_lmq_size = (size_t) atol(value);
 			free(value);
 		} else if ((value = get_conf_value(
 		                line, sz, "web.hook.cancel_timeout")) != NULL) {

--- a/src/supplemental/nanolib/conf_ver2.c
+++ b/src/supplemental/nanolib/conf_ver2.c
@@ -844,6 +844,7 @@ conf_webhook_parse_ver2(conf *config, cJSON *jso)
 		    webhook, pool_size, "pool_size", jso_webhook);
 		hocon_read_num_base(
 		    webhook, cancel_timeout, "cancel_timeout", jso_webhook);
+		hocon_read_num(webhook, ex_lmq_size, jso_webhook);
 		cJSON    *jso_webhook_tls = hocon_get_obj("ssl", jso_webhook);
 		conf_tls *webhook_tls     = &(webhook->tls);
 		conf_tls_parse_ver2_base(webhook_tls, jso_webhook_tls);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support for controlling the webhook flush queue size.
  * Added support for asynchronous flush handling in webhooks.
  * Included the new queue setting in webhook configuration output and version 2 configuration parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->