### PR TITLE
Fix error handler of nmq_base64_encode/decode in scram

### DIFF
--- a/src/mqtt/protocol/mqtt/mqtt_client.c
+++ b/src/mqtt/protocol/mqtt/mqtt_client.c
@@ -883,7 +883,8 @@ mqtt_send_cb(void *arg)
 #endif
 		nni_aio_set_msg(&p->send_aio, NULL);
 		log_warn("MQTT client send error %d!", rv);
-		s->disconnect_code = 0x8B; // TODO hardcode
+		if (s->disconnect_code == 0)
+			s->disconnect_code = 0x8B;
 		nni_pipe_close(p->pipe);
 		return;
 	}

--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -1719,36 +1719,35 @@ nmq_subinfo_decode(nng_msg *msg, void *l, uint8_t ver)
 
 	// get variable length of properties
 	if (ver == MQTT_PROTOCOL_VERSION_v5) {
-		len = get_var_integer(
-		    (uint8_t *) nni_msg_body(msg) + 2, &len_of_varint);
+		len = get_var_integer((uint8_t *) var_ptr + 2, &len_of_varint);
 		if (len > nni_msg_len(msg))
 			return -1;
 	}
+
 	uint32_t pid = 0;
 	NNI_GET16(var_ptr, pid);
 	if (pid == 0) {
-		log_warn(" 0 Packetid in subscribe request");
+		log_warn("0 Packetid in subscribe request");
 		return -2;
 	}
 
 	log_trace("prop len %d varint %d remain %d", len, len_of_varint,
-		nni_msg_len(msg));
-	payload_ptr = (uint8_t *) nni_msg_body(msg) + 2 + len + len_of_varint;
+	    nni_msg_len(msg));
+	payload_ptr = (uint8_t *) var_ptr + 2 + len + len_of_varint;
 
-	size_t pos = 2 + len_of_varint, target_pos = 2 + len_of_varint + len;
+	size_t pos        = 2 + len_of_varint;
+	size_t target_pos = 2 + len_of_varint + len;
+
 	while (pos < target_pos) {
 		switch (*(var_ptr + pos)) {
 		case USER_PROPERTY:
-			// ID Length
 			pos++;
 			for (int j = 0; j < 2; j++) {
 				len_of_str = 0;
 				if (pos + 2 > target_pos)
 					return (-3);
-				// key/Value length
 				NNI_GET16(var_ptr + pos, len_of_str);
 				pos += (2 + len_of_str);
-				// Check the index of properties
 				if (pos > target_pos)
 					return (-3);
 			}
@@ -1778,54 +1777,50 @@ nmq_subinfo_decode(nng_msg *msg, void *l, uint8_t ver)
 		// Check the index of topic len
 		if (bpos + 2 > remain)
 			return (-3);
-		NNI_GET16(payload_ptr + bpos, len_of_topic);
-		if (len_of_str > remain)
-			return -1;
-		bpos += 2;
 
-		if (len_of_topic == 0)
-			continue;
-		// Check the index of topic body
-		if (bpos + len_of_topic > remain)
+		NNI_GET16(payload_ptr + bpos, len_of_topic);
+		bpos += 2;
+		if (len_of_topic + 1 > remain - bpos)
 			return (-3);
+
+		if (len_of_topic == 0) {
+			bpos += 1; // Skip the option byte even if topic is empty
+			continue;
+		}
 
 		if ((sn = nng_alloc(sizeof(struct subinfo))) == NULL)
 			return (-2);
+
 		if ((topic = nng_alloc(len_of_topic + 1)) == NULL) {
 			nng_free(sn, sizeof(struct subinfo));
 			return (-2);
 		}
 
-		strncpy(topic, (char *) payload_ptr + bpos, len_of_topic);
-		topic[len_of_topic] = 0x00;
+		memcpy(topic, payload_ptr + bpos, len_of_topic);
+		topic[len_of_topic] = '\0';
 
 		sn->topic = topic;
 		bpos += len_of_topic;
 
-		// Ensure at least 1 byte is left for subscription options
-		if (bpos >= remain) {
-			nng_free(sn->topic, len_of_topic + 1);
-			nng_free(sn, sizeof(*sn));
-			return (-3);
-		}
-
 		sn->subid = subid;
-		// qos no_local rap retain_handling
-		sn->qos      = (uint8_t) ((0x03 & *(payload_ptr + bpos)));
-		sn->no_local = (uint8_t) ((0x04 & *(payload_ptr + bpos)));
-		sn->rap      = (uint8_t) ((0x08 & *(payload_ptr + bpos)) > 0);
-		sn->retain_handling = (uint8_t) ((0x1f & *(payload_ptr + bpos)));
-		memcpy(sn, payload_ptr + bpos, 1);
+
+		uint8_t opt         = payload_ptr[bpos];
+		sn->qos             = opt & 0x03;        // Bit 0,1
+		sn->no_local        = (opt & 0x04) >> 2; // Bit 2
+		sn->rap             = (opt & 0x08) >> 3; // Bit 3
+		sn->retain_handling = (opt & 0x30) >> 4; // Bit 4,5
+
 		NNI_LIST_NODE_INIT(&sn->node);
 
 		if (0 != nmq_subinfol_add_or(ll, sn)) {
 			// already exists
-			nng_free(sn->topic, strlen(sn->topic) + 1);
+			nng_free(sn->topic, len_of_topic + 1);
 			nng_free(sn, sizeof(*sn));
+		} else {
+			num++;
 		}
 
 		bpos += 1;
-		num++;
 	}
 
 	return num;

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -3637,6 +3637,9 @@ property *
 property_alloc(void)
 {
 	property *p = nni_zalloc(sizeof(property));
+	if (p == NULL) {
+		return NULL;
+	}
 	p->next     = NULL;
 	return p;
 }
@@ -4196,13 +4199,7 @@ decode_buf_properties(uint8_t *packet, uint32_t packet_len, uint32_t *pos,
 		return NULL;
 	}
 
-	struct pos_buf buf = {
-		.curpos = &msg_body[current_pos],
-		.endpos = &msg_body[current_pos + prop_len],
-	};
 
-	log_debug("remain len %d prop len %d curpos %p endpos %p", msg_len, prop_len, buf.curpos, buf.endpos);
-	
 	if (msg_len - current_pos < prop_len) {
 		log_warn("Malformed packet: property len > remaining len!");
 		*len = (uint32_t)-1;
@@ -4211,6 +4208,15 @@ decode_buf_properties(uint8_t *packet, uint32_t packet_len, uint32_t *pos,
 
 	uint8_t prop_id = 0;
 	list            = property_alloc();
+	if (list == NULL) {
+		*len = (uint32_t) -1;
+		return NULL;
+	}
+	struct pos_buf buf = {
+		.curpos = &msg_body[current_pos],
+		.endpos = &msg_body[current_pos + prop_len],
+	};
+	log_debug("remain len %d prop len %d curpos %p endpos %p", msg_len, prop_len, buf.curpos, buf.endpos);
 	property *tail  = list;
 
 	while (buf.curpos < buf.endpos) {

--- a/src/supplemental/scram/scram.c
+++ b/src/supplemental/scram/scram.c
@@ -324,22 +324,30 @@ static char *
 scram_client_final_msg(char *nonce, const char *proof, int client_proofsz)
 {
 	char  *gh         = gs_header();
-	size_t ghb64sz    = BASE64_ENCODE_OUT_SIZE(strlen(gh)) + 1;
-	char  *ghb64      = nng_alloc(ghb64sz);
-	size_t proofb64sz = BASE64_ENCODE_OUT_SIZE(client_proofsz) + 1;
-	char  *proofb64   = nng_alloc(proofb64sz);
+	size_t ghb64sz    = BASE64_ENCODE_OUT_SIZE(strlen(gh));
+	size_t proofb64sz = BASE64_ENCODE_OUT_SIZE(client_proofsz);
 
-	if (!ghb64 || !proofb64 || ghb64sz == 0 || proofb64sz == 0) {
+	if (ghb64sz == 0 || proofb64sz == 0) {
+		return NULL;
+	}
+	ghb64sz++;
+	proofb64sz++;
+	char *ghb64    = nng_alloc(ghb64sz);
+	char *proofb64 = nng_alloc(proofb64sz);
+
+	if (!ghb64 || !proofb64) {
 		if (ghb64)
 			nng_free(ghb64, 0);
 		if (proofb64)
 			nng_free(proofb64, 0);
 		return NULL;
 	}
-	size_t tlen  = nmq_base64_encode((const unsigned char *) proof,
-	    client_proofsz, proofb64, proofb64sz);
+
+	size_t tlen = nmq_base64_encode(
+	    (const unsigned char *) proof, client_proofsz, proofb64, proofb64sz);
 	size_t rlen = nmq_base64_encode(
 	    (const unsigned char *) gh, strlen(gh), ghb64, ghb64sz);
+
 	if (rlen == (size_t) -1 || rlen == 0 || tlen == (size_t) -1 || tlen == 0) {
 		nng_free(ghb64, 0);
 		nng_free(proofb64, 0);
@@ -363,16 +371,18 @@ scram_client_final_msg(char *nonce, const char *proof, int client_proofsz)
 static char *
 scram_server_first_msg(char *nonce, const char *salt, int iteration_cnt)
 {
-	size_t saltb64sz = BASE64_ENCODE_OUT_SIZE(strlen(salt)) + 1;
-	if (saltb64sz <= 1)
+	size_t saltb64sz = BASE64_ENCODE_OUT_SIZE(strlen(salt));
+	if (saltb64sz == 0)
 		return NULL;
+	saltb64sz++;
 	char *saltb64 = nng_alloc(saltb64sz);
 	if (!saltb64)
 		return NULL;
 
-	size_t elen = nmq_base64_encode((const uint8_t *) salt, strlen(salt), saltb64, saltb64sz);
-	if (elen == (size_t)-1 || elen == 0) {
-		nng_free(saltb64, saltb64sz);
+	size_t elen = nmq_base64_encode(
+	    (const uint8_t *) salt, strlen(salt), saltb64, saltb64sz);
+	if (elen == (size_t) -1 || elen == 0) {
+		nng_free(saltb64, 0);
 		return NULL;
 	}
 
@@ -381,7 +391,7 @@ scram_server_first_msg(char *nonce, const char *salt, int iteration_cnt)
 	if (buf) {
 		snprintf(buf, bufsz, "r=%s,s=%s,i=%d", nonce, saltb64, iteration_cnt);
 	}
-	nng_free(saltb64, saltb64sz);
+	nng_free(saltb64, 0);
 	return buf;
 }
 
@@ -395,18 +405,23 @@ scram_server_final_msg(const char *server_sig, int sz, int error)
 			snprintf(buf, 32, "e=%d", error);
 		return buf;
 	}
-	size_t ssb64sz = BASE64_ENCODE_OUT_SIZE(sz) + 1;
-	char  *ssb64   = nng_alloc(ssb64sz);
-	if (ssb64sz == 0 || !ssb64)
+
+	size_t ssb64sz = BASE64_ENCODE_OUT_SIZE(sz);
+	if (ssb64sz == 0)
+		return NULL;
+	ssb64sz++;
+	char *ssb64 = nng_alloc(ssb64sz);
+	if (!ssb64)
 		return NULL;
 
-	size_t rlen = nmq_base64_encode((const unsigned char *) server_sig, sz, ssb64, ssb64sz);
-	if (rlen == (size_t)-1 || rlen == 0) {
+	size_t elen = nmq_base64_encode(
+	    (const unsigned char *) server_sig, sz, ssb64, ssb64sz);
+	if (elen == (size_t) -1 || elen == 0) {
 		nng_free(ssb64, 0);
 		return NULL;
 	}
 
-	size_t bufsz = ssb64sz + 32;
+	size_t bufsz = elen + 32;
 	buf          = nng_alloc(sizeof(char) * bufsz);
 	if (buf) {
 		snprintf(buf, bufsz, "v=%s", ssb64);
@@ -540,6 +555,7 @@ peek_client_final_msg_without_proof(const char *msg)
 		*end = '\0';
 	return m;
 }
+
 char *
 scram_handle_client_final_msg(void *arg, const char *msg, int len)
 {
@@ -560,7 +576,7 @@ scram_handle_client_final_msg(void *arg, const char *msg, int len)
 	}
 
 	int proofsz = ctx->digestsz;
-	if (strlen(proof) * 3 / 4 > proofsz) {
+	if (strlen(proof) * 3 / 4 > (size_t) proofsz) {
 		goto cleanup;
 	}
 
@@ -592,20 +608,28 @@ scram_handle_client_final_msg(void *arg, const char *msg, int len)
 	char *client_key   = nng_alloc(proofsz);
 	char *client_proof = nng_alloc(proofsz + 1);
 
-	if (!client_key || !client_proof) {
-		size_t rlen = nmq_base64_decode(proof, strlen(proof),
-		    (unsigned char *) client_proof, proofsz + 1);
-		if (rlen == (size_t) -1 || rlen == 0) {
-			if (client_sig)
-				nng_free(client_sig, 0);
-			if (client_key)
-				nng_free(client_key, 0);
-			if (client_proof)
-				nng_free(client_proof, 0);
-			nng_free(client_final_msg_without_proof, 0);
-			nng_free(authmsg, authmsg_sz);
-			goto cleanup;
-		}
+	if (!client_sig || !client_key || !client_proof) {
+		if (client_sig)
+			nng_free(client_sig, 0);
+		if (client_key)
+			nng_free(client_key, 0);
+		if (client_proof)
+			nng_free(client_proof, 0);
+		nng_free(client_final_msg_without_proof, 0);
+		nng_free(authmsg, authmsg_sz);
+		goto cleanup;
+	}
+
+	size_t rlen = nmq_base64_decode(
+	    proof, strlen(proof), (unsigned char *) client_proof, proofsz + 1);
+	
+	if (rlen == (size_t) -1 || rlen == 0) {
+		nng_free(client_sig, 0);
+		nng_free(client_key, 0);
+		nng_free(client_proof, 0);
+		nng_free(client_final_msg_without_proof, 0);
+		nng_free(authmsg, authmsg_sz);
+		goto cleanup;
 	}
 
 	xor(client_proof, client_sig, client_key, proofsz);
@@ -677,6 +701,7 @@ scram_handle_server_first_msg(void *arg, const char *msg, int len)
 	if (!salt)
 		goto cleanup_fields;
 	memset(salt, 0, SCRAM_SALT_SZ);
+
 	size_t tlen = nmq_base64_decode(
 	    saltb64, strlen(saltb64), (unsigned char *) salt, SCRAM_SALT_SZ);
 	if (tlen == (size_t) -1 || tlen == 0) {
@@ -687,12 +712,20 @@ scram_handle_server_first_msg(void *arg, const char *msg, int len)
 	scram_ctx_update(ctx, salt);
 
 	char  *gh      = gs_header();
-	size_t ghb64sz = BASE64_ENCODE_OUT_SIZE(strlen(gh)) + 1;
-	char  *ghb64   = nng_alloc(ghb64sz);
-	if (ghb64sz == 0 || !ghb64 ||
-	    (size_t) -1 == nmq_base64_encode((const unsigned char *) gh, strlen(gh), ghb64, ghb64sz)) {
-		if (ghb64)
-			nng_free(ghb64, 0);
+	size_t ghb64sz = BASE64_ENCODE_OUT_SIZE(strlen(gh));
+	if (ghb64sz == 0) {
+		goto cleanup_fields;
+	}
+	ghb64sz ++;
+	char *ghb64 = nng_alloc(ghb64sz);
+	if (!ghb64) {
+		goto cleanup_fields;
+	}
+
+	size_t elen = nmq_base64_encode(
+	    (const unsigned char *) gh, strlen(gh), ghb64, ghb64sz);
+	if (elen == (size_t) -1 || elen == 0) {
+		nng_free(ghb64, 0);
 		goto cleanup_fields;
 	}
 
@@ -798,25 +831,37 @@ scram_handle_server_final_msg(void *arg, const char *msg, int len)
 	char *server_sig =
 	    scram_hmac(ctx, ctx->server_key, ctx->digestsz, authmsg);
 	log_trace("client: server_key %.*s\n", ctx->digestsz, ctx->server_key);
-	size_t ssb64sz = BASE64_ENCODE_OUT_SIZE(ctx->digestsz) + 1;
+
+	size_t ssb64sz = BASE64_ENCODE_OUT_SIZE(ctx->digestsz);
+	if (ssb64sz == 0) {
+		nng_free(authmsg, authmsg_sz);
+		if (server_sig)
+			nng_free(server_sig, 0);
+		nng_free(verifier, 0);
+		return NULL;
+	}
+	ssb64sz++;
 	char  *ssb64   = nng_alloc(ssb64sz);
 	size_t tlen = 0;
-	if (ssb64sz != 0 && ssb64 && server_sig) {
+	if (ssb64 && server_sig) {
 		tlen = nmq_base64_encode((const unsigned char *) server_sig,
 		        ctx->digestsz, ssb64, ssb64sz);
 	}
+
 	if (tlen == (size_t) -1 || tlen == 0) {
-			nng_free(authmsg, authmsg_sz);
-			if (server_sig)
-				nng_free(server_sig, 0);
-			if (ssb64)
-				nng_free(ssb64, 0);
-			nng_free(verifier, 0);
-			return NULL;
+		nng_free(authmsg, authmsg_sz);
+		if (server_sig)
+			nng_free(server_sig, 0);
+		if (ssb64)
+			nng_free(ssb64, 0);
+		nng_free(verifier, 0);
+		return NULL;
 	}
+
 	if (0 == strcmp(verifier, ssb64)) {
 		result = arg;
 	}
+
 	nng_free(authmsg, authmsg_sz);
 	nng_free(ssb64, 0);
 	nng_free(server_sig, 0);

--- a/src/supplemental/scram/scram.c
+++ b/src/supplemental/scram/scram.c
@@ -203,11 +203,12 @@ scram_ctx_update(void *arg, char *salt)
 {
 	struct scram_ctx *ctx   = arg;
 	int               keysz = ctx->digestsz;
-
-	ctx->salt = salt;
-	if (ctx->salt == NULL) {
+	if (salt == NULL) {
 		return -1;
 	}
+	if (ctx->salt)
+		nng_free(ctx->salt, 0);
+	ctx->salt = salt;
 
 	char *salt_pwd = nng_alloc(sizeof(char) * ctx->digestsz);
 	if (!salt_pwd)
@@ -223,12 +224,25 @@ scram_ctx_update(void *arg, char *salt)
 		ctx->salt = NULL;
 		return -2;
 	}
+	if (ctx->salt_pwd)
+		nng_free(ctx->salt_pwd, 0);
 	ctx->salt_pwd = salt_pwd;
 
+	if (ctx->client_key)
+		nng_free(ctx->client_key, 0);
+	if (ctx->server_key)
+		nng_free(ctx->server_key, 0);
+	if (ctx->stored_key)
+		nng_free(ctx->stored_key, 0);
 	ctx->client_key = client_key(ctx->digest, salt_pwd, keysz);
 	ctx->server_key = server_key(ctx->digest, salt_pwd, keysz);
+	if (ctx->client_key == NULL || ctx->server_key == NULL) {
+		return -3;
+	}
 	ctx->stored_key = stored_key(ctx->digest, ctx->client_key, keysz);
-
+	if (ctx->stored_key == NULL) {
+		return -3;
+	}
 	return 0;
 }
 

--- a/src/supplemental/scram/scram.c
+++ b/src/supplemental/scram/scram.c
@@ -285,7 +285,7 @@ scram_ctx_create(
 	snprintf(saltstr, SCRAM_SALT_SZ, "%d", salt);
 	if (0 != (rv = scram_ctx_update(ctx, saltstr))) {
 		log_error("error in updating ctx %d", rv);
-		nng_free(ctx, 0);
+		scram_ctx_free(ctx);
 		return NULL;
 	}
 
@@ -336,12 +336,11 @@ scram_client_final_msg(char *nonce, const char *proof, int client_proofsz)
 			nng_free(proofb64, 0);
 		return NULL;
 	}
-
-	if (0 ==
-	        nmq_base64_encode((const unsigned char *) gh, strlen(gh), ghb64, ghb64sz) ||
-	    0 ==
-	        nmq_base64_encode(
-	            (const unsigned char *) proof, client_proofsz, proofb64, proofb64sz)) {
+	size_t tlen  = nmq_base64_encode((const unsigned char *) proof,
+	    client_proofsz, proofb64, proofb64sz);
+	size_t rlen = nmq_base64_encode(
+	    (const unsigned char *) gh, strlen(gh), ghb64, ghb64sz);
+	if (rlen == (size_t) -1 || rlen == 0 || tlen == (size_t) -1 || tlen == 0) {
 		nng_free(ghb64, 0);
 		nng_free(proofb64, 0);
 		return NULL;
@@ -365,24 +364,24 @@ static char *
 scram_server_first_msg(char *nonce, const char *salt, int iteration_cnt)
 {
 	size_t saltb64sz = BASE64_ENCODE_OUT_SIZE(strlen(salt)) + 1;
-	char  *saltb64   = nng_alloc(saltb64sz);
-	if (saltb64sz == 0 || !saltb64)
+	if (saltb64sz <= 1)
+		return NULL;
+	char *saltb64 = nng_alloc(saltb64sz);
+	if (!saltb64)
 		return NULL;
 
-	if (0 ==
-	    nmq_base64_encode(
-	        (const unsigned char *) salt, strlen(salt), saltb64, saltb64sz)) {
-		nng_free(saltb64, 0);
+	size_t elen = nmq_base64_encode((const uint8_t *) salt, strlen(salt), saltb64, saltb64sz);
+	if (elen == (size_t)-1 || elen == 0) {
+		nng_free(saltb64, saltb64sz);
 		return NULL;
 	}
 
-	size_t bufsz = saltb64sz + strlen(nonce) + 64;
+	size_t bufsz = elen + strlen(nonce) + 64;
 	char  *buf   = nng_alloc(sizeof(char) * bufsz);
 	if (buf) {
-		snprintf(buf, bufsz, "r=%s,s=%s,i=%d", nonce, saltb64,
-		    iteration_cnt);
+		snprintf(buf, bufsz, "r=%s,s=%s,i=%d", nonce, saltb64, iteration_cnt);
 	}
-	nng_free(saltb64, 0);
+	nng_free(saltb64, saltb64sz);
 	return buf;
 }
 
@@ -401,8 +400,8 @@ scram_server_final_msg(const char *server_sig, int sz, int error)
 	if (ssb64sz == 0 || !ssb64)
 		return NULL;
 
-	if (0 ==
-	    nmq_base64_encode((const unsigned char *) server_sig, sz, ssb64, ssb64sz)) {
+	size_t rlen = nmq_base64_encode((const unsigned char *) server_sig, sz, ssb64, ssb64sz);
+	if (rlen == (size_t)-1 || rlen == 0) {
 		nng_free(ssb64, 0);
 		return NULL;
 	}
@@ -593,20 +592,22 @@ scram_handle_client_final_msg(void *arg, const char *msg, int len)
 	char *client_key   = nng_alloc(proofsz);
 	char *client_proof = nng_alloc(proofsz + 1);
 
-	if (!client_key || !client_proof ||
-	    0 ==
-	        nmq_base64_decode(
-	            proof, strlen(proof), (unsigned char *) client_proof, proofsz + 1)) {
-		if (client_sig)
-			nng_free(client_sig, 0);
-		if (client_key)
-			nng_free(client_key, 0);
-		if (client_proof)
-			nng_free(client_proof, 0);
-		nng_free(client_final_msg_without_proof, 0);
-		nng_free(authmsg, authmsg_sz);
-		goto cleanup;
+	if (!client_key || !client_proof) {
+		size_t rlen = nmq_base64_decode(proof, strlen(proof),
+		    (unsigned char *) client_proof, proofsz + 1);
+		if (rlen == (size_t) -1 || rlen == 0) {
+			if (client_sig)
+				nng_free(client_sig, 0);
+			if (client_key)
+				nng_free(client_key, 0);
+			if (client_proof)
+				nng_free(client_proof, 0);
+			nng_free(client_final_msg_without_proof, 0);
+			nng_free(authmsg, authmsg_sz);
+			goto cleanup;
+		}
 	}
+
 	xor(client_proof, client_sig, client_key, proofsz);
 
 	char *hash_client_key = hash(ctx->digest, client_key, ctx->digestsz);
@@ -648,6 +649,7 @@ scram_handle_server_first_msg(void *arg, const char *msg, int len)
 	char             *it    = (char *) msg;
 	char             *itend = it + len - 1;
 	char             *itnext;
+	char             *client_final_msg = NULL;
 	char             *nonce = get_comma_value(it, itend, &itnext, 2);
 	it                      = itnext;
 	char *saltb64           = get_comma_value(it, itend, &itnext, 2);
@@ -675,9 +677,9 @@ scram_handle_server_first_msg(void *arg, const char *msg, int len)
 	if (!salt)
 		goto cleanup_fields;
 	memset(salt, 0, SCRAM_SALT_SZ);
-
-	if (0 ==
-	    nmq_base64_decode(saltb64, strlen(saltb64), (unsigned char *) salt, SCRAM_SALT_SZ)) {
+	size_t tlen = nmq_base64_decode(
+	    saltb64, strlen(saltb64), (unsigned char *) salt, SCRAM_SALT_SZ);
+	if (tlen == (size_t) -1 || tlen == 0) {
 		nng_free(salt, 0);
 		goto cleanup_fields;
 	}
@@ -688,7 +690,7 @@ scram_handle_server_first_msg(void *arg, const char *msg, int len)
 	size_t ghb64sz = BASE64_ENCODE_OUT_SIZE(strlen(gh)) + 1;
 	char  *ghb64   = nng_alloc(ghb64sz);
 	if (ghb64sz == 0 || !ghb64 ||
-	    0 == nmq_base64_encode((const unsigned char *) gh, strlen(gh), ghb64, ghb64sz)) {
+	    (size_t) -1 == nmq_base64_encode((const unsigned char *) gh, strlen(gh), ghb64, ghb64sz)) {
 		if (ghb64)
 			nng_free(ghb64, 0);
 		goto cleanup_fields;
@@ -738,7 +740,6 @@ scram_handle_server_first_msg(void *arg, const char *msg, int len)
 		xor(ctx->client_key, client_sig, client_proof, client_sig_len);
 	}
 
-	char *client_final_msg = NULL;
 	if (client_proof) {
 		client_final_msg = scram_client_final_msg(
 		    nonce, client_proof, client_sig_len);
@@ -799,19 +800,20 @@ scram_handle_server_final_msg(void *arg, const char *msg, int len)
 	log_trace("client: server_key %.*s\n", ctx->digestsz, ctx->server_key);
 	size_t ssb64sz = BASE64_ENCODE_OUT_SIZE(ctx->digestsz) + 1;
 	char  *ssb64   = nng_alloc(ssb64sz);
-
-	if (ssb64sz == 0 || !ssb64 || 0 ==
-	        nmq_base64_encode((const unsigned char *) server_sig,
-	            ctx->digestsz, ssb64, ssb64sz)) {
-		nng_free(authmsg, authmsg_sz);
-		if (server_sig)
-			nng_free(server_sig, 0);
-		if (ssb64)
-			nng_free(ssb64, 0);
-		nng_free(verifier, 0);
-		return NULL;
+	size_t tlen = 0;
+	if (ssb64sz != 0 && ssb64 && server_sig) {
+		tlen = nmq_base64_encode((const unsigned char *) server_sig,
+		        ctx->digestsz, ssb64, ssb64sz);
 	}
-
+	if (tlen == (size_t) -1 || tlen == 0) {
+			nng_free(authmsg, authmsg_sz);
+			if (server_sig)
+				nng_free(server_sig, 0);
+			if (ssb64)
+				nng_free(ssb64, 0);
+			nng_free(verifier, 0);
+			return NULL;
+	}
 	if (0 == strcmp(verifier, ssb64)) {
 		result = arg;
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing MQTT disconnect reasons when send errors occur.
  * Improved handling of invalid, empty, duplicate, or malformed MQTT subscriptions.
  * Prevented crashes when processing malformed packets or when memory allocation fails.
  * Improved SCRAM authentication reliability by validating encoded data and safely handling credential updates and cleanup.
  * Correctly interprets subscription options, including quality of service and message-handling settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->