### PR TITLE
Add ex_busy and remove ex_midaio. Update location of field of refcnt in conn_param

### DIFF
--- a/include/nng/supplemental/nanolib/conf.h
+++ b/include/nng/supplemental/nanolib/conf.h
@@ -656,7 +656,7 @@ struct conf_web_hook {
 
 	nng_mtx  *ex_mtx; // mutex for saios
 	nng_aio  *ex_aio; // Await flush
-	nng_aio  *ex_midaio; // Forward flush reqs in ex_aio cb
+	bool      ex_busy; // Is busy in flush
 	nng_aio **saios;  // Aios for sending message
 	nng_lmq  *ex_lmq; // Lmq for await flush
 	size_t    ex_lmq_size; // Capacity of ex lmq

--- a/src/core/message.h
+++ b/src/core/message.h
@@ -101,9 +101,9 @@ struct pipe_db {
 
 // TODO use ZALLOC later
 struct conn_param {
+	nni_atomic_int     refcnt;
 	nng_time           will_delay_interval;
 	nng_time           msg_expiry_interval;
-	nni_atomic_int     refcnt;
 	char               ip_addr_v4[16];
 	// Server-side listening port (string), used by HTTP auth %p
 	char               server_port[8];

--- a/src/supplemental/nanolib/conf.c
+++ b/src/supplemental/nanolib/conf.c
@@ -1132,6 +1132,7 @@ conf_init(conf *nanomq_conf)
 	nanomq_conf->web_hook.cancel_timeout = (nng_duration) 5000;
 	nanomq_conf->web_hook.saios          = NULL;
 	nanomq_conf->web_hook.ex_lmq_size    = 0;
+	nanomq_conf->web_hook.ex_busy        = false;
 	conf_tls_init(&nanomq_conf->web_hook.tls);
 
 	nanomq_conf->exchange.count           = 0;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web hook flush handling to more reliably track active forwarding operations.
  * Ensured web hook state starts in an idle condition during configuration initialization.
  * Updated internal connection state layout to support more consistent message and connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->