### PR TITLE
FIX [mqtt_parser] own MQTT v5 topic aliases per connection

### DIFF
--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -1684,7 +1684,8 @@ NNG_DECL void           conn_param_set_password(
 NNG_DECL void        conn_param_set_proto_ver(conn_param *cparam, uint8_t ver);
 // Topic aliases belong to the connection that registered them (MQTT 5 spec
 // 3.3.2.3.4). conn_param_get_topic_alias returns a copy owned by the caller,
-// or NULL if this connection never registered that alias.
+// which releases it with nng_strfree(), or NULL if this connection never
+// registered that alias.
 NNG_DECL void        conn_param_set_topic_alias(
            conn_param *cparam, uint32_t alias, const char *topic);
 NNG_DECL char       *conn_param_get_topic_alias(

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -1682,6 +1682,13 @@ NNG_DECL void           conn_param_set_username(
 NNG_DECL void           conn_param_set_password(
               conn_param *cparam, const char *password);
 NNG_DECL void        conn_param_set_proto_ver(conn_param *cparam, uint8_t ver);
+// Topic aliases belong to the connection that registered them (MQTT 5 spec
+// 3.3.2.3.4). conn_param_get_topic_alias returns a copy owned by the caller,
+// or NULL if this connection never registered that alias.
+NNG_DECL void        conn_param_set_topic_alias(
+           conn_param *cparam, uint32_t alias, const char *topic);
+NNG_DECL char       *conn_param_get_topic_alias(
+          conn_param *cparam, uint32_t alias);
 NNG_DECL uint64_t    conn_param_get_will_delay_timestamp(conn_param *cparam);
 NNG_DECL uint64_t    conn_param_get_will_mexp(conn_param *cparam);
 NNG_DECL void        nng_msg_set_proto_data(nng_msg *m, void *ops, void *data);

--- a/include/nng/supplemental/nanolib/hash_table.h
+++ b/include/nng/supplemental/nanolib/hash_table.h
@@ -52,17 +52,20 @@ alias_cmp(void *x_, void *y_)
 	return *alias - ele_x->alias;
 }
 
-NNG_DECL void dbhash_init_alias_table(void);
+// Topic aliases are per-connection state (MQTT 5 spec 3.3.2.3.4), so the
+// vector of alias/topic pairs belongs to the connection that registered them
+// (its conn_param) rather than to a global table keyed on pipe id. A NULL
+// vector is an empty one, and the owner is responsible for serialising
+// access; see conn_param_set_topic_alias().
 
-NNG_DECL void dbhash_destroy_alias_table(void);
 // This function do not verify value of alias and topic,
 // therefore you should make sure alias and topic is
 // not illegal.
-NNG_DECL void dbhash_insert_atpair(uint32_t pipe_id, uint32_t alias, const char *topic);
+NNG_DECL void dbhash_atpair_insert(dbhash_atpair_t ***vecp, uint32_t alias, const char *topic);
 
-NNG_DECL const char *dbhash_find_atpair(uint32_t pipe_id, uint32_t alias);
+NNG_DECL const char *dbhash_atpair_find(dbhash_atpair_t **vec, uint32_t alias);
 
-NNG_DECL void dbhash_del_atpair_queue(uint32_t pipe_id);
+NNG_DECL void dbhash_atpair_free_all(dbhash_atpair_t **vec);
 
 NNG_DECL void dbhash_init_pipe_table(void);
 

--- a/src/core/message.h
+++ b/src/core/message.h
@@ -127,6 +127,15 @@ struct conn_param {
 	uint8_t            payload_format_indicator;
 	void              *nano_qos_db; // 'sqlite' or 'nni_id_hash_map'
 	bool               assignedid;
+	// Topic aliases this connection registered. Held here, and not in a
+	// table keyed on pipe id, so that they last exactly as long as the
+	// connection plus any publish of its own still in flight: a publish
+	// the broker already acked can never lose its mapping to a concurrent
+	// disconnect, and a reconnecting client cannot inherit them.
+	// topic_alias_mtx guards the vector, as several worker ctxs may be
+	// handling publishes from this connection at once.
+	nni_mtx                 topic_alias_mtx;
+	struct dbhash_atpair_s **topic_alias; // sorted by alias, NULL if empty
 	struct mqtt_string pro_name;
 	struct mqtt_string clientid;
 	struct mqtt_string will_topic;

--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -12,6 +12,7 @@
 #include "core/zmalloc.h"
 #include "nng/protocol/mqtt/mqtt.h"
 #include "nng/protocol/mqtt/mqtt_parser.h"
+#include "nng/supplemental/nanolib/hash_table.h"
 #include "supplemental/mqtt/mqtt_msg.h"
 
 #include "nng/mqtt/packet.h"
@@ -899,6 +900,9 @@ conn_param_init(conn_param *cparam)
 	cparam->will_prop_len   = 0;
 	cparam->will_properties = NULL;
 	cparam->nano_qos_db     = NULL;
+
+	cparam->topic_alias = NULL;
+	nni_mtx_init(&cparam->topic_alias_mtx);
 }
 
 int
@@ -944,6 +948,11 @@ conn_param_free(conn_param *cparam)
 	property_free(cparam->properties);
 	property_free(cparam->will_properties);
 
+	// The last reference is gone, so no publish of this connection is
+	// still in flight and the aliases can go with it.
+	dbhash_atpair_free_all(cparam->topic_alias);
+	cparam->topic_alias = NULL;
+	nni_mtx_fini(&cparam->topic_alias_mtx);
 
 	nng_free(cparam, sizeof(struct conn_param));
 	cparam = NULL;
@@ -966,6 +975,43 @@ conn_param_clone(conn_param *cparam)
 	}
 	nni_atomic_inc(&cparam->refcnt);
 	log_trace("%p is cloned!! %d", cparam, nni_atomic_get(&cparam->refcnt));
+}
+
+// conn_param_set_topic_alias registers the alias -> topic mapping this
+// connection just published, replacing any previous topic for that alias.
+// Neither alias nor topic is validated here; the caller checks them against
+// the server's topic alias maximum first.
+void
+conn_param_set_topic_alias(conn_param *cparam, uint32_t alias, const char *topic)
+{
+	if (cparam == NULL || topic == NULL) {
+		return;
+	}
+	nni_mtx_lock(&cparam->topic_alias_mtx);
+	dbhash_atpair_insert(&cparam->topic_alias, alias, topic);
+	nni_mtx_unlock(&cparam->topic_alias_mtx);
+}
+
+// conn_param_get_topic_alias returns a copy of the topic this connection
+// registered for alias, or NULL if it registered none. The copy is made
+// under the lock, since a later publish on the same connection may replace
+// the mapping; the caller owns it and frees it with nng_strfree.
+char *
+conn_param_get_topic_alias(conn_param *cparam, uint32_t alias)
+{
+	const char *topic;
+	char       *dup = NULL;
+
+	if (cparam == NULL) {
+		return NULL;
+	}
+	nni_mtx_lock(&cparam->topic_alias_mtx);
+	if ((topic = dbhash_atpair_find(cparam->topic_alias, alias)) != NULL) {
+		dup = nng_strdup(topic);
+	}
+	nni_mtx_unlock(&cparam->topic_alias_mtx);
+
+	return dup;
 }
 
 /* Fowler/Noll/Vo (FNV) hash function, variant 1a */

--- a/src/supplemental/mqtt/mqtt_msg.c
+++ b/src/supplemental/mqtt/mqtt_msg.c
@@ -1049,6 +1049,8 @@ nni_get_conn_param_from_msg(nni_msg *msg)
 	}
 	conn_ctx->tls_peer_cn = NULL;
 	conn_ctx->tls_subject = NULL;
+	conn_ctx->topic_alias = NULL;
+	nni_mtx_init(&conn_ctx->topic_alias_mtx);
 	nni_atomic_init(&conn_ctx->refcnt);
 	nni_atomic_set(&conn_ctx->refcnt, 1);
 

--- a/src/supplemental/nanolib/hash_table.c
+++ b/src/supplemental/nanolib/hash_table.c
@@ -200,6 +200,12 @@ dbhash_atpair_insert(dbhash_atpair_t ***vecp, uint32_t a, const char *t)
 	dbhash_atpair_t **vec    = *vecp;
 	size_t            index  = 0;
 
+	if (atpair == NULL) {
+		// Keep the vector free of holes: alias_cmp would dereference
+		// one on the next lookup. The alias simply stays unregistered.
+		return;
+	}
+
 	if (true == binary_search((void **) vec, 0, &index, &a, alias_cmp)) {
 		dbhash_atpair_free(vec[index]);
 		vec[index] = atpair;

--- a/src/supplemental/nanolib/hash_table.c
+++ b/src/supplemental/nanolib/hash_table.c
@@ -25,9 +25,6 @@
 static dbhash_atpair_t *dbhash_atpair_alloc(uint32_t alias, const char *topic);
 static void             dbhash_atpair_free(dbhash_atpair_t *atpair);
 
-KHASH_MAP_INIT_INT(alias_table, dbhash_atpair_t **)
-static nni_rwlock alias_lock;
-static khash_t(alias_table) *ah = NULL;
 // avoid hash collision
 static uint8_t g_nanomq_hash_seed[16];
 
@@ -193,117 +190,64 @@ DJBHash64(char *str)
 	return hash;
 }
 
+// The alias vector is kept sorted by alias so that lookups, which happen on
+// every aliased publish, stay logarithmic. Its owner (the conn_param) holds
+// the vector and serialises access to it; see conn_param_set_topic_alias().
 void
-dbhash_init_alias_table(void)
+dbhash_atpair_insert(dbhash_atpair_t ***vecp, uint32_t a, const char *t)
 {
-	dbhash_check_init(alias_table, ah, alias_lock);
-}
-
-static dbhash_atpair_t **
-find_atpair_vec(uint32_t p)
-{
-	khint_t k = kh_get(alias_table, ah, p);
-	if (k == kh_end(ah)) {
-		return NULL;
-	}
-
-	return kh_val(ah, k);
-}
-
-void
-dbhash_insert_atpair(uint32_t p, uint32_t a, const char *t)
-{
-	int               absent;
 	dbhash_atpair_t * atpair = dbhash_atpair_alloc(a, t);
-	dbhash_atpair_t **vec    = NULL;
-	khint32_t         k      = 0;
+	dbhash_atpair_t **vec    = *vecp;
+	size_t            index  = 0;
 
-	nni_rwlock_wrlock(&alias_lock);
-	k = kh_get(alias_table, ah, p);
-	if (k == kh_end(ah)) {
-		k = kh_put(alias_table, ah, p, &absent);
+	if (true == binary_search((void **) vec, 0, &index, &a, alias_cmp)) {
+		dbhash_atpair_free(vec[index]);
+		vec[index] = atpair;
+	} else if (cvector_size(vec) == index) {
 		cvector_push_back(vec, atpair);
-		kh_value(ah, k) = vec;
-
 	} else {
-		size_t index = 0;
-		vec          = kh_val(ah, k);
-
-		if (true ==
-		    binary_search((void **) vec, 0, &index, &a, alias_cmp)) {
-			dbhash_atpair_t *tmp = vec[index];
-			dbhash_atpair_free(tmp);
-			vec[index] = atpair;
-		} else {
-			if (cvector_size(vec) == index) {
-				cvector_push_back(vec, atpair);
-			} else {
-				cvector_insert(vec, index, atpair);
-			}
-		}
-
-		kh_val(ah, k) = vec;
+		cvector_insert(vec, index, atpair);
 	}
 
-	nni_rwlock_unlock(&alias_lock);
+	*vecp = vec;
 	return;
 }
 
+// The returned topic is owned by the vector and is only valid while the
+// caller still holds the lock that guards it.
 const char *
-dbhash_find_atpair(uint32_t p, uint32_t a)
+dbhash_atpair_find(dbhash_atpair_t **vec, uint32_t a)
 {
-	nni_rwlock_rdlock(&alias_lock);
-	const char *t = NULL;
+	size_t index = 0;
 
-	dbhash_atpair_t **vec = find_atpair_vec(p);
-	if (vec) {
-		size_t index = 0;
-
-		if (true ==
-		    binary_search((void **) vec, 0, &index, &a, alias_cmp)) {
-			if (vec[index]) {
-				t = vec[index]->topic;
-			}
+	if (vec == NULL) {
+		return NULL;
+	}
+	if (true == binary_search((void **) vec, 0, &index, &a, alias_cmp)) {
+		if (vec[index]) {
+			return vec[index]->topic;
 		}
 	}
 
-	nni_rwlock_unlock(&alias_lock);
-	return t;
+	return NULL;
 }
 
 void
-dbhash_del_atpair_queue(uint32_t p)
+dbhash_atpair_free_all(dbhash_atpair_t **vec)
 {
-	nni_rwlock_wrlock(&alias_lock);
+	size_t size;
 
-	khint32_t k = kh_get(alias_table, ah, p);
-	if (k == kh_end(ah)) {
-		nni_rwlock_unlock(&alias_lock);
+	if (vec == NULL) {
 		return;
 	}
 
-	dbhash_atpair_t **vec = kh_val(ah, k);
-	;
-	if (vec) {
-		size_t size = cvector_size(vec);
-		for (size_t i = 0; i < size; i++) {
-			if (vec[i]) {
-				dbhash_atpair_free(vec[i]);
-			}
+	size = cvector_size(vec);
+	for (size_t i = 0; i < size; i++) {
+		if (vec[i]) {
+			dbhash_atpair_free(vec[i]);
 		}
-		cvector_free(vec);
 	}
-
-	kh_del(alias_table, ah, k);
-	nni_rwlock_unlock(&alias_lock);
-}
-
-void
-dbhash_destroy_alias_table(void)
-{
-	// for each
-	kh_destroy(alias_table, ah);
-	ah = NULL;
+	cvector_free(vec);
 }
 
 KHASH_MAP_INIT_INT(pipe_table, topic_queue *)

--- a/src/supplemental/nanolib/hash_test.c
+++ b/src/supplemental/nanolib/hash_test.c
@@ -50,34 +50,38 @@ assert_str(const char *s1, const char *s2)
 static void
 test_check_alias_table(void)
 {
-	const char *r = NULL;
+	dbhash_atpair_t **vec = NULL;
+	const char       *r   = NULL;
 
-	// Make sure delete on an empty table is OK!
+	// Make sure lookup on an empty vector is OK!
 	for (int i = 0; i < TABLE_SZ; i++) {
-		dbhash_del_atpair_queue(table1[i].pipe);
-		r = dbhash_find_atpair(table1[i].pipe, table1[i].key);
+		r = dbhash_atpair_find(vec, table1[i].key);
 		NUTS_TRUE(!r);
 	}
 	// Check if insert many is OK!
 	for (int i = 0; i < TABLE_SZ; i++) {
-		dbhash_insert_atpair(
-		    table1[i].pipe, table1[i].key, table1[i].topic);
-		r = dbhash_find_atpair(table1[i].pipe, table1[i].key);
+		dbhash_atpair_insert(&vec, table1[i].key, table1[i].topic);
+		r = dbhash_atpair_find(vec, table1[i].key);
 		NUTS_TRUE(NULL != r);
 		assert_str(r, table1[i].topic);
 	}
-
+	// and that the earlier aliases survived the later inserts
 	for (int i = 0; i < TABLE_SZ; i++) {
-		r = dbhash_find_atpair(table1[i].pipe, table1[i].key);
+		r = dbhash_atpair_find(vec, table1[i].key);
 		NUTS_TRUE(NULL != r);
 		assert_str(r, table1[i].topic);
 	}
-
+	// Re-registering an alias replaces the topic it maps to
 	for (int i = 0; i < TABLE_SZ; i++) {
-		dbhash_del_atpair_queue(table1[i].pipe);
-		r = dbhash_find_atpair(table1[i].pipe, table1[i].key);
-		NUTS_TRUE(NULL == r);
+		dbhash_atpair_insert(&vec, table1[i].key, table2[i].topic);
+		r = dbhash_atpair_find(vec, table1[i].key);
+		NUTS_TRUE(NULL != r);
+		assert_str(r, table2[i].topic);
 	}
+
+	dbhash_atpair_free_all(vec);
+	// Make sure free on an empty vector is OK!
+	dbhash_atpair_free_all(NULL);
 
 	return;
 }
@@ -85,17 +89,16 @@ test_check_alias_table(void)
 static void
 test_alias_table(void)
 {
-	for (size_t i = 0; i < TABLE_SZ; i++) {
-		dbhash_insert_atpair(
-		    table1[i].pipe, table1[i].key, table1[i].topic);
-		dbhash_find_atpair(table1[i].pipe, table1[i].key);
-		dbhash_del_atpair_queue(table1[i].pipe);
+	dbhash_atpair_t **vec = NULL;
 
-		dbhash_insert_atpair(
-		    table2[i].pipe, table2[i].key, table2[i].topic);
-		dbhash_find_atpair(table2[i].pipe, table2[i].key);
-		dbhash_del_atpair_queue(table2[i].pipe);
+	for (size_t i = 0; i < TABLE_SZ; i++) {
+		dbhash_atpair_insert(&vec, table1[i].key, table1[i].topic);
+		dbhash_atpair_find(vec, table1[i].key);
+
+		dbhash_atpair_insert(&vec, table2[i].key, table2[i].topic);
+		dbhash_atpair_find(vec, table2[i].key);
 	}
+	dbhash_atpair_free_all(vec);
 
 	return;
 }
@@ -301,20 +304,11 @@ test_single_thread(void *args)
 void
 hash_test(void)
 {
-	dbhash_init_alias_table();
 	dbhash_init_pipe_table();
 	dbhash_init_cached_table();
 	test_check();
 	// test_concurrent(test_single_thread);
 	test_single_thread(NULL);
-
-	for (size_t i = 0; i < TABLE_SZ; i++) {
-		const char *r =
-		    dbhash_find_atpair(table1[i].pipe, table1[i].key);
-		NUTS_TRUE(!r);
-		r = dbhash_find_atpair(table2[i].pipe, table2[i].key);
-		NUTS_TRUE(!r);
-	}
 
 	for (size_t j = 0; j < TABLE_SZ; j++) {
 		topic_queue *tq = dbhash_get_topic_queue(table1[j].key);
@@ -324,7 +318,6 @@ hash_test(void)
 		NUTS_TRUE(NULL != tq);
 	}
 
-	dbhash_destroy_alias_table();
 	dbhash_destroy_pipe_table();
 	dbhash_destroy_cached_table();
 


### PR DESCRIPTION
## Problem

MQTT v5 topic aliases lived in a global table keyed on pipe id. nanomq
overwrites the pipe id with `nanomq_siphash_32(clientid)` in
`tcptran_pipe_init` (`src/sp/transport/mqtt/broker_tcp.c`), so that table is
really keyed per client id and is shared by successive connections of one
client.

The broker deleted the key when it processed the disconnect event. But the
transport PUBACKs a QoS 1 publish as soon as it reads it off the wire, before
any app layer processing, so a client can disconnect while publishes the
broker has already acknowledged are still queued on worker ctxs. When the
disconnect event won that race, those publishes failed their alias lookup,
were dropped despite having been acknowledged, and the pipe was kicked:

```
ERROR nanomq/pub_handler.c: could not find topic by alias: 10
WARN  src/sp/protocol/mqtt/nmq_mqtt.c: pipe id <publisher> is gone, pub failed
```

## Why not the CONNACK reset

nanomq/nanomq#2391 moved the reset to CONNACK. @JaylinYu closed it, and he was
right: because the key is a client id hash, an alias record for a client that
never reconnects is never reclaimed. He asked for the state to be bound to the
connection, or for reclamation to be deferred until queued publishes have
drained. This takes the first route.

## Fix

`conn_param` is refcounted, and every message of a connection still in flight
holds a reference: `nano_pipe_recv_cb` clones it for each `CMD_PUBLISH` before
handing the message to the app layer. Owning the alias vector there gives
exactly the lifetime we want, without any new bookkeeping:

- a publish the broker has already acknowledged cannot lose its mapping to a
  concurrent disconnect, because its own reference keeps the vector alive
- the vector is freed with the last reference, so nothing is left unattended
  when a client never connects back
- a new connection parses a new `conn_param`, so it always starts empty

The global khash and the deletion on the disconnect event are both gone.
`dbhash_{init,destroy}_alias_table`, `dbhash_insert_atpair`,
`dbhash_find_atpair` and `dbhash_del_atpair_queue` are replaced by
`dbhash_atpair_insert/find/free_all`, which operate on a caller owned vector.
`conn_param_set_topic_alias` and `conn_param_get_topic_alias` wrap them with a
per `conn_param` mutex, since several worker ctxs can be handling publishes of
one connection at once, and they copy the topic out under that lock, which
`dbhash_find_atpair` did not do.

`nni_get_conn_param_from_msg` builds a `conn_param` field by field and does not
call `conn_param_init`, so it initialises the new members too.

### What this costs

Aliases are no longer shared between connections, which is the point, but it is also a memory trade worth stating. Previously every connection whose client id hashed to the same pipe id shared one vector; now each connection owns its own, so worst case alias memory is the number of live connections times up to `max_topic_alias` topics, each bounded by the packet size limit. Any single client could already pin that much for the life of its connection, so the ceiling per connection is unchanged, and the vector is freed with the connection rather than lingering under a client id key. What goes away is the accidental sharing, which was never correct.

## A second bug this fixes

MQTT 5 makes topic aliases per Network Connection state (spec 3.3.2.3.4,
MQTT-3.3.2-7). Today they survive a reconnect: the key is a client id hash, and
the cached session path sets `p->event = false` so no disconnect event is
generated to clear them. A client reconnecting with `clean_start=0` therefore
inherits the previous connection's aliases.

Register alias 9 for `per/a`, disconnect cleanly, reconnect with the same
client id and `clean_start=0` plus session expiry, then publish with an empty
topic name and alias 9:

- current `main`: the message is delivered on `per/a`
- this branch: the alias is rejected with `could not find topic by alias: 9`

## Validation

Local build on top of `8a33434a`, broker pinned to 2 cores, raw socket MQTT v5 clients.

The disconnect race does not reproduce naturally at this scale, so to make it observable I added an identical env gated `nng_msleep()` immediately before the alias lookup in `handle_pub` on both the unpatched and patched build. It stands in for a worker that has been handed a publish but has not run yet. With a 50 ms delay, 4 workers, burst of 10, 10 trials each:

- unpatched: 8 `could not find topic by alias`, 345 of 440 publishes delivered
- patched: 0, 440 of 440

On the shipped code without the delay hook, under an AddressSanitizer build (`-DDEBUG=1 -DASAN=1`, both the broker and the nng library instrumented): 2520 of 2520 aliased publishes delivered, 660 of 660 through a same client id takeover, the only two `could not find topic by alias` lines in the whole broker output being the two a stale alias probe deliberately provokes, and no ASan reports.

Under a ThreadSanitizer build of the same code, which is the interesting one since this change adds a mutex: 960 aliased publishes across 6 concurrent workers with hard disconnects, plus same client id takeovers and a kept session reconnect, produced **no data races at all**, and none naming `topic_alias`, `dbhash_atpair` or the accessors. The TSan runtime was confirmed live via its own startup banner rather than inferred from an empty report.

Per connection semantics hold, both for a clean reconnect and for a kept session. Memory is flat against `main`: 200 connections registering 200 aliases each with 200 byte topics ends at 137980 kB RSS patched versus 137528 kB unpatched, where an unfreed alias set would have been several MB.

`hash_test` passes, and bridging between two brokers still forwards, which
exercises the `nni_get_conn_param_from_msg` path.

## Residual

This fixes the lifetime, not the ordering. App layer publish processing is still not strictly ordered per connection, so an extreme overload reorder of the alias registering publish against a later lookup on the same connection remains theoretically possible. I did not observe it in 400 isolation probe trials, and it is a separate problem from the one here: closing it would need per connection ordering of `handle_pub`, which is the shape of the "defer reclamation until queued publishes have drained" option and a much larger change. Flagging it so the scope of this PR is not overstated.

## Companion

The nanomq side (`broker.c`, `pub_handler.c`, the submodule bump and a
regression test for the alias lookup path, which nothing covers today) is ready
on `jayenashar/nanomq:fix/topic-alias-conn-param` and I will raise it once this
lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MQTT topic alias support for connections.
  * Applications can register topic aliases and retrieve their associated topics.
  * Topic aliases are maintained independently for each connection.
  * Re-registering an alias updates its associated topic.
* **Bug Fixes**
  * Improved alias handling for concurrent MQTT message processing.
* **Tests**
  * Expanded coverage for alias registration, lookup, replacement, empty states, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

