### PR TITLE
fix(mqtt): Unlink receive pipes during session handoff

### DIFF
--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -566,6 +566,10 @@ nano_pipe_fini(void *arg)
 	}
 	nni_mtx_lock(&s->lk);
 	nni_mtx_lock(&p->lk);
+	if (nni_list_active(&s->recvpipes, p)) {
+		// Session handoff can bypass the normal close path.
+		nni_list_remove(&s->recvpipes, p);
+	}
 	if ((msg = nni_aio_get_msg(&p->aio_recv)) != NULL) {
 		nni_aio_set_msg(&p->aio_recv, NULL);
 	}


### PR DESCRIPTION
Defensively remove a finalized MQTT pipe from the receive list when a persistent-session handoff bypasses normal close cleanup.

No upstream issue is filed; NanoMQ TLS ASAN persistent-session churn exposed the failure. NanoMQ [PR #2406](https://github.com/nanomq/nanomq/pull/2406) will pin the canonical merged SHA.

Validated with the same ASAN workload; the broker completes the stress workload and remains responsive afterward.

I have read and agree to NanoNNG contributing guidelines.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>