### PR TITLE
* FIX [property/mqtt_parser] apply strict property checker. avoid mal…

### DIFF
--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -649,6 +649,10 @@ conn_handler(uint8_t *packet, conn_param *cparam, size_t max)
 				   len, max, cparam->prop_len, pos);
 		cparam->properties = decode_buf_properties(
 		    packet, max, &pos, &cparam->prop_len, true);
+		if (cparam->prop_len == (uint32_t)-1) {
+			log_warn("Malformed CONNECT: invalid properties payload");
+			return PROTOCOL_ERROR;
+		}
 		if (cparam->properties) {
 			conn_param_set_property(cparam, cparam->properties);
 			if ((rv = check_properties(cparam->properties, NULL)) != SUCCESS) {
@@ -697,6 +701,10 @@ conn_handler(uint8_t *packet, conn_param *cparam, size_t max)
 		if (cparam->pro_ver == MQTT_PROTOCOL_VERSION_v5) {
 			cparam->will_properties = decode_buf_properties(
 			    packet, max, &pos, &cparam->will_prop_len, true);
+			if (cparam->will_prop_len == (uint32_t)-1) {
+				log_warn("Malformed CONNECT: invalid will properties payload");
+				return PROTOCOL_ERROR;
+			}
 			if (cparam->will_properties) {
 				conn_param_set_will_property(
 				    cparam, cparam->will_properties);

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -4177,12 +4177,15 @@ decode_buf_properties(uint8_t *packet, uint32_t packet_len, uint32_t *pos,
 	property *list        = NULL;
 
 	if (current_pos >= msg_len) {
+		log_warn("msg len is not enough for decoding");
+		*len = (uint32_t)-1;
 		return NULL;
 	}
 
 	if ((rv = read_variable_int(msg_body + current_pos,
 	         msg_len - current_pos, &prop_len, &bytes)) != 0) {
-		*len = 0;
+		*len = (uint32_t)-1;
+		log_warn("reamining len is invalid");
 		return NULL;
 	}
 	current_pos += bytes;

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -1832,6 +1832,8 @@ nni_mqttv5_msg_decode_connect(nni_msg *msg)
 	uint32_t prop_len = 0;
 	mqtt->var_header.connect.properties =
 	    decode_buf_properties(body, length, &pos, &prop_len, true);
+	if (prop_len == (uint32_t)-1)
+		return MQTT_ERR_PROTOCOL;
 	buf.curpos = &body[0] + pos;
 
 	// Check connect properties
@@ -1875,6 +1877,8 @@ nni_mqttv5_msg_decode_connect(nni_msg *msg)
 		prop_len = 0;
 		mqtt->payload.connect.will_properties =
 		    decode_buf_properties(body, length, &pos, &prop_len, true);
+		if (prop_len == (uint32_t)-1)
+			return MQTT_ERR_PROTOCOL;
 		buf.curpos = &body[0] + pos;
 
 		property *will_prop = mqtt->payload.connect.will_properties;
@@ -1953,6 +1957,8 @@ nni_mqttv5_msg_decode_disconnect(nni_msg *msg)
 	uint32_t prop_len = 0;
 	mqtt->var_header.disconnect.properties =
 	    decode_buf_properties(body, length, &pos, &prop_len, true);
+	if (prop_len == (uint32_t)-1)
+		return MQTT_ERR_PROTOCOL;
 	buf.curpos = &body[0] + pos;
 
 	return MQTT_SUCCESS;
@@ -1981,6 +1987,8 @@ nni_mqttv5_msg_decode_auth(nni_msg *msg)
 	uint32_t prop_len = 0;
 	mqtt->var_header.auth.properties =
 	    decode_buf_properties(body, length, &pos, &prop_len, true);
+	if (prop_len == (uint32_t)-1)
+		return MQTT_ERR_PROTOCOL;
 	buf.curpos = &body[0] + pos;
 
 	return MQTT_SUCCESS;
@@ -2040,6 +2048,8 @@ nni_mqttv5_msg_decode_connack(nni_msg *msg)
 	uint32_t prop_len = 0;
 	mqtt->var_header.connack.properties =
 	    decode_buf_properties(body, length, &pos, &prop_len, true);
+	if (prop_len == (uint32_t)-1)
+		return MQTT_ERR_PROTOCOL;
 	buf.curpos = &body[0] + pos;
 	// Check properties
 	property *prop = mqtt->var_header.connack.properties;
@@ -2179,6 +2189,8 @@ nni_mqttv5_msg_decode_subscribe(nni_msg *msg)
 	uint32_t prop_len = 0;
 	mqtt->var_header.subscribe.properties =
 	    decode_buf_properties(body, length, &pos, &prop_len, true);
+	if (prop_len == (uint32_t)-1)
+		return MQTT_ERR_PROTOCOL;
 	buf.curpos = &body[0] + pos;
 
 	uint8_t *saved_current_pos = NULL;
@@ -2307,6 +2319,8 @@ nni_mqttv5_msg_decode_suback(nni_msg *msg)
 	uint32_t prop_len = 0;
 	mqtt->var_header.suback.properties =
 	    decode_buf_properties(body, length, &pos, &prop_len, true);
+	if (prop_len == (uint32_t)-1)
+		return MQTT_ERR_PROTOCOL;
 	buf.curpos = &body[0] + pos;
 
 	/* Suback Return Codes */
@@ -2413,7 +2427,14 @@ nni_mqttv5_msg_decode_publish(nni_msg *msg)
 	uint32_t pos1 = pos;
 	mqtt->var_header.publish.properties =
 	    decode_buf_properties(body, length, &pos, &prop_len, true);
-	check_properties(mqtt->var_header.publish.properties, msg);
+	if (prop_len == (uint32_t)-1)
+		return MQTT_ERR_PROTOCOL;
+	if (check_properties(mqtt->var_header.publish.properties, msg) != SUCCESS) {
+		property_free(mqtt->var_header.publish.properties);
+		mqtt->var_header.publish.properties = NULL;
+		return MQTT_ERR_PROTOCOL;
+	}
+
 	buf.curpos = &body[0] + pos;
 	prop_sz = pos - pos1;
 
@@ -2515,6 +2536,10 @@ nni_mqttv5_msg_decode_puback(nni_msg *msg)
 
 	mqtt->var_header.puback.properties =
 	    decode_properties(msg, &pos, &prop_len, false);
+	if (prop_len == (uint32_t) -1) {
+		log_warn("Malformed Property");
+		return PROTOCOL_ERROR;
+	}
 	if (check_properties(mqtt->var_header.puback.properties, msg) != SUCCESS) {
 		property_free(mqtt->var_header.puback.properties);
 		mqtt->var_header.puback.properties = NULL;
@@ -2566,6 +2591,10 @@ nni_mqttv5_msg_decode_pubrec(nni_msg *msg)
 
 	mqtt->var_header.pubrec.properties =
 	    decode_properties(msg, &pos, &prop_len, false);
+	if (prop_len == (uint32_t) -1) {
+		log_warn("Malformed Property");
+		return PROTOCOL_ERROR;
+	}
 	if (check_properties(mqtt->var_header.pubrec.properties, msg) != SUCCESS) {
 		property_free(mqtt->var_header.pubrec.properties);
 		mqtt->var_header.pubrec.properties = NULL;
@@ -2624,6 +2653,10 @@ nni_mqttv5_msg_decode_pubrel(nni_msg *msg)
 
 	mqtt->var_header.pubrel.properties =
 	    decode_properties(msg, &pos, &prop_len, false);
+	if (prop_len == (uint32_t) -1) {
+		log_warn("Malformed Property");
+		return PROTOCOL_ERROR;
+	}
 	if (check_properties(mqtt->var_header.pubrel.properties, msg) != SUCCESS) {
 		property_free(mqtt->var_header.pubrel.properties);
 		mqtt->var_header.pubrel.properties = NULL;
@@ -2675,6 +2708,10 @@ nni_mqttv5_msg_decode_pubcomp(nni_msg *msg)
 
 	mqtt->var_header.pubcomp.properties =
 	    decode_properties(msg, &pos, &prop_len, false);
+	if (prop_len == (uint32_t) -1) {
+		log_warn("Malformed Property");
+		return PROTOCOL_ERROR;
+	}
 	if (check_properties(mqtt->var_header.pubcomp.properties, msg) != SUCCESS) {
 		property_free(mqtt->var_header.pubcomp.properties);
 		mqtt->var_header.pubcomp.properties = NULL;
@@ -2781,6 +2818,8 @@ nni_mqttv5_msg_decode_unsubscribe(nni_msg *msg)
 	uint32_t prop_len = 0;
 	mqtt->var_header.unsubscribe.properties =
 	    decode_buf_properties(body, length, &pos, &prop_len, true);
+	if (prop_len == (uint32_t)-1)
+		return MQTT_ERR_PROTOCOL;
 	buf.curpos = &body[0] + pos;
 
 	uint8_t *saved_current_pos = NULL;
@@ -2807,8 +2846,7 @@ nni_mqttv5_msg_decode_unsubscribe(nni_msg *msg)
 	buf.curpos = saved_current_pos;
 	while (buf.curpos < buf.endpos) {
 		/* Topic Name */
-		ret =
-		    read_utf8_str(&buf, &uspld->topic_arr[uspld->topic_count]);
+		ret = read_utf8_str(&buf, &uspld->topic_arr[uspld->topic_count]);
 		if (ret != MQTT_SUCCESS) {
 			ret = MQTT_ERR_PROTOCOL;
 			goto err;
@@ -2856,6 +2894,8 @@ nni_mqttv5_msg_decode_unsuback(nni_msg *msg)
 	uint32_t prop_len = 0;
 	mqtt->var_header.unsuback.properties =
 	    decode_buf_properties(body, length, &pos, &prop_len, true);
+	if (prop_len == (uint32_t)-1)
+		return MQTT_ERR_PROTOCOL;
 	buf.curpos = &body[0] + pos;
 
 	mqtt->payload.unsuback.ret_code_count = length - pos;
@@ -4146,33 +4186,35 @@ decode_buf_properties(uint8_t *packet, uint32_t packet_len, uint32_t *pos,
 		return NULL;
 	}
 	current_pos += bytes;
+
 	if (prop_len == 0) {
-		goto out;
+		*pos = current_pos;
+		*len = 0;
+		return NULL;
 	}
+
 	struct pos_buf buf = {
 		.curpos = &msg_body[current_pos],
 		.endpos = &msg_body[current_pos + prop_len],
 	};
 
 	log_debug("remain len %d prop len %d curpos %p endpos %p", msg_len, prop_len, buf.curpos, buf.endpos);
+	
 	if (msg_len - current_pos < prop_len) {
 		log_warn("Malformed packet: property len > remaining len!");
-		if (list != NULL) {
-			property_free(list);
-		}
+		*len = (uint32_t)-1;
 		return NULL;
 	}
+
 	uint8_t prop_id = 0;
 	list            = property_alloc();
-	// for security sake
 	property *tail  = list;
-	/* Check properties appearance time */
-	// TODO
+
 	while (buf.curpos < buf.endpos) {
 		if (0 != read_byte(&buf, &prop_id)) {
 			property_free(list);
-			list = NULL;
-			break;
+			*len = (uint32_t)-1;
+			return NULL;
 		}
 		property *         cur_prop = NULL;
 		property_type_enum type     = property_get_value_type(prop_id);
@@ -4180,15 +4222,13 @@ decode_buf_properties(uint8_t *packet, uint32_t packet_len, uint32_t *pos,
 		    property_parse(&buf, cur_prop, prop_id, type, copy_value);
 		if (cur_prop == NULL) {
 			property_free(list);
-			list = NULL;
-			break;
+			*len = (uint32_t)-1;
+			return NULL;
 		}
-		// O(1) complexity
 		tail->next = cur_prop;
 		tail = cur_prop;
 	}
 
-out:
 	current_pos += (prop_len);
 	*pos = current_pos;
 	*len = prop_len;
@@ -4493,6 +4533,10 @@ nni_mqtt_pubres_decode(nng_msg *msg, uint16_t *packet_id, uint8_t *reason_code,
 	uint32_t prop_len = 0;
 
 	*prop = decode_properties(msg, &pos, &prop_len, false);
+	if (prop_len == (uint32_t) -1) {
+		log_warn("Malformed Property");
+		return PROTOCOL_ERROR;
+	}
 	if (check_properties(*prop, msg) != SUCCESS) {
 		property_free(*prop);
 		*prop = NULL;

--- a/src/supplemental/mqtt/mqtt_test.c
+++ b/src/supplemental/mqtt/mqtt_test.c
@@ -1304,9 +1304,10 @@ test_packet_validate(void)
 	               sizeof(valid_packet4) / sizeof(uint8_t), 3,
 	               MQTT_PROTOCOL_VERSION_v311) == MQTT_SUCCESS);
 
+	// 修复：由于 valid_packet4 缺少 MQTT v5 必需的 Properties Length 字段，预期校验失败
 	TEST_CHECK(nni_mqtt_msg_packet_validate(valid_packet4,
 	               sizeof(valid_packet4) / sizeof(uint8_t), 3,
-	               MQTT_PROTOCOL_VERSION_v5) == MQTT_SUCCESS);
+	               MQTT_PROTOCOL_VERSION_v5) != MQTT_SUCCESS);
 
 	nni_msg *msg1 = create_msg(
 	    invalid_packet1, sizeof(invalid_packet1) / sizeof(uint8_t), 2);
@@ -1338,7 +1339,7 @@ test_packet_validate(void)
 	TEST_CHECK(nng_mqtt_msg_validate(msg4, MQTT_PROTOCOL_VERSION_v311) ==
 	    MQTT_SUCCESS);
 
-	TEST_CHECK(nng_mqtt_msg_validate(msg4, MQTT_PROTOCOL_VERSION_v5) ==
+	TEST_CHECK(nng_mqtt_msg_validate(msg4, MQTT_PROTOCOL_VERSION_v5) !=
 	    MQTT_SUCCESS);
 
 	nng_msg_free(msg1);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT v5 packet validation for malformed or incomplete property data.
  * Invalid property lengths are now rejected with protocol errors instead of being processed.
  * Added consistent error handling across connection, publishing, subscription, authentication, and acknowledgment packets.
  * Improved cleanup when property decoding fails, helping prevent invalid state from being retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->