### PR TITLE
move QoS ACK logic from transport to protocol layer

### DIFF
--- a/src/mqtt/protocol/mqtt/mqtt_client.c
+++ b/src/mqtt/protocol/mqtt/mqtt_client.c
@@ -920,6 +920,8 @@ mqtt_recv_cb(void *arg)
 	mqtt_sock_t *s          = p->mqtt_sock;
 	nni_aio     *user_aio   = NULL;
 	nni_msg     *cached_msg = NULL;
+	nni_msg     *msg	    = NULL;
+	nni_msg     *ack_msg    = NULL;
 	mqtt_ctx_t  *ctx;
 
 	if ((rv = nni_aio_result(&p->recv_aio)) != 0) {
@@ -930,8 +932,11 @@ mqtt_recv_cb(void *arg)
 	}
 
 	nni_mtx_lock(&s->mtx);
-	nni_msg *msg = nni_aio_get_msg(&p->recv_aio);
+	msg = nni_aio_get_msg(&p->recv_aio);
+	ack_msg = nni_aio_get_prov_data(&p->recv_aio);
 	nni_aio_set_msg(&p->recv_aio, NULL);
+	nni_aio_set_prov_data(&p->recv_aio, NULL);
+
 	if (nni_atomic_get_bool(&s->closed) ||
 	    nni_atomic_get_bool(&p->closed)) {
 		// free msg and dont return data when pipe is closed.
@@ -941,12 +946,17 @@ mqtt_recv_cb(void *arg)
 			nni_stat_inc(&s->msg_recv_drop, 1);
 #endif
 		}
+		if (ack_msg) {
+			nni_msg_free(ack_msg);
+#ifdef NNG_ENABLE_STATS
+			nni_stat_inc(&s->msg_send_drop, 1);
+#endif
+		}
 		nni_mtx_unlock(&s->mtx);
 		return;
 	}
-	nni_msg *ack_msg = NULL;
-	if ((ack_msg = nni_aio_get_prov_data(&p->recv_aio)) != NULL) {
-		nni_aio_set_prov_data(&p->recv_aio, NULL);
+
+	if (ack_msg  != NULL) {
 		if (!p->busy) {
 			p->busy = true;
 			nni_aio_set_msg(&p->send_aio, ack_msg);

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -1164,7 +1164,7 @@ nano_pipe_recv_cb(void *arg)
 		if (p->conn_param) {
 			p->conn_param->will_flag = 0;
 		} else {
-			// nni_pipe_close(p->pipe);
+			log_warn("Null conn_param detected!");
 			break;
 		}
 		if (p->conn_param->pro_ver == MQTT_VERSION_V5) {

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -1116,15 +1116,32 @@ nano_pipe_recv_cb(void *arg)
 	log_trace(" ######### nano_pipe_recv_cb ######### ");
 	p->ka_refresh = 0;
 	msg           = nni_aio_get_msg(&p->aio_recv);
+	nni_aio_set_msg(&p->aio_recv, NULL);
 	if (msg == NULL) {
 		goto end;
 	}
 	if (nni_atomic_get_bool(&p->closed)) {
+		// If we are closed, then we can't return data.
+		// This drops DISCONNECT packet.
 		nni_msg_free(msg);
+		log_trace("pipe is closed abruptly!");
 		return;
 	}
-
-	// ttl = nni_atomic_get(&s->ttl);
+	nni_mtx_lock(&p->lk);
+	nni_msg *ack_msg = NULL;
+	if ((ack_msg = nni_aio_get_prov_data(&p->aio_recv)) != NULL) {
+		nni_aio_set_prov_data(&p->aio_recv, NULL);
+		if (!p->busy) {
+			p->busy = true;
+			nni_aio_set_msg(&p->aio_send, ack_msg);
+			nni_pipe_send(p->pipe, &p->aio_send);
+		} else {
+			if (0 != nni_lmq_put(&p->rlmq, ack_msg)) {
+				log_warn("Warning! ack msg lost due to busy socket");
+				nni_msg_free(ack_msg);
+			}
+		}
+	}
 	nni_msg_set_pipe(msg, p->id);
 	ptr    = nni_msg_body(msg);
 	cparam = p->conn_param;
@@ -1147,7 +1164,7 @@ nano_pipe_recv_cb(void *arg)
 		if (p->conn_param) {
 			p->conn_param->will_flag = 0;
 		} else {
-			nni_pipe_close(p->pipe);
+			// nni_pipe_close(p->pipe);
 			break;
 		}
 		if (p->conn_param->pro_ver == MQTT_VERSION_V5) {
@@ -1172,7 +1189,7 @@ nano_pipe_recv_cb(void *arg)
 		} else {
 			nni_atomic_set(&p->reason_code, 0x00);
 		}
-		nni_pipe_close(p->pipe);
+		// pipe close must be called without lock
 		break;
 	case CMD_CONNACK:
 	case CMD_PUBLISH:
@@ -1182,16 +1199,14 @@ nano_pipe_recv_cb(void *arg)
 	case CMD_PUBACK:
 	case CMD_PUBCOMP:
 		// rid marks packet ID of resend QoS msg
-		nni_mtx_lock(&p->lk);
 		NNI_GET16(ptr, ackid);
 		p->rid = ackid + 1;
-		nni_mtx_unlock(&p->lk);
 	case CMD_CONNECT:
 	case CMD_PUBREC:
 	case CMD_PUBREL:
+		nni_mtx_unlock(&p->lk);
 		goto drop;
 	case CMD_PINGREQ:
-		nni_mtx_lock(&p->lk);
 		nni_msg_clone(s->pingmsg);
 		if (!p->busy) {
 			p->busy = true;
@@ -1205,21 +1220,11 @@ nano_pipe_recv_cb(void *arg)
 		nni_mtx_unlock(&p->lk);
 		goto drop;
 	default:
+		nni_mtx_unlock(&p->lk);
 		goto drop;
 	}
+	nni_mtx_unlock(&p->lk);
 	nni_mtx_lock(&s->lk);
-	if (nni_atomic_get_bool(&p->closed)) {
-		// If we are closed, then we can't return data.
-		// This drops DISCONNECT packet.
-		nni_aio_set_msg(&p->aio_recv, NULL);
-		nni_msg_free(msg);
-		if (type == CMD_SUBSCRIBE || type == CMD_UNSUBSCRIBE ||
-		    type == CMD_CONNACK || type == CMD_PUBLISH)
-			conn_param_free(cparam);
-		log_trace("pipe is closed abruptly!");
-		nni_mtx_unlock(&s->lk);
-		return;
-	}
 
 	if ((ctx = nni_list_first(&s->recvq)) == NULL) {
 		// No one waiting to receive yet, holding pattern.
@@ -1252,9 +1257,12 @@ nano_pipe_recv_cb(void *arg)
 	ctx->pipe_id = p->id;
 	log_trace("currently processing pipe_id: %d", p->id);
 	nni_mtx_unlock(&s->lk);
-
-	// schedule another receive
-	nni_pipe_recv(p->pipe, &p->aio_recv);
+	if (type == CMD_DISCONNECT) {
+		nni_pipe_close(p->pipe);
+	} else {
+		// schedule another receive
+		nni_pipe_recv(p->pipe, &p->aio_recv);
+	}
 	nni_aio_set_msg(aio, msg);
 	nni_aio_finish_sync(aio, 0, nni_msg_len(msg));
 	log_trace("end of nano_pipe_recv_cb %p", ctx);

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -1120,12 +1120,13 @@ nano_pipe_recv_cb(void *arg)
 	msg           = nni_aio_get_msg(&p->aio_recv);
 	ack_msg       = nni_aio_get_prov_data(&p->aio_recv);
 	nni_aio_set_prov_data(&p->aio_recv, NULL);
-	// nni_aio_set_msg(&p->aio_recv, NULL);
 	if (nni_atomic_get_bool(&p->closed)) {
 		// If we are closed, then we can't return data.
 		// This drops DISCONNECT packet.
-		if (msg)
+		if (msg) {
+			nni_aio_set_msg(&p->aio_recv, NULL);
 			nni_msg_free(msg);
+		}
 		if (ack_msg != NULL) {
 			nni_msg_free(ack_msg);
 		}

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -1132,8 +1132,7 @@ nano_pipe_recv_cb(void *arg)
 		return;
 	}
 	nni_mtx_lock(&p->lk);
-	nni_msg *ack_msg = NULL;
-	if ((ack_msg = nni_aio_get_prov_data(&p->aio_recv)) != NULL) {
+	if (ack_msg  != NULL) {
 		nni_aio_set_prov_data(&p->aio_recv, NULL);
 		if (!p->busy) {
 			p->busy = true;

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -1120,6 +1120,8 @@ nano_pipe_recv_cb(void *arg)
 	msg           = nni_aio_get_msg(&p->aio_recv);
 	ack_msg       = nni_aio_get_prov_data(&p->aio_recv);
 	nni_aio_set_prov_data(&p->aio_recv, NULL);
+	// Do not set aio_recv msg NULL here, breaks CI.
+	// nng_ctx_recv could get msg from aio_recv directly
 	if (nni_atomic_get_bool(&p->closed)) {
 		// If we are closed, then we can't return data.
 		// This drops DISCONNECT packet.

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -1115,11 +1115,12 @@ nano_pipe_recv_cb(void *arg)
 		return;
 	}
 	log_trace(" ######### nano_pipe_recv_cb ######### ");
+	nni_mtx_lock(&p->lk);
 	p->ka_refresh = 0;
 	msg           = nni_aio_get_msg(&p->aio_recv);
 	ack_msg       = nni_aio_get_prov_data(&p->aio_recv);
 	nni_aio_set_prov_data(&p->aio_recv, NULL);
-	nni_aio_set_msg(&p->aio_recv, NULL);
+	// nni_aio_set_msg(&p->aio_recv, NULL);
 	if (nni_atomic_get_bool(&p->closed)) {
 		// If we are closed, then we can't return data.
 		// This drops DISCONNECT packet.
@@ -1131,7 +1132,6 @@ nano_pipe_recv_cb(void *arg)
 		log_trace("pipe is closed abruptly!");
 		return;
 	}
-	nni_mtx_lock(&p->lk);
 	if (ack_msg  != NULL) {
 		nni_aio_set_prov_data(&p->aio_recv, NULL);
 		if (!p->busy) {

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -1103,7 +1103,8 @@ nano_pipe_recv_cb(void *arg)
 	nano_sock  *s      = p->broker;
 	conn_param *cparam = NULL;
 	nano_ctx   *ctx;
-	nni_msg    *msg;
+	nni_msg    *msg     = NULL;
+	nni_msg    *ack_msg = NULL;
 	nni_aio    *aio;
 	int         rv = 0;
 
@@ -1116,14 +1117,17 @@ nano_pipe_recv_cb(void *arg)
 	log_trace(" ######### nano_pipe_recv_cb ######### ");
 	p->ka_refresh = 0;
 	msg           = nni_aio_get_msg(&p->aio_recv);
+	ack_msg       = nni_aio_get_prov_data(&p->aio_recv);
+	nni_aio_set_prov_data(&p->aio_recv, NULL);
 	nni_aio_set_msg(&p->aio_recv, NULL);
-	if (msg == NULL) {
-		goto end;
-	}
 	if (nni_atomic_get_bool(&p->closed)) {
 		// If we are closed, then we can't return data.
 		// This drops DISCONNECT packet.
-		nni_msg_free(msg);
+		if (msg)
+			nni_msg_free(msg);
+		if (ack_msg != NULL) {
+			nni_msg_free(ack_msg);
+		}
 		log_trace("pipe is closed abruptly!");
 		return;
 	}
@@ -1141,6 +1145,10 @@ nano_pipe_recv_cb(void *arg)
 				nni_msg_free(ack_msg);
 			}
 		}
+	}
+	if (msg == NULL) {
+		nni_mtx_unlock(&p->lk);
+		goto end;
 	}
 	nni_msg_set_pipe(msg, p->id);
 	ptr    = nni_msg_body(msg);

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -1133,10 +1133,10 @@ nano_pipe_recv_cb(void *arg)
 			nni_msg_free(ack_msg);
 		}
 		log_trace("pipe is closed abruptly!");
+		nni_mtx_unlock(&p->lk);
 		return;
 	}
 	if (ack_msg  != NULL) {
-		nni_aio_set_prov_data(&p->aio_recv, NULL);
 		if (!p->busy) {
 			p->busy = true;
 			nni_aio_set_msg(&p->aio_send, ack_msg);

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -946,43 +946,7 @@ tcptran_pipe_recv_cb(void *arg)
 		    qmsg, packet_id, reason_code, prop, p->pro_ver);
 		property_free(prop);
 		nni_mqtt_pubres_header_encode(qmsg, ack_cmd);
-		// TODO move ack msg logic to protocol layer for safety.
-		if (p->busy == false) {
-			iov[0].iov_len = nni_msg_header_len(qmsg);
-			iov[0].iov_buf = nni_msg_header(qmsg);
-			iov[1].iov_len = nni_msg_len(qmsg);
-			iov[1].iov_buf = nni_msg_body(qmsg);
-			p->busy        = true;
-			nni_aio_set_msg(p->qsaio, qmsg);
-			// send ACK down...
-			nni_aio_set_iov(p->qsaio, 2, iov);
-			nng_stream_send(p->conn, p->qsaio);
-		} else {
-			log_debug("resend ack later");
-			if (nni_lmq_full(&p->rslmq)) {
-				// Make space for the new message.
-				if (nni_lmq_cap(&p->rslmq) <= NANO_MAX_QOS_PACKET) {
-					if ((rv = nni_lmq_resize(&p->rslmq,
-					         nni_lmq_cap(&p->rslmq) * 2)) == 0) {
-						if (nni_lmq_put(&p->rslmq, qmsg) != 0)
-							nni_msg_free(qmsg);
-					} else {
-						// memory error.
-						nni_msg_free(qmsg);
-						log_error("Failed to resize ACK lmq %d", rv);
-					}
-				} else {
-					nni_msg *old;
-					(void) nni_lmq_get(&p->rslmq, &old);
-					nni_msg_free(old);
-					if (nni_lmq_put(&p->rslmq, qmsg) != 0)
-						nni_msg_free(qmsg);
-				}
-			} else {
-				if (nni_lmq_put(&p->rslmq, qmsg) != 0)
-					nni_msg_free(qmsg);
-			}
-		}
+		nni_aio_set_prov_data(aio, qmsg);
 		ack = false;
 	}
 

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -44,10 +44,8 @@ struct tcptran_pipe {
 	uint8_t        *qos_buf; // msg trunk for qos & V4/V5 conversion
 	nni_aio        *txaio;
 	nni_aio        *rxaio;
-	nni_aio        *qsaio;   // send qos ack/rel
 	nni_aio        *rpaio;   // reply DISCONNECT/PING
 	nni_aio        *negoaio; // deal with connect
-	nni_lmq         rslmq;
 	nni_msg        *rxmsg, *cnmsg;
 	nni_mtx         mtx;
 	conn_param     *tcp_cparam;
@@ -150,7 +148,6 @@ tcptran_pipe_close(void *arg)
 		nni_free(p->npipe->subinfol, sizeof(nni_list));
 		p->npipe->subinfol = NULL;
 	}
-	nni_lmq_flush(&p->rslmq);
 	conn_param_free(p->tcp_cparam);
 	nni_mtx_unlock(&p->mtx);
 
@@ -158,7 +155,6 @@ tcptran_pipe_close(void *arg)
 	nni_aio_close(p->rxaio);
 	nni_aio_close(p->rpaio);
 	nni_aio_close(p->txaio);
-	nni_aio_close(p->qsaio);
 	nni_aio_close(p->negoaio);
 
 	log_trace("tcptran_pipe_close\n");
@@ -169,7 +165,6 @@ tcptran_pipe_stop(void *arg)
 {
 	tcptran_pipe *p = arg;
 
-	nni_aio_stop(p->qsaio);
 	nni_aio_stop(p->rpaio);
 	nni_aio_stop(p->rxaio);
 	nni_aio_stop(p->txaio);
@@ -243,12 +238,10 @@ tcptran_pipe_fini(void *arg)
 	nni_mtx_unlock(&p->mtx);
 
 	nng_stream_free(p->conn);
-	nni_aio_free(p->qsaio);
 	nni_aio_free(p->rpaio);
 	nni_aio_free(p->rxaio);
 	nni_aio_free(p->txaio);
 	nni_aio_free(p->negoaio);
-	nni_lmq_fini(&p->rslmq);
 	nni_mtx_fini(&p->mtx);
 	NNI_FREE_STRUCT(p);
 }
@@ -274,14 +267,10 @@ tcptran_pipe_alloc(tcptran_pipe **pipep)
 		return (NNG_ENOMEM);
 	}
 	nni_mtx_init(&p->mtx);
-	if (((rv = nni_aio_alloc(&p->txaio, nmq_tcptran_pipe_send_cb, p)) !=
-	        0) ||
-	    ((rv = nni_aio_alloc(
-	          &p->qsaio, nmq_tcptran_pipe_qos_send_cb, p)) != 0) ||
+	if (((rv = nni_aio_alloc(&p->txaio, nmq_tcptran_pipe_send_cb, p)) != 0) ||
 	    ((rv = nni_aio_alloc(&p->rpaio, nmq_tcptran_pipe_rp_send_cb, p)) != 0) ||
 	    ((rv = nni_aio_alloc(&p->rxaio, tcptran_pipe_recv_cb, p)) != 0) ||
-	    ((rv = nni_aio_alloc(&p->negoaio, tcptran_pipe_nego_cb, p)) !=
-	        0)) {
+	    ((rv = nni_aio_alloc(&p->negoaio, tcptran_pipe_nego_cb, p)) != 0)) {
 		tcptran_pipe_fini(p);
 		return (rv);
 	}
@@ -487,76 +476,6 @@ error:
 	log_error("connect nego error rv:(%d)", rv);
 	return;
 }
-
-static void
-nmq_tcptran_pipe_qos_send_cb(void *arg)
-{
-	tcptran_pipe *p = arg;
-	nni_msg      *msg;
-	nni_aio      *qsaio = p->qsaio;
-	uint8_t       type;
-	size_t        n;
-	int           rv;
-
-	if ((rv = nni_aio_result(qsaio)) != 0) {
-		log_warn(" send aio error %s", nng_strerror(rv));
-		nni_msg_free(nni_aio_get_msg(qsaio));
-		nni_aio_set_msg(qsaio, NULL);
-		tcptran_pipe_close(p);
-		return;
-	}
-	if (nni_atomic_get_bool(&p->closed)) {
-		msg = nni_aio_get_msg(qsaio);
-		nni_msg_free(msg);
-		return;
-	}
-	nni_mtx_lock(&p->mtx);
-	n = nni_aio_count(qsaio);
-	nni_aio_iov_advance(qsaio, n);
-
-	// more bytes to send
-	if (nni_aio_iov_count(qsaio) > 0) {
-		nng_stream_send(p->conn, qsaio);
-		nni_mtx_unlock(&p->mtx);
-		return;
-	}
-	msg = nni_aio_get_msg(qsaio);
-	if (msg != NULL)
-		type = nni_msg_cmd_type(msg);
-	else {
-		log_warn("NULL msg detected in send_cb");
-		nni_mtx_unlock(&p->mtx);
-		tcptran_pipe_close(p);
-		return;
-	}
-
-	if (p->pro_ver == MQTT_PROTOCOL_VERSION_v5) {
-		(type == CMD_PUBCOMP || type == CMD_PUBACK) ? p->qrecv_quota++
-		                                            : p->qrecv_quota;
-	}
-	nni_msg_free(msg);
-	nni_aio_set_msg(qsaio, NULL);
-	if (nni_lmq_get(&p->rslmq, &msg) == 0) {
-		nni_iov iov[2];
-		iov[0].iov_len = nni_msg_header_len(msg);
-		iov[0].iov_buf = nni_msg_header(msg);
-		iov[1].iov_len = nni_msg_len(msg);
-		iov[1].iov_buf = nni_msg_body(msg);
-		nni_aio_set_msg(qsaio, msg);
-		// send it down...
-		nni_aio_set_iov(qsaio, 2, iov);
-		nng_stream_send(p->conn, qsaio);
-		p->busy = true;
-		nni_mtx_unlock(&p->mtx);
-		return;
-	}
-
-	p->busy = false;
-	nni_aio_set_msg(qsaio, NULL);
-	nni_mtx_unlock(&p->mtx);
-	return;
-}
-
 
 static void
 nmq_tcptran_pipe_rp_send_cb(void *arg)
@@ -998,7 +917,6 @@ tcptran_pipe_send_cancel(nni_aio *aio, void *arg, int rv)
 		nni_mtx_unlock(&p->mtx);
 		return;
 	}
-	nni_aio_abort(p->qsaio, rv);
 	nni_aio_list_remove(aio);
 	nni_mtx_unlock(&p->mtx);
 

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -87,7 +87,6 @@ struct tcptran_ep {
 static void tcptran_pipe_send_start(tcptran_pipe *);
 static void tcptran_pipe_recv_start(tcptran_pipe *);
 static void nmq_tcptran_pipe_send_cb(void *);
-static void nmq_tcptran_pipe_qos_send_cb(void *);
 static void nmq_tcptran_pipe_rp_send_cb(void *arg);
 static void tcptran_pipe_recv_cb(void *);
 static void tcptran_pipe_nego_cb(void *);
@@ -189,7 +188,6 @@ tcptran_pipe_init(void *arg, nni_pipe *npipe)
 	p->conn_buf = NULL;
 	p->busy     = false;
 
-	nni_lmq_init(&p->rslmq, 16);
 	p->qos_buf = nng_zalloc(16 + NNI_NANO_MAX_PACKET_SIZE);
 	p->npipe->subinfol = nni_zalloc(sizeof(nni_list));
 	if (p->npipe->subinfol == NULL) {

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -91,7 +91,6 @@ struct tlstran_ep {
 static void tlstran_pipe_send_start(tlstran_pipe *);
 static void tlstran_pipe_recv_start(tlstran_pipe *);
 static void tlstran_pipe_send_cb(void *);
-static void tlstran_pipe_qos_send_cb(void *);
 static void tlstran_pipe_recv_cb(void *);
 static void tlstran_pipe_nego_cb(void *);
 static void tlstran_ep_fini(void *);

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -44,10 +44,8 @@ struct tlstran_pipe {
 	uint8_t        *qos_buf; // msg trunk for qos & V4/V5 conversion
 	nni_aio        *txaio;
 	nni_aio        *rxaio;
-	nni_aio        *qsaio;   // send qos ack/rel
 	nni_aio        *rpaio;   // reply DISCONNECT/PING
 	nni_aio        *negoaio; // deal with connect
-	nni_lmq         rslmq;
 	nni_msg        *rxmsg, *cnmsg;
 	nni_mtx         mtx;
 	conn_param     *tcp_cparam;
@@ -153,7 +151,6 @@ tlstran_pipe_close(void *arg)
 		nni_free(p->npipe->subinfol, sizeof(nni_list));
 		p->npipe->subinfol = NULL;
 	}
-	nni_lmq_flush(&p->rslmq);
 	conn_param_free(p->tcp_cparam);
 	nni_mtx_unlock(&p->mtx);
 
@@ -161,7 +158,6 @@ tlstran_pipe_close(void *arg)
 	nni_aio_close(p->rxaio);
 	nni_aio_close(p->rpaio);
 	nni_aio_close(p->txaio);
-	nni_aio_close(p->qsaio);
 	nni_aio_close(p->negoaio);
 
 	log_trace("tlstran_pipe_close\n");
@@ -171,8 +167,7 @@ static void
 tlstran_pipe_stop(void *arg)
 {
 	tlstran_pipe *p = arg;
-	
-	nni_aio_stop(p->qsaio);
+
 	nni_aio_stop(p->rpaio);
 	nni_aio_stop(p->rxaio);
 	nni_aio_stop(p->txaio);
@@ -200,7 +195,6 @@ tlstran_pipe_init(void *arg, nni_pipe *npipe)
 	p->conn_buf = NULL;
 	p->busy     = false;
 
-	nni_lmq_init(&p->rslmq, 16);
 	nni_atomic_init_bool(&p->closed);
 	p->qos_buf = nng_zalloc(16 + NNI_NANO_MAX_PACKET_SIZE);
 	p->npipe->subinfol = nni_zalloc(sizeof(nni_list));
@@ -250,13 +244,11 @@ tlstran_pipe_fini(void *arg)
 	nni_mtx_unlock(&p->mtx);
 
 	nng_stream_free(p->conn);
-	nni_aio_free(p->qsaio);
 	nni_aio_free(p->rpaio);
 	nni_aio_free(p->rxaio);
 	nni_aio_free(p->txaio);
 	nni_aio_free(p->negoaio);
 
-	nni_lmq_fini(&p->rslmq);
 	nni_mtx_fini(&p->mtx);
 	log_trace(" ************ tlstran_pipe_finit [%p] ************ ", p);
 	NNI_FREE_STRUCT(p);
@@ -284,7 +276,6 @@ tlstran_pipe_alloc(tlstran_pipe **pipep)
 	}
 	nni_mtx_init(&p->mtx);
 	if (((rv = nni_aio_alloc(&p->txaio, tlstran_pipe_send_cb, p)) != 0) ||
-	    ((rv = nni_aio_alloc(&p->qsaio, tlstran_pipe_qos_send_cb, p)) != 0) ||
 	    ((rv = nni_aio_alloc(&p->rpaio, NULL, p)) != 0) ||
 	    ((rv = nni_aio_alloc(&p->rxaio, tlstran_pipe_recv_cb, p)) != 0) ||
 	    ((rv = nni_aio_alloc(&p->negoaio, tlstran_pipe_nego_cb, p)) !=
@@ -489,74 +480,6 @@ error:
 	tlstran_pipe_reap(p);
 	log_error("connect nego error rv:(%d) %s MQTT reason code %d",
 			  rv, nng_strerror(rv), code);
-	return;
-}
-
-static void
-tlstran_pipe_qos_send_cb(void *arg)
-{
-	tlstran_pipe *p = arg;
-	nni_msg      *msg;
-	nni_aio      *qsaio = p->qsaio;
-	uint8_t       type;
-	size_t        n;
-	int           rv;
-
-	if ((rv = nni_aio_result(qsaio)) != 0) {
-		log_warn(" send aio error %s", nng_strerror(rv));
-		nni_msg_free(nni_aio_get_msg(qsaio));
-		nni_aio_set_msg(qsaio, NULL);
-		tlstran_pipe_close(p);
-		return;
-	}
-	if (nni_atomic_get_bool(&p->closed)) {
-		msg = nni_aio_get_msg(qsaio);
-		nni_msg_free(msg);
-		return;
-	}
-	nni_mtx_lock(&p->mtx);
-	n = nni_aio_count(qsaio);
-	nni_aio_iov_advance(qsaio, n);
-	if (nni_aio_iov_count(qsaio) > 0) {
-		nng_stream_send(p->conn, qsaio);
-		nni_mtx_unlock(&p->mtx);
-		return;
-	}
-	msg = nni_aio_get_msg(qsaio);
-	if (msg != NULL)
-		type = nni_msg_cmd_type(msg);
-	else {
-		log_warn("NULL msg detected in send_cb");
-		nni_mtx_unlock(&p->mtx);
-		tlstran_pipe_close(p);
-		return;
-	}
-
-	if (p->pro_ver == MQTT_PROTOCOL_VERSION_v5) {
-		(type == CMD_PUBCOMP || type == CMD_PUBACK) ? p->qrecv_quota++
-		                                        : p->qrecv_quota;
-	}
-	nni_msg_free(msg);
-	nni_aio_set_msg(qsaio, NULL);
-	// not very sure if this cause fragmented msg
-	if (nni_lmq_get(&p->rslmq, &msg) == 0) {
-		nni_iov iov;
-		nni_msg_insert(
-		    msg, nni_msg_header(msg), nni_msg_header_len(msg));
-		iov.iov_len = nni_msg_len(msg);
-		iov.iov_buf = nni_msg_body(msg);
-		nni_aio_set_msg(qsaio, msg);
-		// send it down...
-		nni_aio_set_iov(qsaio, 1, &iov);
-		nng_stream_send(p->conn, p->qsaio);
-		p->busy = true;
-		nni_mtx_unlock(&p->mtx);
-		return;
-	}
-
-	p->busy = false;
-	nni_aio_set_msg(qsaio, NULL);
-	nni_mtx_unlock(&p->mtx);
 	return;
 }
 
@@ -985,7 +908,6 @@ tlstran_pipe_send_cancel(nni_aio *aio, void *arg, int rv)
 		nni_mtx_unlock(&p->mtx);
 		return;
 	}
-	nni_aio_abort(p->qsaio, rv);
 	nni_aio_list_remove(aio);
 	nni_mtx_unlock(&p->mtx);
 

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -857,7 +857,6 @@ tlstran_pipe_recv_cb(void *arg)
 		property_free(prop);
 		nni_mqtt_pubres_header_encode(qmsg, ack_cmd);
 		nni_aio_set_prov_data(aio, qmsg);
-		nni_aio_set_prov_data(aio, qmsg);
 		ack = false;
 	}
 

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -929,50 +929,13 @@ tlstran_pipe_recv_cb(void *arg)
 			goto recv_error;
 		}
 		// TODO set reason code or property here if necessary
-
 		nni_msg_set_cmd_type(qmsg, ack_cmd);
 		nni_mqtt_msgack_encode(
 		    qmsg, packet_id, reason_code, prop, p->pro_ver);
 		property_free(prop);
 		nni_mqtt_pubres_header_encode(qmsg, ack_cmd);
-		// if (prop != NULL) {
-		// nni_msg_proto_set_property(qmsg, prop);
-		// }
-		if (p->busy == false) {
-			nni_msg_insert(qmsg, nni_msg_header(qmsg),
-			    nni_msg_header_len(qmsg));
-			iov[0].iov_len = nni_msg_len(qmsg);
-			iov[0].iov_buf = nni_msg_body(qmsg);
-			p->busy        = true;
-			nni_aio_set_msg(p->qsaio, qmsg);
-			// send ACK down...
-			nni_aio_set_iov(p->qsaio, 1, iov);
-			nng_stream_send(p->conn, p->qsaio);
-			log_trace("QoS ACK msg sent!");
-		} else {
-			if (nni_lmq_full(&p->rslmq)) {
-				// Make space for the new message. TODO add max
-				// limit of msgq len in conf
-				if (nni_lmq_cap(&p->rslmq) <=
-				    NANO_MAX_QOS_PACKET) {
-					if ((rv = nni_lmq_resize(&p->rslmq,
-					         nni_lmq_cap(&p->rslmq) *
-					             2)) == 0) {
-						nni_lmq_put(&p->rslmq, qmsg);
-					} else {
-						// memory error.
-						nni_msg_free(qmsg);
-					}
-				} else {
-					nni_msg *old;
-					(void) nni_lmq_get(&p->rslmq, &old);
-					nni_msg_free(old);
-					nni_lmq_put(&p->rslmq, qmsg);
-				}
-			} else {
-				nni_lmq_put(&p->rslmq, qmsg);
-			}
-		}
+		nni_aio_set_prov_data(aio, qmsg);
+		nni_aio_set_prov_data(aio, qmsg);
 		ack = false;
 	}
 

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -1363,7 +1363,6 @@ wstran_pipe_fini(void *arg)
 	nni_aio_free(p->txaio);
 	nni_mtx_fini(&p->mtx);
 	nni_lmq_fini(&p->recvlmq);
-	nni_lmq_fini(&p->rslmq);
 	log_trace(" ************ wstran_pipe_fini [%p] ************ ", p);
 	NNI_FREE_STRUCT(p);
 }

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -507,8 +507,7 @@ done:
 			ack     = true;
 		} else if (cmd == CMD_PUBACK || cmd == CMD_PUBCOMP) {
 			if ((rv = nni_mqtt_pubres_decode(vmsg, &packet_id,
-			         &reason_code, &prop, p->ws_param->pro_ver)) !=
-			    0) {
+			         &reason_code, &prop, p->ws_param->pro_ver)) != 0) {
 				log_warn(
 				    "decode PUBACK or PUBCOMP variable header "
 				    "failed!");
@@ -568,40 +567,7 @@ done:
 			nni_mqtt_msgack_encode(qmsg, packet_id, reason_code,
 			    prop, p->ws_param->pro_ver);
 			nni_mqtt_pubres_header_encode(qmsg, ack_cmd);
-			if (!nni_aio_busy(p->qsaio)) {
-				iov[0].iov_len = nni_msg_header_len(qmsg);
-				iov[0].iov_buf = nni_msg_header(qmsg);
-				iov[1].iov_len = nni_msg_len(qmsg);
-				iov[1].iov_buf = nni_msg_body(qmsg);
-				nni_aio_set_msg(p->qsaio, qmsg);
-				// send ACK down...
-				nni_aio_set_iov(p->qsaio, 2, iov);
-				nng_stream_send(p->ws, p->qsaio);
-			} else {
-				if (nni_lmq_full(&p->rslmq)) {
-					// Make space for the new message.
-					if (nni_lmq_cap(&p->rslmq) <= NANO_MAX_QOS_PACKET) {
-						if ((rv = nni_lmq_resize(&p->rslmq,
-						         nni_lmq_cap(&p->rslmq) * 2)) == 0) {
-							if (nni_lmq_put(&p->rslmq, qmsg) != 0)
-								nni_msg_free(qmsg);
-						} else {
-							log_warn("QoS Ack msg lost!");
-							nni_msg_free(qmsg);
-						}
-					} else {
-						nni_msg *old;
-						(void) nni_lmq_get(&p->rslmq, &old);
-						log_warn("QoS Ack msg lost!");
-						nni_msg_free(old);
-						if (nni_lmq_put(&p->rslmq, qmsg) != 0)
-							nni_msg_free(qmsg);
-					}
-				} else {
-					if (nni_lmq_put(&p->rslmq, qmsg) != 0)
-						nni_msg_free(qmsg);
-				}
-			}
+			nni_aio_set_prov_data(uaio, qmsg);
 			ack = false;
 			
 		}

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -90,6 +90,7 @@ struct ws_pipe {
 	size_t      qlength; // length of qos_buf
 	size_t      wantrxhead;
 	nni_lmq     recvlmq;
+	nni_lmq     rslmq;	// Only for QoS msg ack cache
 	conf       *conf;
 	nni_msg    *tmp_msg;	// Serving as recv buffer, convergence all msg from nng ws
 	nni_aio    *user_txaio;
@@ -97,6 +98,7 @@ struct ws_pipe {
 	nni_aio    *ep_aio;
 	nni_aio    *txaio;
 	nni_aio    *rxaio;
+	nni_aio    *qsaio;
 	nni_pipe   *npipe;
 	conn_param *ws_param;
 	nng_stream *ws;
@@ -505,7 +507,8 @@ done:
 			ack     = true;
 		} else if (cmd == CMD_PUBACK || cmd == CMD_PUBCOMP) {
 			if ((rv = nni_mqtt_pubres_decode(vmsg, &packet_id,
-			         &reason_code, &prop, p->ws_param->pro_ver)) != 0) {
+			         &reason_code, &prop, p->ws_param->pro_ver)) !=
+			    0) {
 				log_warn(
 				    "decode PUBACK or PUBCOMP variable header "
 				    "failed!");
@@ -565,7 +568,40 @@ done:
 			nni_mqtt_msgack_encode(qmsg, packet_id, reason_code,
 			    prop, p->ws_param->pro_ver);
 			nni_mqtt_pubres_header_encode(qmsg, ack_cmd);
-			nni_aio_set_prov_data(uaio, qmsg);
+			if (!nni_aio_busy(p->qsaio)) {
+				iov[0].iov_len = nni_msg_header_len(qmsg);
+				iov[0].iov_buf = nni_msg_header(qmsg);
+				iov[1].iov_len = nni_msg_len(qmsg);
+				iov[1].iov_buf = nni_msg_body(qmsg);
+				nni_aio_set_msg(p->qsaio, qmsg);
+				// send ACK down...
+				nni_aio_set_iov(p->qsaio, 2, iov);
+				nng_stream_send(p->ws, p->qsaio);
+			} else {
+				if (nni_lmq_full(&p->rslmq)) {
+					// Make space for the new message.
+					if (nni_lmq_cap(&p->rslmq) <= NANO_MAX_QOS_PACKET) {
+						if ((rv = nni_lmq_resize(&p->rslmq,
+						         nni_lmq_cap(&p->rslmq) * 2)) == 0) {
+							if (nni_lmq_put(&p->rslmq, qmsg) != 0)
+								nni_msg_free(qmsg);
+						} else {
+							log_warn("QoS Ack msg lost!");
+							nni_msg_free(qmsg);
+						}
+					} else {
+						nni_msg *old;
+						(void) nni_lmq_get(&p->rslmq, &old);
+						log_warn("QoS Ack msg lost!");
+						nni_msg_free(old);
+						if (nni_lmq_put(&p->rslmq, qmsg) != 0)
+							nni_msg_free(qmsg);
+					}
+				} else {
+					if (nni_lmq_put(&p->rslmq, qmsg) != 0)
+						nni_msg_free(qmsg);
+				}
+			}
 			ack = false;
 			
 		}
@@ -1286,6 +1322,7 @@ wstran_pipe_stop(void *arg)
 
 	nni_aio_stop(p->rxaio);
 	nni_aio_stop(p->txaio);
+	nni_aio_stop(p->qsaio);
 }
 
 static int
@@ -1321,6 +1358,7 @@ wstran_pipe_init(void *arg, nni_pipe *pipe)
 	}
 	NNI_LIST_INIT(p->npipe->subinfol, struct subinfo, node);
 	nni_lmq_init(&p->recvlmq, 1024);
+	nni_lmq_init(&p->rslmq, 1024);
 	// the size limit of qos_buf reserve 1 byte for property length
 	p->qlength = 16 + NNI_NANO_MAX_PACKET_SIZE;
 	if (!p->conf->sqlite.enable && pipe->nano_qos_db == NULL) {
@@ -1361,8 +1399,11 @@ wstran_pipe_fini(void *arg)
 	nng_stream_free(p->ws);
 	nni_aio_free(p->rxaio);
 	nni_aio_free(p->txaio);
+	nni_aio_wait(p->qsaio);
+	nni_aio_free(p->qsaio);
 	nni_mtx_fini(&p->mtx);
 	nni_lmq_fini(&p->recvlmq);
+	nni_lmq_fini(&p->rslmq);
 	log_trace(" ************ wstran_pipe_fini [%p] ************ ", p);
 	NNI_FREE_STRUCT(p);
 }
@@ -1396,10 +1437,13 @@ wstran_pipe_close(void *arg)
 		p->npipe->subinfol = NULL;
 	}
 
+	nni_lmq_flush(&p->rslmq);
 	conn_param_free(p->ws_param);
 	nni_mtx_unlock(&p->mtx);
 	nng_stream_close(p->ws);
 	nni_aio_close(p->rxaio);
+	nni_aio_abort(p->qsaio, NNG_ECANCELED);
+	nni_aio_close(p->qsaio);
 	nni_aio_close(p->txaio);
 }
 
@@ -1416,6 +1460,7 @@ wstran_pipe_alloc(ws_pipe **pipep, void *ws)
 
 	// Initialize AIOs.
 	if (((rv = nni_aio_alloc(&p->txaio, wstran_pipe_send_cb, p)) != 0) ||
+	    ((rv = nni_aio_alloc(&p->qsaio, wstran_pipe_qos_send_cb, p)) != 0) ||
 	    ((rv = nni_aio_alloc(&p->rxaio, wstran_pipe_recv_cb, p)) != 0)) {
 		wstran_pipe_fini(p);
 		return (rv);

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -90,7 +90,6 @@ struct ws_pipe {
 	size_t      qlength; // length of qos_buf
 	size_t      wantrxhead;
 	nni_lmq     recvlmq;
-	nni_lmq     rslmq;	// Only for QoS msg ack cache
 	conf       *conf;
 	nni_msg    *tmp_msg;	// Serving as recv buffer, convergence all msg from nng ws
 	nni_aio    *user_txaio;
@@ -98,7 +97,6 @@ struct ws_pipe {
 	nni_aio    *ep_aio;
 	nni_aio    *txaio;
 	nni_aio    *rxaio;
-	nni_aio    *qsaio;
 	nni_pipe   *npipe;
 	conn_param *ws_param;
 	nng_stream *ws;
@@ -1288,7 +1286,6 @@ wstran_pipe_stop(void *arg)
 
 	nni_aio_stop(p->rxaio);
 	nni_aio_stop(p->txaio);
-	nni_aio_stop(p->qsaio);
 }
 
 static int
@@ -1324,7 +1321,6 @@ wstran_pipe_init(void *arg, nni_pipe *pipe)
 	}
 	NNI_LIST_INIT(p->npipe->subinfol, struct subinfo, node);
 	nni_lmq_init(&p->recvlmq, 1024);
-	nni_lmq_init(&p->rslmq, 1024);
 	// the size limit of qos_buf reserve 1 byte for property length
 	p->qlength = 16 + NNI_NANO_MAX_PACKET_SIZE;
 	if (!p->conf->sqlite.enable && pipe->nano_qos_db == NULL) {
@@ -1365,8 +1361,6 @@ wstran_pipe_fini(void *arg)
 	nng_stream_free(p->ws);
 	nni_aio_free(p->rxaio);
 	nni_aio_free(p->txaio);
-	nni_aio_wait(p->qsaio);
-	nni_aio_free(p->qsaio);
 	nni_mtx_fini(&p->mtx);
 	nni_lmq_fini(&p->recvlmq);
 	nni_lmq_fini(&p->rslmq);
@@ -1403,13 +1397,10 @@ wstran_pipe_close(void *arg)
 		p->npipe->subinfol = NULL;
 	}
 
-	nni_lmq_flush(&p->rslmq);
 	conn_param_free(p->ws_param);
 	nni_mtx_unlock(&p->mtx);
 	nng_stream_close(p->ws);
 	nni_aio_close(p->rxaio);
-	nni_aio_abort(p->qsaio, NNG_ECANCELED);
-	nni_aio_close(p->qsaio);
 	nni_aio_close(p->txaio);
 }
 
@@ -1426,7 +1417,6 @@ wstran_pipe_alloc(ws_pipe **pipep, void *ws)
 
 	// Initialize AIOs.
 	if (((rv = nni_aio_alloc(&p->txaio, wstran_pipe_send_cb, p)) != 0) ||
-	    ((rv = nni_aio_alloc(&p->qsaio, wstran_pipe_qos_send_cb, p)) != 0) ||
 	    ((rv = nni_aio_alloc(&p->rxaio, wstran_pipe_recv_cb, p)) != 0)) {
 		wstran_pipe_fini(p);
 		return (rv);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MQTT acknowledgment flow across TCP and TLS by simplifying the ACK delivery path and ensuring ACKs are tied to the active receive operation.
  - Fixed cleanup so both received messages and associated acknowledgment/processing data are released correctly when connections or pipes close.
  - Enhanced disconnect handling with clearer warnings when connection parameters are missing.
  - Improved retransmission/cancel behavior by removing the prior QoS ACK resend mechanism and adjusting lifecycle handling to avoid stale in-flight operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->