### PR TITLE
fix(nmq_mqtt): don't register pipes closed during the unlocked auth window

### DIFF
--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -717,6 +717,39 @@ auth_verify:
 	}
 	nmq_connack_encode(msg, s->conf, p->conn_param, rv);
 	nni_mtx_lock(&s->lk);
+	// CONNECT verification and the HTTP auth callback above run outside
+	// s->lk, so the pipe may have been closed in the meantime (client
+	// disconnect, or a client-ID collision kick via nni_pipe_set_pid ->
+	// nni_pipe_close). Do not register a dead pipe in s->pipes: the stale
+	// entry would dangle after the pipe is reaped. A clean_start=0 close
+	// takes nano_pipe_close's session-cache path, which swaps p_closed
+	// back to false after caching, so the cache flag must be checked as
+	// well — a pipe still inside pipe_start can only be cached if it was
+	// closed during the auth window. When auth rejected the client, evict
+	// the cached entry — an unauthenticated CONNECT must not leave a
+	// stored session behind; when auth succeeded, keep the session and
+	// arm the expiry timer the successful-start path would have armed so
+	// nano_pipe_timer_cb finalizes it like any other stored session (the
+	// cached early-return in nano_pipe_close leaves aio_timer un-closed).
+	if (nni_pipe_is_closed(npipe) || nni_atomic_get_bool(&npipe->cache)) {
+		if (nni_atomic_get_bool(&npipe->cache)) {
+			if (rv != SUCCESS) {
+				if (nni_id_get(&s->cached_sessions,
+				        npipe->p_id) == p) {
+					nni_id_remove(
+					    &s->cached_sessions, npipe->p_id);
+				}
+				nni_atomic_set_bool(&npipe->cache, false);
+			} else {
+				nni_sleep_aio(
+				    s->conf->qos_duration * 1500, &p->aio_timer);
+			}
+		}
+		nni_mtx_unlock(&s->lk);
+		conn_param_free(p->conn_param);
+		nni_msg_free(msg);
+		return NNG_ECLOSED;
+	}
 	if (rv != 0) {
 		// send connack with reason code 0x05
 		log_warn("Invalid auth info or authentication denied");


### PR DESCRIPTION
## Background

We run NanoMQ (0.24.11) as an edge MQTT broker with `auth_http` enabled against a local sidecar. Under a client-ID-collision reconnect storm (two clients repeatedly reconnecting with the same client ID, one holding rejected credentials), the broker deadlocked in place for hours: process alive, all taskq threads asleep, TLS listener no longer accepting, HTTP API hung. On 0.24.11 the root cause was `nano_pipe_start` running the synchronous `nmq_auth_http_connect` while holding `s->lk` (the code even notes `// potential dead lock if HTTP fails`).

`main` has since moved CONNECT verification + HTTP auth **outside** `s->lk` — which fixes that serialization, and matches the patch we deployed. But the unlocked auth window opens a lifecycle race this PR closes.

## The race

While the HTTP auth round-trip is in flight (no `s->lk` held), the pipe can be closed:
- the client disconnects, or
- a concurrent CONNECT with the same client ID kicks it (`nni_pipe_set_pid` → `nni_pipe_close`).

`nano_pipe_start` then re-acquires `s->lk` and inserts the already-closed pipe into `s->pipes` — a stale entry that dangles once the pipe is reaped (use-after-free / wedged reconnects for that client ID).

## The fix (and two subtleties)

After re-acquiring `s->lk`, bail with `NNG_ECLOSED` when the pipe died during the auth window:

1. `nni_pipe_is_closed()` alone is insufficient: a `clean_start=0` close takes `nano_pipe_close`'s session-cache path, which swaps `p_closed` back to `false` after caching. The guard therefore also checks `npipe->cache` — a pipe still inside `pipe_start` can only be cached if it was closed during the auth window.
2. When the close cached the session, the bail arms the same `qos_duration * 1500` expiry timer the successful-start path arms. The cached early-return in `nano_pipe_close` leaves `aio_timer` un-closed, so `nano_pipe_timer_cb` finalizes the session like any other stored session instead of it accumulating in `cached_sessions` indefinitely.

The bail frees the CONNACK msg and releases the `conn_param` clone taken at the top of `pipe_start`.

## Testing

- `ninja nng` builds clean with this change (gcc 12, Debian bookworm).
- The same-shape guard (on top of a 0.24.11 backport of the auth-outside-lock restructure) is deployed on our production aarch64 broker, which previously wedged under this exact reconnect-storm scenario; it has been stable under continuous collision churn from a stale-credentialed peer.

Happy to adjust style/placement — and if a fully-async auth path is planned, this guard is still needed for any window where the pipe start yields between transport negotiation and registration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MQTT connection handling during authentication and authorization.
  - Prevented closed or unavailable connections from being registered or left in an incomplete state.
  - Ensured appropriate connection errors are returned and startup resources are released correctly.
  - Improved handling of cached sessions after authentication failures.
  - Preserved valid cached sessions and ensured their expiration timers start correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->