### PR TITLE
Add no local config reader & improve cmakelist for new ver of msquic

### DIFF
--- a/include/nng/supplemental/nanolib/conf.h
+++ b/include/nng/supplemental/nanolib/conf.h
@@ -224,6 +224,7 @@ typedef struct conf_websocket conf_websocket;
 #define NO_QOS    3 // default QoS level value for forwarding bridge msg, 3 = keep old qos
 
 typedef struct {
+	bool        nolocal;
 	char       *remote_topic;
 	uint32_t    remote_topic_len;
 	char       *local_topic;
@@ -236,7 +237,6 @@ typedef struct {
 	uint32_t    prefix_len;
 	char       *suffix;
 	uint32_t    suffix_len;
-	uint8_t     nolocal;
 	uint8_t     retain; // override for retain
 	uint8_t     qos;    // override for QoS
 	uint8_t     retain_as_published;

--- a/src/supplemental/nanolib/conf_ver2.c
+++ b/src/supplemental/nanolib/conf_ver2.c
@@ -1174,6 +1174,7 @@ conf_session_node_parse(conf_session_node *node, cJSON *obj)
 	{
 		topics *s = NNI_ALLOC_STRUCT(s);
 		s->retain = NO_RETAIN;
+		s->nolocal = true;
 		hocon_read_str(s, remote_topic, subscription);
 		hocon_read_num(s, qos, subscription);
 		cJSON *jso_key = cJSON_GetObjectItem(subscription, "retain");
@@ -1183,6 +1184,7 @@ conf_session_node_parse(conf_session_node *node, cJSON *obj)
 		}
 		hocon_read_num(s, retain_as_published, subscription);
 		hocon_read_num(s, retain_handling, subscription);
+		hocon_read_bool(s, nolocal, subscription);
 		s->remote_topic_len = strlen(s->remote_topic);
 		s->stream_id = 0;
 		hocon_read_num(s, stream_id, subscription);

--- a/src/supplemental/quic/CMakeLists.txt
+++ b/src/supplemental/quic/CMakeLists.txt
@@ -34,7 +34,7 @@ if (NNG_ENABLE_QUIC)
     endif()
 
     nng_include_directories("$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/build/_deps/opensslquic-build/openssl/include>")    
-    # nng_include_directories(${CMAKE_SOURCE_DIR}/build/_deps/opensslquic-build/openssl/include)
+    nng_include_directories(${CMAKE_SOURCE_DIR}/build/_deps/opensslquic-build/openssl/include)
     ## link openssl through target
     # nng_link_libraries("${CMAKE_SOURCE_DIR}/build/_deps/opensslquic-build/openssl/lib/libssl.a")
     # nng_link_libraries("${CMAKE_SOURCE_DIR}/build/_deps/opensslquic-build/openssl/lib/libcrypto.a")

--- a/src/supplemental/quic/CMakeLists.txt
+++ b/src/supplemental/quic/CMakeLists.txt
@@ -33,11 +33,13 @@ if (NNG_ENABLE_QUIC)
         nng_link_libraries(ws2_32)
     endif()
 
-    nng_include_directories("$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/build/_deps/opensslquic-build/openssl/include>")    
-    nng_include_directories(${CMAKE_SOURCE_DIR}/build/_deps/opensslquic-build/openssl/include)
-    ## link openssl through target
-    # nng_link_libraries("${CMAKE_SOURCE_DIR}/build/_deps/opensslquic-build/openssl/lib/libssl.a")
-    # nng_link_libraries("${CMAKE_SOURCE_DIR}/build/_deps/opensslquic-build/openssl/lib/libcrypto.a")
+    nng_include_directories("$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/_deps/opensslquic-build/include>")
+    nng_include_directories(${CMAKE_BINARY_DIR}/_deps/opensslquic-build/include)
+
+    nng_include_directories("$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/_deps/opensslquic-build/quictls/include>")
+    nng_include_directories(${CMAKE_BINARY_DIR}/_deps/opensslquic-build/quictls/include)
+
+    nng_include_directories("$<TARGET_PROPERTY:OpenSSL,INTERFACE_INCLUDE_DIRECTORIES>")
 
     if(NNG_PROTO_MQTT_BROKER)
         if(NOT ANDROID)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring local message delivery behavior per subscription rule through an optional `nolocal` setting.

* **Bug Fixes**
  * Improved QUIC build configuration to locate OpenSSL-related headers more reliably across build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->