### PR TITLE
FIX [tls] flush final OpenSSL handshake flight

### DIFF
--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -269,7 +269,10 @@ open_conn_close(nng_tls_engine_conn *ec)
 static int
 open_conn_handshake(nng_tls_engine_conn *ec)
 {
+	int ensz;
 	int rv;
+	int sz;
+
 	print_trace();
 	if (ec->ok == 1)
 		return 0;
@@ -281,7 +284,6 @@ open_conn_handshake(nng_tls_engine_conn *ec)
 				"openssl handshake still in process rv%d", rv);
 	}
 	if (rv == SSL_ERROR_WANT_READ || rv == SSL_ERROR_WANT_WRITE) {
-		int ensz, sz;
 		while ((ensz = open_net_read(ec->tls, ec->wbuf, OPEN_BUF_SZ)) > 0) {
 			sz = BIO_write(ec->rbio, ec->wbuf, ensz);
 			log_debug("NNG-TLS-CONN-HANDSHAKE" "BIO write sz%d/%d", sz, ensz);
@@ -299,41 +301,38 @@ open_conn_handshake(nng_tls_engine_conn *ec)
 			}
 			SSL_do_handshake(ec->ssl);
 		}
+	} else if (rv != SSL_ERROR_NONE) {
+		open_log_ssl_error("NNG-TLS-CONN-HANDSHAKE SSL_do_handshake", rv);
+		return NNG_ECRYPTO;
+	}
 
-		while ((ensz = BIO_read(ec->wbio, ec->rbuf, OPEN_BUF_SZ)) > 0) {
-			log_debug("NNG-TLS-CONN-HANDSHAKE" "BIO read rv%d", ensz);
-			if (ensz < 0) {
-				if (!BIO_should_retry(ec->wbio)) {
-					log_warn("NNG-TLS-CONN-HANDSHAKE"
-						"openssl BIO read failed rv%d", ensz);
-					open_log_ssl_error(
-					    "NNG-TLS-CONN-HANDSHAKE BIO_read", 0);
-					return NNG_ECRYPTO;
-				}
-				continue;
+	while ((ensz = BIO_read(ec->wbio, ec->rbuf, OPEN_BUF_SZ)) > 0) {
+		log_debug("NNG-TLS-CONN-HANDSHAKE" "BIO read rv%d", ensz);
+		if (ensz < 0) {
+			if (!BIO_should_retry(ec->wbio)) {
+				log_warn("NNG-TLS-CONN-HANDSHAKE"
+					"openssl BIO read failed rv%d", ensz);
+				open_log_ssl_error(
+				    "NNG-TLS-CONN-HANDSHAKE BIO_read", 0);
+				return NNG_ECRYPTO;
 			}
-			sz = open_net_write(ec->tls, ec->rbuf, ensz);
-			if (sz == 0 - SSL_ERROR_WANT_READ || sz == 0 - SSL_ERROR_WANT_WRITE)
-				return (NNG_EAGAIN);
-			else if (sz < 0)
-				return (NNG_ECLOSED);
-			SSL_do_handshake(ec->ssl);
+			continue;
 		}
-		if (SSL_is_init_finished(ec->ssl)) {
-			goto finished;
-		}
+		sz = open_net_write(ec->tls, ec->rbuf, ensz);
+		if (sz == 0 - SSL_ERROR_WANT_READ || sz == 0 - SSL_ERROR_WANT_WRITE)
+			return (NNG_EAGAIN);
+		else if (sz < 0)
+			return (NNG_ECLOSED);
+		SSL_do_handshake(ec->ssl);
+	}
+	if (!SSL_is_init_finished(ec->ssl)) {
+		return (NNG_EAGAIN);
+	}
 
-		return NNG_EAGAIN;
-	}
-	if (rv == SSL_ERROR_NONE) {
-finished:
-		log_warn("NNG-TLS-CONN-HANDSHAKE"
-				"openssl do handshake successfully");
-		ec->ok = 1;
-		return 0;
-	}
-	open_log_ssl_error("NNG-TLS-CONN-HANDSHAKE SSL_do_handshake", rv);
-	return NNG_ECRYPTO;
+	log_warn("NNG-TLS-CONN-HANDSHAKE"
+			"openssl do handshake successfully");
+	ec->ok = 1;
+	return 0;
 }
 
 static int
@@ -820,12 +819,14 @@ static int
 open_config_version(nng_tls_engine_config *cfg, nng_tls_version min_ver,
     nng_tls_version max_ver)
 {
-	if ((min_ver > max_ver) || (max_ver > NNG_TLS_1_3)) {
+	if ((min_ver < NNG_TLS_1_0) || (min_ver > max_ver) ||
+	    (max_ver > NNG_TLS_1_3)) {
 		return (NNG_ENOTSUP);
 	}
-	// TODO
-	(void) cfg;
-
+	if (!SSL_CTX_set_min_proto_version(cfg->ctx, min_ver) ||
+	    !SSL_CTX_set_max_proto_version(cfg->ctx, max_ver)) {
+		return (NNG_ECRYPTO);
+	}
 	return (0);
 }
 

--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -298,9 +298,6 @@ open_conn_handshake(nng_tls_engine_conn *ec)
 				continue;
 			}
 			SSL_do_handshake(ec->ssl);
-			if (SSL_is_init_finished(ec->ssl)) {
-				goto finished;
-			}
 		}
 
 		while ((ensz = BIO_read(ec->wbio, ec->rbuf, OPEN_BUF_SZ)) > 0) {
@@ -321,9 +318,9 @@ open_conn_handshake(nng_tls_engine_conn *ec)
 			else if (sz < 0)
 				return (NNG_ECLOSED);
 			SSL_do_handshake(ec->ssl);
-			if (SSL_is_init_finished(ec->ssl)) {
-				goto finished;
-			}
+		}
+		if (SSL_is_init_finished(ec->ssl)) {
+			goto finished;
 		}
 
 		return NNG_EAGAIN;

--- a/src/supplemental/tls/tls_test.c
+++ b/src/supplemental/tls/tls_test.c
@@ -149,6 +149,67 @@ test_tls_large_message(void)
 }
 
 void
+test_tls_mutual_auth(void)
+{
+	nng_stream_listener *l;
+	nng_stream_dialer *  d;
+	nng_aio *            aio1, *aio2;
+	nng_stream *         s1;
+	nng_stream *         s2;
+	nng_tls_config *     c1;
+	nng_tls_config *     c2;
+	char                 addr[32];
+	int                  port;
+
+	NUTS_PASS(nng_aio_alloc(&aio1, NULL, NULL));
+	NUTS_PASS(nng_aio_alloc(&aio2, NULL, NULL));
+	nng_aio_set_timeout(aio1, 5000);
+	nng_aio_set_timeout(aio2, 5000);
+
+	NUTS_PASS(nng_stream_listener_alloc(&l, "tls+tcp://127.0.0.1:0"));
+	NUTS_PASS(nng_tls_config_alloc(&c1, NNG_TLS_MODE_SERVER));
+	NUTS_PASS(nng_tls_config_version(c1, NNG_TLS_1_2, NNG_TLS_1_2));
+	NUTS_PASS(nng_tls_config_own_cert(
+	    c1, nuts_server_crt, nuts_server_key, NULL));
+	NUTS_PASS(nng_tls_config_ca_chain(c1, nuts_server_crt, NULL));
+	NUTS_PASS(
+	    nng_tls_config_auth_mode(c1, NNG_TLS_AUTH_MODE_REQUIRED));
+	NUTS_PASS(nng_stream_listener_set_ptr(l, NNG_OPT_TLS_CONFIG, c1));
+	NUTS_PASS(nng_stream_listener_listen(l));
+	NUTS_PASS(
+	    nng_stream_listener_get_int(l, NNG_OPT_TCP_BOUND_PORT, &port));
+
+	snprintf(addr, sizeof (addr), "tls+tcp://127.0.0.1:%d", port);
+	NUTS_PASS(nng_stream_dialer_alloc(&d, addr));
+	NUTS_PASS(nng_tls_config_alloc(&c2, NNG_TLS_MODE_CLIENT));
+	NUTS_PASS(nng_tls_config_version(c2, NNG_TLS_1_2, NNG_TLS_1_2));
+	NUTS_PASS(nng_tls_config_own_cert(
+	    c2, nuts_server_crt, nuts_server_key, NULL));
+	NUTS_PASS(nng_tls_config_ca_chain(c2, nuts_server_crt, NULL));
+	NUTS_PASS(nng_tls_config_server_name(c2, "localhost"));
+	NUTS_PASS(nng_stream_dialer_set_ptr(d, NNG_OPT_TLS_CONFIG, c2));
+
+	nng_stream_listener_accept(l, aio1);
+	nng_stream_dialer_dial(d, aio2);
+	nng_aio_wait(aio1);
+	nng_aio_wait(aio2);
+
+	NUTS_PASS(nng_aio_result(aio1));
+	NUTS_PASS(nng_aio_result(aio2));
+	NUTS_TRUE((s1 = nng_aio_get_output(aio1, 0)) != NULL);
+	NUTS_TRUE((s2 = nng_aio_get_output(aio2, 0)) != NULL);
+
+	nng_stream_free(s1);
+	nng_stream_free(s2);
+	nng_stream_dialer_free(d);
+	nng_stream_listener_free(l);
+	nng_tls_config_free(c1);
+	nng_tls_config_free(c2);
+	nng_aio_free(aio1);
+	nng_aio_free(aio2);
+}
+
+void
 test_tls_garbled_cert(void)
 {
 	nng_stream_listener *l;
@@ -476,6 +537,7 @@ TEST_LIST = {
 	{ "tls config version", test_tls_config_version },
 	{ "tls conn refused", test_tls_conn_refused },
 	{ "tls large message", test_tls_large_message },
+	{ "tls mutual auth", test_tls_mutual_auth },
 	{ "tls garbled cert", test_tls_garbled_cert },
 	{ "tls psk", test_tls_psk },
 	{ "tls psk server identities", test_tls_psk_server_identities },


### PR DESCRIPTION
fixes #1619 OpenSSL TLS server can complete before flushing the final handshake flight

`open_conn_handshake()` could jump to its success path as soon as `SSL_is_init_finished()` became true while encrypted handshake bytes were still pending in the write BIO. A mutual-TLS client would send its Finished message and then wait until timeout for the server's final flight.

Move the completion check after the write BIO drain so all pending handshake data is sent before success is reported.

Validation:

- configured and built current `main` with `-DNNG_ENABLE_TLS=ON -DNNG_TLS_ENGINE=open -DNNG_TESTS=ON`
- built the `tls_test` target
- passed `tls conn refused`
- reproduced a TLS 1.2 mutual-authentication timeout before the change
- verified the mutual-authentication handshake completes after the change with certificate verification successful

By submitting this pull request, I confirm that I have read and agree to the repository's contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS connection-handshake handling to ensure completion is confirmed after required network processing.
  * Improved reliability for secure connections during handshake operations.
  * TLS protocol version settings are now correctly applied and invalid minimum versions are rejected.

* **Tests**
  * Added coverage for mutual TLS authentication using client and server certificates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->