### PR TITLE
fix: handle partial MQTT TLS negotiation writes

### DIFF
--- a/src/mqtt/transport/tls/mqtt_tls.c
+++ b/src/mqtt/transport/tls/mqtt_tls.c
@@ -297,20 +297,23 @@ mqtts_tcptran_pipe_nego_cb(void *arg)
 	}
 	// We start transmitting before we receive.
 	if (p->gottxhead < p->wanttxhead) {
-		p->gottxhead += nni_aio_count(aio);
+		size_t n = nni_aio_count(aio);
+
+		p->gottxhead += n;
+		nni_aio_iov_advance(aio, n);
+		if (nni_aio_iov_count(aio) > 0) {
+			nng_stream_send(p->conn, aio);
+			nni_mtx_unlock(&ep->mtx);
+			return;
+		}
 	} else if (p->gotrxhead < p->wantrxhead) {
 		p->gotrxhead += nni_aio_count(aio);
 	}
 
 	if (p->gottxhead < p->wanttxhead) {
-		nni_iov iov;
-		iov.iov_len = p->wanttxhead - p->gottxhead;
-		iov.iov_buf = &p->txlen[p->gottxhead];
-		// send it down...
-		nni_aio_set_iov(aio, 1, &iov);
-		nng_stream_send(p->conn, aio);
-		nni_mtx_unlock(&ep->mtx);
-		return;
+		log_error("MQTT negotiation send completed without consuming all IOVs");
+		rv = NNG_EPROTO;
+		goto error;
 	}
 
 	// receving fixed header
@@ -1241,9 +1244,12 @@ mqtts_tcptran_pipe_start(
 	p->rxmsg      = NULL;
 	p->proto      = mqtt_version;
 
+	if (nni_msg_header_len(connmsg) > 0) {
+		iov[niov].iov_buf = nni_msg_header(connmsg);
+		iov[niov].iov_len = nni_msg_header_len(connmsg);
+		niov++;
+	}
 	if (nni_msg_len(connmsg) > 0) {
-		nni_msg_insert(connmsg, nni_msg_header(connmsg),
-		    nni_msg_header_len(connmsg));
 		iov[niov].iov_buf = nni_msg_body(connmsg);
 		iov[niov].iov_len = nni_msg_len(connmsg);
 		niov++;


### PR DESCRIPTION
### **Description**

## Summary

Fix MQTT CONNECT packet corruption in the TLS transport when the underlying stream send completes only part of the submitted data.

The MQTT TLS negotiation callback previously attempted to resume an incomplete CONNECT write from `p->txlen`. However, `p->txlen` is only a small internal fixed-header buffer and does not contain the CONNECT packet.

This could cause the client to send unrelated memory instead of the remaining CONNECT data and potentially read past the end of `p->txlen`. The broker would then reject the corrupted CONNECT packet as malformed.

## Root cause

`nng_stream_send()` is allowed to complete only part of the supplied IOVs.

The previous continuation logic only updated the number of bytes sent:

```c
p->gottxhead += nni_aio_count(aio);
It then reconstructed the remaining write using:
iov.iov_buf = &p->txlen[p->gottxhead];
iov.iov_len = p->wanttxhead - p->gottxhead;
p->txlen does not own the CONNECT packet data. The CONNECT packet is stored in the message header and body submitted through the negotiation AIO.
If the initial stream write completed partially, the subsequent write therefore used the wrong buffer.
Changes
Advance the original negotiation AIO IOVs with nni_aio_iov_advance().
Resubmit the same AIO while unsent IOV data remains.
Remove the continuation logic that reads CONNECT data from p->txlen.
Submit the CONNECT message header and body as separate IOVs, matching the plain MQTT TCP transport.
Add a defensive check for inconsistent negotiation send state.
The essential part of the fix is preserving and advancing the original AIO IOVs:
size_t n = nni_aio_count(aio);

p->gottxhead += n;
nni_aio_iov_advance(aio, n);

if (nni_aio_iov_count(aio) > 0) {
    nng_stream_send(p->conn, aio);
    nni_mtx_unlock(&ep->mtx);
    return;
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT TLS negotiation when data is sent in multiple segments.
  * Added protocol error handling when negotiation data cannot be fully transmitted.
  * Updated CONNECT message transmission to handle headers separately for more reliable communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->