### PR TITLE
* MDF [broker_tcp] restore default max packet size limit

### DIFF
--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -689,9 +689,9 @@ tcptran_pipe_recv_cb(void *arg)
 		// Make sure the message payload is not too big.  If it is
 		// the caller will shut down the pipe.
 		if (len > p->conf->max_packet_size) {
-			// log_error("Size of packet exceeds limitation: 0x95\n");
-			// rv = NMQ_PACKET_TOO_LARGE;
-			// goto recv_error;
+			log_error("Size of packet exceeds limitation: 0x95\n");
+			rv = NMQ_PACKET_TOO_LARGE;
+			goto recv_error;
 		}
 
 		if ((rv = nni_msg_alloc(&p->rxmsg, (size_t) len)) != 0) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced the configured maximum MQTT packet size.
  * Oversized packets are now rejected with an error instead of being received and allocated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->