### PR TITLE
Restore conn_param ref counter method

### DIFF
--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -613,6 +613,7 @@ nano_pipe_init(void *arg, nni_pipe *pipe, void *s)
 	nni_aio_init(&p->aio_recv, nano_pipe_recv_cb, p);
 
 	p->conn_param  = nni_pipe_get_conn_param(pipe);
+	// Must keep one free here for safety decoupled transport & protocol 
 	conn_param_free(p->conn_param);
 	p->id          = nni_pipe_id(pipe);
 	p->rid         = 1;

--- a/src/sp/protocol/mqtt/nmq_mqtt.c
+++ b/src/sp/protocol/mqtt/nmq_mqtt.c
@@ -613,6 +613,7 @@ nano_pipe_init(void *arg, nni_pipe *pipe, void *s)
 	nni_aio_init(&p->aio_recv, nano_pipe_recv_cb, p);
 
 	p->conn_param  = nni_pipe_get_conn_param(pipe);
+	conn_param_free(p->conn_param);
 	p->id          = nni_pipe_id(pipe);
 	p->rid         = 1;
 	p->pipe        = pipe;

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -147,7 +147,7 @@ tcptran_pipe_close(void *arg)
 		nni_free(p->npipe->subinfol, sizeof(nni_list));
 		p->npipe->subinfol = NULL;
 	}
-	conn_param_free(p->tcp_cparam);
+	// conn_param_free(p->tcp_cparam);
 	nni_mtx_unlock(&p->mtx);
 
 	nng_stream_close(p->conn);

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -147,7 +147,6 @@ tcptran_pipe_close(void *arg)
 		nni_free(p->npipe->subinfol, sizeof(nni_list));
 		p->npipe->subinfol = NULL;
 	}
-	// conn_param_free(p->tcp_cparam);
 	nni_mtx_unlock(&p->mtx);
 
 	nng_stream_close(p->conn);

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -150,7 +150,6 @@ tlstran_pipe_close(void *arg)
 		nni_free(p->npipe->subinfol, sizeof(nni_list));
 		p->npipe->subinfol = NULL;
 	}
-	conn_param_free(p->tcp_cparam);
 	nni_mtx_unlock(&p->mtx);
 
 	nng_stream_close(p->conn);

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -1438,7 +1438,6 @@ wstran_pipe_close(void *arg)
 	}
 
 	nni_lmq_flush(&p->rslmq);
-	conn_param_free(p->ws_param);
 	nni_mtx_unlock(&p->mtx);
 	nng_stream_close(p->ws);
 	nni_aio_close(p->rxaio);


### PR DESCRIPTION
We have to decouple transport & protocol on the shared conn_param. I used to make it right, but accidentally break it at last ver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection lifecycle handling across MQTT, secure MQTT, and WebSocket transports.
  * Prevented connection settings from being released prematurely or redundantly during connection shutdown.
  * Increased reliability when closing and reusing transport connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->