### PR TITLE
Fix will property propagation to publish

### DIFF
--- a/include/nng/protocol/mqtt/mqtt_parser.h
+++ b/include/nng/protocol/mqtt/mqtt_parser.h
@@ -111,6 +111,7 @@ NNG_DECL nng_msg *nano_encode_publish_msg(uint8_t proto_ver, uint8_t qos,
     property *prop, const char *topic, const char *topic_suffix);
 // TODO : check duplicated declaration
 NNG_DECL reason_code check_properties(property *prop, nng_msg *msg);
+NNG_DECL reason_code check_will_properties(property *prop);
 NNG_DECL property *decode_buf_properties(uint8_t *packet, uint32_t packet_len,
     uint32_t *pos, uint32_t *len, bool copy_value);
 NNG_DECL property *decode_properties(

--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -708,11 +708,15 @@ conn_handler(uint8_t *packet, conn_param *cparam, size_t max)
 			if (cparam->will_properties) {
 				conn_param_set_will_property(
 				    cparam, cparam->will_properties);
-				if ((rv = check_properties(
-						cparam->will_properties, NULL)) != SUCCESS) {
+				if ((rv = check_will_properties(
+						cparam->will_properties)) != SUCCESS) {
 					log_info("Malformed CONNECT: check will property failed");
-					return PROTOCOL_ERROR;
+					return rv;
 				}
+				// will_delay_interval is valid on reception
+				// but not when publishing the will message
+				property_remove(cparam->will_properties,
+				    WILL_DELAY_INTERVAL);
 			} else {
 				log_warn("property decode failed!");
 			}
@@ -1196,6 +1200,10 @@ nano_dismsg_composer(reason_code code, char* rstr, uint8_t *ref, property *prop)
 	{
 	case PROTOCOL_ERROR:
 		buf[0] = (uint8_t)PROTOCOL_ERROR;
+		nng_msg_append(msg, buf, 1);
+		break;
+	case MALFORMED_PACKET:
+		buf[0] = (uint8_t)MALFORMED_PACKET;
 		nng_msg_append(msg, buf, 1);
 		break;
 	default:

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -4163,6 +4163,39 @@ check_properties(property *prop, nni_msg *msg)
 	return SUCCESS;
 }
 
+// Will properties live inside a CONNECT, so check_properties() cannot tell them
+// apart from the CONNECT's own properties, both reach it with a NULL msg.
+reason_code
+check_will_properties(property *prop)
+{
+	reason_code rc = check_properties(prop, NULL);
+
+	if (rc != SUCCESS || prop == NULL) {
+		return rc;
+	}
+
+	for (property *p = prop->next; p != NULL; p = p->next) {
+		switch (p->id) {
+		case WILL_DELAY_INTERVAL:
+		case PAYLOAD_FORMAT_INDICATOR:
+		case MESSAGE_EXPIRY_INTERVAL:
+		case CONTENT_TYPE:
+		case RESPONSE_TOPIC:
+		case CORRELATION_DATA:
+		case USER_PROPERTY:
+			break;
+
+		default:
+			log_warn("Property 0x%02X not allowed in Will "
+			         "Properties!",
+			    p->id);
+			return MALFORMED_PACKET;
+		}
+	}
+
+	return SUCCESS;
+}
+
 /**
  * packet_len: remaining length
  * len: property length

--- a/src/supplemental/mqtt/mqtt_test.c
+++ b/src/supplemental/mqtt/mqtt_test.c
@@ -1588,6 +1588,40 @@ test_property_api(void)
 	NUTS_PASS(mqtt_property_free(plist));
 }
 
+void
+test_check_will_property_ids(void)
+{
+	property *plist = mqtt_property_alloc();
+
+	// The complete set of legal will properties.
+	mqtt_property_append(
+	    plist, mqtt_property_set_value_u32(WILL_DELAY_INTERVAL, 32));
+	mqtt_property_append(
+	    plist, mqtt_property_set_value_u8(PAYLOAD_FORMAT_INDICATOR, 1));
+	mqtt_property_append(
+	    plist, mqtt_property_set_value_u32(MESSAGE_EXPIRY_INTERVAL, 60));
+	mqtt_property_append(plist,
+	    mqtt_property_set_value_str(CONTENT_TYPE, "tp", 2, true));
+	mqtt_property_append(plist,
+	    mqtt_property_set_value_str(RESPONSE_TOPIC, "resp", 4, true));
+	mqtt_property_append(plist,
+	    mqtt_property_set_value_binary(
+	        CORRELATION_DATA, (uint8_t *) "cd", 2, true));
+	mqtt_property_append(plist,
+	    mqtt_property_set_value_strpair(
+	        USER_PROPERTY, "a", 1, "b", 1, true));
+
+	NUTS_TRUE(check_will_properties(plist) == SUCCESS);
+
+	// Session Expiry Interval is a CONNECT property, not a Will property.
+	mqtt_property_append(
+	    plist, mqtt_property_set_value_u32(SESSION_EXPIRY_INTERVAL, 10));
+
+	NUTS_TRUE(check_will_properties(plist) == MALFORMED_PACKET);
+
+	NUTS_PASS(mqtt_property_free(plist));
+}
+
 TEST_LIST = {
 	// TODO: there is still some encode & decode functions should be
 	// tested.
@@ -1640,5 +1674,6 @@ TEST_LIST = {
 	{ "test topic_qos create & free", test_topic_qos_array_create_free },
 	{ "test topic create & free", test_topic_array_create_free },
 	{ "test property api", test_property_api },
+	{ "check will property ids", test_check_will_property_ids },
 	{ NULL, NULL },
 };


### PR DESCRIPTION
## Summary

MQTT v5 allows a different set of properties on the will message sent as part of the CONNECT message from what is allowed on PUBLISH or on the CONNECT message itself. This results in that some will messages, such as those including will_delay_interval will be accepted in CONNECT, but then result in an malformed message being published to clients, which in turn makes them close the connection.

The dropped connection has been verified both with mosquitto and paho MQTT-clients.

This change verifies that the will message does not contain properties not allowed by the standard, and makes sure the will_delay_interval specifically is not included in the set of properties forwarded to the PUBLISH path.

## Validation

The full test suite fails on two tests (nng.tcp and nng.ws) when running locally. nng.tcp does timeout and nng.ws fails with Connection refused. Both errors are pre-existing on main, indicating environmental problems rather than code problems.

## Alternatives or future work

As an alternative to this change, it was considered to add full validation of allowed properties on both reception and sending for all MQTT message types. This was not implemented at this time as it is not needed to fix the problem at hand, but it could be done instead or on top of this for more strict validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT 5 Will Property validation.
  * Invalid Will Properties now return the appropriate malformed-packet error.
  * Disconnect messages now include the correct reason code for malformed packets.
  * Will Delay Interval is handled correctly after successful validation.

* **Tests**
  * Added coverage for valid and invalid MQTT Will Property combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->