### PR TITLE
support nolocal flag overwritten

### DIFF
--- a/src/supplemental/nanolib/conf_ver2.c
+++ b/src/supplemental/nanolib/conf_ver2.c
@@ -1352,8 +1352,9 @@ conf_bridge_node_parse(
 	cJSON *subscription = NULL;
 	cJSON_ArrayForEach(subscription, subscriptions)
 	{
-		topics *s = NNI_ALLOC_STRUCT(s);
-		s->retain = NO_RETAIN;
+		topics *s  = NNI_ALLOC_STRUCT(s);
+		s->retain  = NO_RETAIN;
+		s->nolocal = true;
 		hocon_read_str(s, remote_topic, subscription);
 		hocon_read_str(s, local_topic, subscription);
 		hocon_read_num(s, qos, subscription);

--- a/src/supplemental/nanolib/conf_ver2.c
+++ b/src/supplemental/nanolib/conf_ver2.c
@@ -1184,7 +1184,6 @@ conf_session_node_parse(conf_session_node *node, cJSON *obj)
 		}
 		hocon_read_num(s, retain_as_published, subscription);
 		hocon_read_num(s, retain_handling, subscription);
-		hocon_read_bool(s, nolocal, subscription);
 		s->remote_topic_len = strlen(s->remote_topic);
 		s->stream_id = 0;
 		hocon_read_num(s, stream_id, subscription);
@@ -1388,6 +1387,7 @@ conf_bridge_node_parse(
 		}
 		hocon_read_num(s, retain_as_published, subscription);
 		hocon_read_num(s, retain_handling, subscription);
+		hocon_read_bool(s, nolocal, subscription);
 		if (!s->remote_topic || !s->local_topic) {
 			log_warn("remote_topic/local_topic not found");
 			if (s->remote_topic) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the `nolocal` subscription setting.
  * Subscription entries now default to local message filtering while honoring an explicitly configured `nolocal` value.
  * Prevented subscription-level settings from being incorrectly inherited or ignored during configuration parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->