### PR TITLE
tls: support PKCS#11 credential URIs with OpenSSL

### DIFF
--- a/.github/workflows/pkcs11.yml
+++ b/.github/workflows/pkcs11.yml
@@ -1,0 +1,108 @@
+name: pkcs11
+
+# Copyright 2026 Liebherr-Digital Development Center (LDC) <peter.bestler@liebherr.de>
+#
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).
+
+on:
+  workflow_dispatch:
+
+jobs:
+  integration:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes \
+            libssl-dev ninja-build opensc pkcs11-provider softhsm2
+
+      - name: Initialize SoftHSM token
+        env:
+          TOKEN_PIN: "123456"
+        run: |
+          mkdir -p "${RUNNER_TEMP}/softhsm/tokens"
+          printf 'directories.tokendir = %s\n' \
+            "${RUNNER_TEMP}/softhsm/tokens" \
+            > "${RUNNER_TEMP}/softhsm/softhsm2.conf"
+          echo "SOFTHSM2_CONF=${RUNNER_TEMP}/softhsm/softhsm2.conf" \
+            >> "${GITHUB_ENV}"
+          export SOFTHSM2_CONF="${RUNNER_TEMP}/softhsm/softhsm2.conf"
+
+          softhsm_module="$(dpkg -L libsofthsm2 | \
+            sed -n '/\/libsofthsm2\.so$/p' | head -n 1)"
+          provider_module="$(dpkg -L pkcs11-provider | \
+            sed -n '/\/pkcs11\.so$/p' | head -n 1)"
+          test -n "${softhsm_module}"
+          test -n "${provider_module}"
+
+          cat > "${RUNNER_TEMP}/softhsm/openssl.cnf" <<EOF
+          openssl_conf = openssl_init
+
+          [openssl_init]
+          providers = providers
+
+          [providers]
+          default = default_provider
+          pkcs11 = pkcs11_provider
+
+          [default_provider]
+          activate = 1
+
+          [pkcs11_provider]
+          module = ${provider_module}
+          pkcs11-module-path = ${softhsm_module}
+          activate = 1
+          EOF
+          echo "OPENSSL_CONF=${RUNNER_TEMP}/softhsm/openssl.cnf" \
+            >> "${GITHUB_ENV}"
+          export OPENSSL_CONF="${RUNNER_TEMP}/softhsm/openssl.cnf"
+
+          softhsm2-util --init-token --free --label NanoMQ \
+            --so-pin 12345678 --pin "${TOKEN_PIN}"
+
+          pkcs11-tool --module "${softhsm_module}" --login \
+            --pin "${TOKEN_PIN}" --token-label NanoMQ \
+            --keypairgen --key-type rsa:2048 --id 01 \
+            --label server-key --usage-sign
+
+          key_uri='pkcs11:token=NanoMQ;object=server-key;type=private'
+          openssl req -new -x509 \
+            -key "${key_uri};pin-value=${TOKEN_PIN}" \
+            -out "${RUNNER_TEMP}/softhsm/server-cert.pem" \
+            -days 1 -subj '/CN=localhost' \
+            -addext 'subjectAltName=DNS:localhost'
+          openssl x509 -in "${RUNNER_TEMP}/softhsm/server-cert.pem" \
+            -outform DER -out "${RUNNER_TEMP}/softhsm/server-cert.der"
+
+          pkcs11-tool --module "${softhsm_module}" --login \
+            --pin "${TOKEN_PIN}" --token-label NanoMQ \
+            --write-object "${RUNNER_TEMP}/softhsm/server-cert.der" \
+            --type cert --id 01 --label server-cert
+
+          echo 'NNG_PKCS11_KEY_URI=pkcs11:token=NanoMQ;object=server-key;type=private' \
+            >> "${GITHUB_ENV}"
+          echo 'NNG_PKCS11_CERT_URI=pkcs11:token=NanoMQ;object=server-cert;type=cert' \
+            >> "${GITHUB_ENV}"
+          echo 'NNG_PKCS11_CA_URI=pkcs11:token=NanoMQ;object=server-cert;type=cert' \
+            >> "${GITHUB_ENV}"
+          echo "NNG_PKCS11_PIN=${TOKEN_PIN}" >> "${GITHUB_ENV}"
+
+      - name: Configure
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DNNG_ENABLE_TLS=ON \
+            -DNNG_TLS_ENGINE=open \
+            -DNNG_REQUIRE_PKCS11_PROVIDER=ON \
+            -DNNG_TEST_PKCS11_PROVIDER=ON
+
+      - name: Build
+        run: cmake --build build --target pkcs11_test
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure -R '\.pkcs11_test$'

--- a/cmake/NNGOptions.cmake
+++ b/cmake/NNGOptions.cmake
@@ -1,5 +1,6 @@
 #
 # Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
+# Copyright 2026 Liebherr-Digital Development Center (LDC) <peter.bestler@liebherr.de>
 #
 # This software is supplied under the terms of the MIT License, a
 # copy of which should be located in the distribution where this
@@ -134,6 +135,36 @@ if (NNG_ENABLE_TLS)
 else ()
     set(NNG_TLS_ENGINE none)
 endif ()
+
+option (NNG_REQUIRE_PKCS11_PROVIDER
+    "Require OpenSSL 3 provider support for PKCS#11 credentials."
+    OFF)
+if (NNG_REQUIRE_PKCS11_PROVIDER)
+    if (NOT NNG_ENABLE_TLS)
+        message(FATAL_ERROR
+            "NNG_REQUIRE_PKCS11_PROVIDER requires NNG_ENABLE_TLS=ON.")
+    endif ()
+    if (NOT NNG_TLS_ENGINE STREQUAL "open")
+        message(FATAL_ERROR
+            "NNG_REQUIRE_PKCS11_PROVIDER requires NNG_TLS_ENGINE=open.")
+    endif ()
+endif ()
+
+option (NNG_TEST_PKCS11_PROVIDER
+    "Run the PKCS#11 provider integration test."
+    OFF)
+if (NNG_TEST_PKCS11_PROVIDER)
+    if (NOT NNG_TESTS)
+        message(FATAL_ERROR
+            "NNG_TEST_PKCS11_PROVIDER requires NNG_TESTS=ON.")
+    endif ()
+    if (NOT NNG_REQUIRE_PKCS11_PROVIDER)
+        message(FATAL_ERROR
+            "NNG_TEST_PKCS11_PROVIDER requires "
+            "NNG_REQUIRE_PKCS11_PROVIDER=ON.")
+    endif ()
+endif ()
+mark_as_advanced(NNG_TEST_PKCS11_PROVIDER)
 
 # HTTP API support.
 option (NNG_ENABLE_HTTP "Enable HTTP API." ON)

--- a/include/nng/supplemental/nanolib/conf.h
+++ b/include/nng/supplemental/nanolib/conf.h
@@ -1,3 +1,11 @@
+// Copyright 2026 Liebherr-Digital Development Center (LDC) <peter.bestler@liebherr.de>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
 #ifndef CONF_H
 #define CONF_H
 
@@ -711,6 +719,7 @@ NNG_DECL int  get_time(const char *str, uint64_t *second);
 NNG_DECL int  get_time_ms(const char *str, uint64_t *second);
 NNG_DECL void conf_parse(conf *nanomq_conf);
 NNG_DECL void conf_parse_ver2(conf *nanomq_conf, bool is_reload);
+NNG_DECL bool conf_tls_is_pkcs11_uri(const char *value);
 NNG_DECL void conf_gateway_parse_ver2(zmq_gateway_conf *gateway);
 NNG_DECL void conf_vsomeip_gateway_parse_ver2(vsomeip_gateway_conf *config);
 NNG_DECL void conf_dds_gateway_init(dds_gateway_conf *config);

--- a/include/nng/supplemental/nanolib/conf.h
+++ b/include/nng/supplemental/nanolib/conf.h
@@ -719,6 +719,7 @@ NNG_DECL int  get_time(const char *str, uint64_t *second);
 NNG_DECL int  get_time_ms(const char *str, uint64_t *second);
 NNG_DECL void conf_parse(conf *nanomq_conf);
 NNG_DECL void conf_parse_ver2(conf *nanomq_conf, bool is_reload);
+/** Returns whether value is a PKCS#11 URI, matched case-insensitively. */
 NNG_DECL bool conf_tls_is_pkcs11_uri(const char *value);
 NNG_DECL void conf_gateway_parse_ver2(zmq_gateway_conf *gateway);
 NNG_DECL void conf_vsomeip_gateway_parse_ver2(vsomeip_gateway_conf *config);

--- a/src/supplemental/nanolib/conf.c
+++ b/src/supplemental/nanolib/conf.c
@@ -325,6 +325,7 @@ get_conf_value_with_prefix2(char *line, size_t len, const char *prefix,
 	return value;
 }
 
+/** Returns whether value is a PKCS#11 URI, matched case-insensitively. */
 bool
 conf_tls_is_pkcs11_uri(const char *value)
 {
@@ -332,6 +333,7 @@ conf_tls_is_pkcs11_uri(const char *value)
 	    (nng_strncasecmp(value, "pkcs11:", sizeof("pkcs11:") - 1) == 0));
 }
 
+/** Loads a TLS value from a PKCS#11 URI or from the referenced file. */
 static void
 conf_tls_load_inline_or_file(char **dst, const char *value)
 {
@@ -345,6 +347,7 @@ conf_tls_load_inline_or_file(char **dst, const char *value)
 	}
 }
 
+/** Parses legacy TLS settings, including file paths and PKCS#11 URIs. */
 void
 conf_tls_parse(
     conf_tls *tls, const char *path, const char *prefix1, const char *prefix2)

--- a/src/supplemental/nanolib/conf.c
+++ b/src/supplemental/nanolib/conf.c
@@ -1,5 +1,6 @@
 //
 // Copyright 2021 NanoMQ Team, Inc. <jaylin@emqx.io> //
+// Copyright 2026 Liebherr-Digital Development Center (LDC) <peter.bestler@liebherr.de>
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
 // file was obtained (LICENSE.txt).  A copy of the license may also be
@@ -324,6 +325,26 @@ get_conf_value_with_prefix2(char *line, size_t len, const char *prefix,
 	return value;
 }
 
+bool
+conf_tls_is_pkcs11_uri(const char *value)
+{
+	return ((value != NULL) &&
+	    (nng_strncasecmp(value, "pkcs11:", sizeof("pkcs11:") - 1) == 0));
+}
+
+static void
+conf_tls_load_inline_or_file(char **dst, const char *value)
+{
+	FREE_NONULL(*dst);
+	if (conf_tls_is_pkcs11_uri(value)) {
+		*dst = nng_strdup(value);
+		return;
+	}
+	if (0 == file_load_data(value, (void **) dst)) {
+		log_warn("Read cert/key file %s failed!", value);
+	}
+}
+
 void
 conf_tls_parse(
     conf_tls *tls, const char *path, const char *prefix1, const char *prefix2)
@@ -353,22 +374,19 @@ conf_tls_parse(
 			tls->key_password = value;
 		} else if ((value = get_conf_value_with_prefix2(line, sz,
 		                prefix1, prefix2, "tls.keyfile")) != NULL) {
-			FREE_NONULL(tls->key);
 			FREE_NONULL(tls->keyfile);
 			tls->keyfile = value;
-			file_load_data(tls->keyfile, (void **) &tls->key);
+			conf_tls_load_inline_or_file(&tls->key, tls->keyfile);
 		} else if ((value = get_conf_value_with_prefix2(line, sz,
 		                prefix1, prefix2, "tls.certfile")) != NULL) {
-			FREE_NONULL(tls->cert);
 			FREE_NONULL(tls->certfile);
 			tls->certfile = value;
-			file_load_data(tls->certfile, (void **) &tls->cert);
+			conf_tls_load_inline_or_file(&tls->cert, tls->certfile);
 		} else if ((value = get_conf_value_with_prefix2(line, sz,
 		                prefix1, prefix2, "tls.cacertfile")) != NULL) {
-			FREE_NONULL(tls->ca);
 			FREE_NONULL(tls->cafile);
 			tls->cafile = value;
-			file_load_data(tls->cafile, (void **) &tls->ca);
+			conf_tls_load_inline_or_file(&tls->ca, tls->cafile);
 		} else if ((value = get_conf_value_with_prefix2(line, sz,
 		                prefix1, prefix2, "tls.verify_peer")) !=
 		    NULL) {

--- a/src/supplemental/nanolib/conf_test.c
+++ b/src/supplemental/nanolib/conf_test.c
@@ -334,6 +334,7 @@ test_get_time_days(void)
 	// If not supported, should fail gracefully
 }
 
+/** Verifies that the legacy configuration preserves PKCS#11 TLS URIs. */
 void
 test_conf_parse_tls_pkcs11_old(void)
 {
@@ -358,6 +359,7 @@ test_conf_parse_tls_pkcs11_old(void)
 	conf_tls_destroy(&tls);
 }
 
+/** Verifies that version 2 configuration preserves PKCS#11 TLS URIs. */
 void
 test_conf_parse_ver2_tls_pkcs11(void)
 {
@@ -386,6 +388,7 @@ test_conf_parse_ver2_tls_pkcs11(void)
 	conf_fini(conf);
 }
 
+/** Verifies case-insensitive PKCS#11 URI detection and rejection cases. */
 void
 test_conf_tls_is_pkcs11_uri(void)
 {

--- a/src/supplemental/nanolib/conf_test.c
+++ b/src/supplemental/nanolib/conf_test.c
@@ -1,4 +1,13 @@
+// Copyright 2026 Liebherr-Digital Development Center (LDC) <peter.bestler@liebherr.de>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
 #include "nng/supplemental/nanolib/conf.h"
+#include "nng/supplemental/nanolib/nanolib.h"
 
 #include "nuts.h"
 
@@ -6,19 +15,41 @@
 #define OLD_CONF_PATH \
 	NANOMQ_TEST_CONF_DIR "/nmq_old_test.conf"
 #define CONF_PATH NANOMQ_TEST_CONF_DIR "/nmq_test.conf"
+#define PKCS11_OLD_CONF_PATH \
+	NANOMQ_TEST_CONF_DIR "/nmq_tls_pkcs11_old_test.conf"
+#define PKCS11_CONF_PATH \
+	NANOMQ_TEST_CONF_DIR "/nmq_tls_pkcs11_test.conf"
 #elif defined(ENABLE_NANOMQ_TESTS)
 #define OLD_CONF_PATH                                            \
 	"../../../../../nng/src/supplemental/nanolib/test_conf/" \
 	"nmq_old_test.conf"
 #define CONF_PATH \
 	"../../../../../nng/src/supplemental/nanolib/test_conf/nmq_test.conf"
+#define PKCS11_OLD_CONF_PATH                                    \
+	"../../../../../nng/src/supplemental/nanolib/test_conf/" \
+	"nmq_tls_pkcs11_old_test.conf"
+#define PKCS11_CONF_PATH                                         \
+	"../../../../../nng/src/supplemental/nanolib/test_conf/" \
+	"nmq_tls_pkcs11_test.conf"
 #else
 #define OLD_CONF_PATH \
 	"../../../../src/supplemental/nanolib/test_conf/nmq_old_test.conf"
 #define CONF_PATH \
 	"../../../../src/supplemental/nanolib/test_conf/nmq_test.conf"
+#define PKCS11_OLD_CONF_PATH                               \
+	"../../../../src/supplemental/nanolib/test_conf/" \
+	"nmq_tls_pkcs11_old_test.conf"
+#define PKCS11_CONF_PATH                                   \
+	"../../../../src/supplemental/nanolib/test_conf/" \
+	"nmq_tls_pkcs11_test.conf"
 #endif
 
+#define PKCS11_KEY_URI \
+	"pkcs11:token=NanoMQ;object=broker-key;type=private"
+#define PKCS11_CERT_URI \
+	"pkcs11:token=NanoMQ;object=broker-cert;type=cert"
+#define PKCS11_CA_URI \
+	"pkcs11:token=NanoMQ;object=broker-ca;type=cert"
 
 conf *
 get_test_conf(const char *conf_path)
@@ -303,10 +334,73 @@ test_get_time_days(void)
 	// If not supported, should fail gracefully
 }
 
+void
+test_conf_parse_tls_pkcs11_old(void)
+{
+	conf_tls tls;
+	conf_tls_init(&tls);
+	conf_tls_parse(&tls, PKCS11_OLD_CONF_PATH, "\0", "\0");
+
+	NUTS_TRUE(NULL != tls.keyfile);
+	NUTS_TRUE(NULL != tls.key);
+	NUTS_TRUE(strcmp(tls.keyfile, PKCS11_KEY_URI) == 0);
+	NUTS_TRUE(0 == strcmp(tls.key, tls.keyfile));
+
+	NUTS_TRUE(NULL != tls.certfile);
+	NUTS_TRUE(NULL != tls.cert);
+	NUTS_TRUE(strcmp(tls.certfile, PKCS11_CERT_URI) == 0);
+	NUTS_TRUE(0 == strcmp(tls.cert, tls.certfile));
+	NUTS_TRUE(NULL != tls.cafile);
+	NUTS_TRUE(NULL != tls.ca);
+	NUTS_TRUE(strcmp(tls.cafile, PKCS11_CA_URI) == 0);
+	NUTS_TRUE(0 == strcmp(tls.ca, tls.cafile));
+
+	conf_tls_destroy(&tls);
+}
+
+void
+test_conf_parse_ver2_tls_pkcs11(void)
+{
+	conf *conf = get_test_conf(PKCS11_CONF_PATH);
+	NUTS_TRUE(conf != NULL);
+	conf_parse_ver2(conf, false);
+
+	NUTS_TRUE(NULL != conf->tls.url);
+	NUTS_TRUE(
+	    0 == strcmp(conf->tls.url, "tls+nmq-tcp://0.0.0.0:8883"));
+
+	NUTS_TRUE(NULL != conf->tls.keyfile);
+	NUTS_TRUE(NULL != conf->tls.key);
+	NUTS_TRUE(strcmp(conf->tls.keyfile, PKCS11_KEY_URI) == 0);
+	NUTS_TRUE(0 == strcmp(conf->tls.key, conf->tls.keyfile));
+
+	NUTS_TRUE(NULL != conf->tls.certfile);
+	NUTS_TRUE(NULL != conf->tls.cert);
+	NUTS_TRUE(strcmp(conf->tls.certfile, PKCS11_CERT_URI) == 0);
+	NUTS_TRUE(0 == strcmp(conf->tls.cert, conf->tls.certfile));
+	NUTS_TRUE(NULL != conf->tls.cafile);
+	NUTS_TRUE(NULL != conf->tls.ca);
+	NUTS_TRUE(strcmp(conf->tls.cafile, PKCS11_CA_URI) == 0);
+	NUTS_TRUE(0 == strcmp(conf->tls.ca, conf->tls.cafile));
+
+	conf_fini(conf);
+}
+
+void
+test_conf_tls_is_pkcs11_uri(void)
+{
+	NUTS_TRUE(conf_tls_is_pkcs11_uri(PKCS11_KEY_URI));
+	NUTS_TRUE(conf_tls_is_pkcs11_uri(
+	    "PKCS11:token=NanoMQ;object=broker-key;type=private"));
+	NUTS_TRUE(!conf_tls_is_pkcs11_uri("/etc/certs/key.pem"));
+	NUTS_TRUE(!conf_tls_is_pkcs11_uri(NULL));
+}
+
 NUTS_TESTS = {
    {"get size", test_get_size},
    {"get time", test_get_time},
    {"conf parse v2", test_conf_parse_ver2},
+   {"conf parse v2 pkcs11", test_conf_parse_ver2_tls_pkcs11},
    {"conf parse", test_conf_parse},
    {"get size edge cases", test_get_size_edge_cases},
    {"get size null params", test_get_size_null_params},
@@ -321,5 +415,7 @@ NUTS_TESTS = {
    {"conf fini null", test_conf_fini_null},
    {"get size bytes unit", test_get_size_bytes_unit},
    {"get time days", test_get_time_days},
+   {"conf parse pkcs11", test_conf_parse_tls_pkcs11_old},
+   {"identify pkcs11 URIs", test_conf_tls_is_pkcs11_uri},
    {NULL, NULL}
 };

--- a/src/supplemental/nanolib/conf_ver2.c
+++ b/src/supplemental/nanolib/conf_ver2.c
@@ -1,3 +1,11 @@
+// Copyright 2026 Liebherr-Digital Development Center (LDC) <peter.bestler@liebherr.de>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
 #include "core/nng_impl.h"
 
 #include "nng/exchange/exchange.h"
@@ -71,10 +79,25 @@ cJSON *hocon_get_obj(char *key, cJSON *jso);
 char *
 compose_url(char *head, char *address)
 {
-	size_t url_len = strlen(head) + strlen(address) + 1;
-	char  *url     = nng_alloc(url_len + 1);
+	size_t url_len;
+	char  *url;
+
+	if (address == NULL) {
+		return (NULL);
+	}
+	if (strstr(address, "://") != NULL) {
+		return (nng_strdup(address));
+	}
+	if (head == NULL) {
+		return (nng_strdup(address));
+	}
+
+	url_len = strlen(head) + strlen(address) + 1;
+	if ((url = nng_alloc(url_len)) == NULL) {
+		return (NULL);
+	}
 	snprintf(url, url_len, "%s%s", head, address);
-	return url;
+	return (url);
 }
 
 #define hocon_read_address_base(structure, field, key, head, jso)             \
@@ -419,6 +442,19 @@ conf_basic_parse_ver2(conf *config, cJSON *jso)
 }
 
 static void
+conf_tls_read_inline_or_file(char **dst, const char *value, const char *name)
+{
+	FREE_NONULL(*dst);
+	if (conf_tls_is_pkcs11_uri(value)) {
+		*dst = nng_strdup(value);
+		return;
+	}
+	if (0 == file_load_data(value, (void **) dst)) {
+		log_warn("Read %s %s failed!", name, value);
+	}
+}
+
+static void
 conf_tls_parse_ver2_base(conf_tls *tls, cJSON *jso_tls)
 {
 	if (jso_tls) {
@@ -429,17 +465,23 @@ conf_tls_parse_ver2_base(conf_tls *tls, cJSON *jso_tls)
 		hocon_read_str_base(tls, cafile, "cacertfile", jso_tls);
 		hocon_read_str(tls, key_password, jso_tls);
 
-		if (NULL == tls->keyfile ||
-		    0 == file_load_data(tls->keyfile, (void **) &tls->key)) {
+		if (NULL == tls->keyfile) {
 			log_warn("Read keyfile %s failed!", tls->keyfile);
+		} else {
+			conf_tls_read_inline_or_file(
+			    &tls->key, tls->keyfile, "keyfile");
 		}
-		if (NULL == tls->certfile ||
-		    0 == file_load_data(tls->certfile, (void **) &tls->cert)) {
+		if (NULL == tls->certfile) {
 			log_warn("Read certfile %s failed!", tls->certfile);
+		} else {
+			conf_tls_read_inline_or_file(
+			    &tls->cert, tls->certfile, "certfile");
 		}
-		if (NULL == tls->cafile ||
-		    0 == file_load_data(tls->cafile, (void **) &tls->ca)) {
+		if (NULL == tls->cafile) {
 			log_error("Read cacertfile %s failed!", tls->cafile);
+		} else {
+			conf_tls_read_inline_or_file(
+			    &tls->ca, tls->cafile, "cacertfile");
 		}
 	}
 

--- a/src/supplemental/nanolib/conf_ver2.c
+++ b/src/supplemental/nanolib/conf_ver2.c
@@ -76,6 +76,7 @@ cJSON *hocon_get_obj(char *key, cJSON *jso);
 		}                                                             \
 	} while (0);
 
+/** Composes a URL unless address already contains a complete URL. */
 char *
 compose_url(char *head, char *address)
 {
@@ -441,6 +442,7 @@ conf_basic_parse_ver2(conf *config, cJSON *jso)
 	return;
 }
 
+/** Loads a version 2 TLS value from a PKCS#11 URI or referenced file. */
 static void
 conf_tls_read_inline_or_file(char **dst, const char *value, const char *name)
 {
@@ -454,6 +456,7 @@ conf_tls_read_inline_or_file(char **dst, const char *value, const char *name)
 	}
 }
 
+/** Parses the common version 2 TLS options from a JSON object. */
 static void
 conf_tls_parse_ver2_base(conf_tls *tls, cJSON *jso_tls)
 {

--- a/src/supplemental/nanolib/env.c
+++ b/src/supplemental/nanolib/env.c
@@ -77,6 +77,7 @@ set_data_from_path_var(void **var, const char *env_str)
 	}
 }
 
+/** Reads a TLS environment value as either a PKCS#11 URI or file path. */
 static void
 set_tls_data_from_path_or_uri_var(void **var, const char *env_str)
 {
@@ -200,6 +201,7 @@ read_env_pid_file()
 	return pid_file;
 }
 
+/** Applies supported environment variables to the NanoMQ configuration. */
 void
 read_env_conf(conf *config)
 {

--- a/src/supplemental/nanolib/env.c
+++ b/src/supplemental/nanolib/env.c
@@ -1,3 +1,11 @@
+// Copyright 2026 Liebherr-Digital Development Center (LDC) <peter.bestler@liebherr.de>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
 #include "nng/supplemental/nanolib/env.h"
 #include "core/nng_impl.h"
 #include "nng/nng.h"
@@ -66,6 +74,24 @@ set_data_from_path_var(void **var, const char *env_str)
 
 	if ((env = getenv(env_str)) != NULL) {
 		file_load_data(env, var);
+	}
+}
+
+static void
+set_tls_data_from_path_or_uri_var(void **var, const char *env_str)
+{
+	char *env = NULL;
+
+	if ((env = getenv(env_str)) != NULL) {
+		if (*var) {
+			free(*var);
+			*var = NULL;
+		}
+		if (conf_tls_is_pkcs11_uri(env)) {
+			*var = nni_strdup(env);
+		} else {
+			file_load_data(env, var);
+		}
 	}
 }
 
@@ -220,11 +246,11 @@ read_env_conf(conf *config)
 	set_string_var(&config->tls.certfile, NANOMQ_TLS_CERT_PATH);
 	set_string_var(&config->tls.keyfile, NANOMQ_TLS_KEY_PATH);
 
-	set_data_from_path_var(
+	set_tls_data_from_path_or_uri_var(
 	    (void **) &config->tls.ca, NANOMQ_TLS_CA_CERT_PATH);
-	set_data_from_path_var(
+	set_tls_data_from_path_or_uri_var(
 	    (void **) &config->tls.cert, NANOMQ_TLS_CERT_PATH);
-	set_data_from_path_var(
+	set_tls_data_from_path_or_uri_var(
 	    (void **) &config->tls.key, NANOMQ_TLS_KEY_PATH);
 
 	set_string_var(&config->tls.key_password, NANOMQ_TLS_KEY_PASSWORD);

--- a/src/supplemental/nanolib/test_conf/nmq_tls_pkcs11_old_test.conf
+++ b/src/supplemental/nanolib/test_conf/nmq_tls_pkcs11_old_test.conf
@@ -1,0 +1,14 @@
+#
+# Copyright 2026 Liebherr-Digital Development Center (LDC) <peter.bestler@liebherr.de>
+#
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).  A copy of the license may also be
+# found online at https://opensource.org/licenses/MIT.
+#
+
+tls.enable=true
+tls.url=tls+nmq-tcp://0.0.0.0:8883
+tls.keyfile=pkcs11:token=NanoMQ;object=broker-key;type=private
+tls.certfile=pkcs11:token=NanoMQ;object=broker-cert;type=cert
+tls.cacertfile=pkcs11:token=NanoMQ;object=broker-ca;type=cert

--- a/src/supplemental/nanolib/test_conf/nmq_tls_pkcs11_test.conf
+++ b/src/supplemental/nanolib/test_conf/nmq_tls_pkcs11_test.conf
@@ -1,0 +1,15 @@
+#
+# Copyright 2026 Liebherr-Digital Development Center (LDC) <peter.bestler@liebherr.de>
+#
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).  A copy of the license may also be
+# found online at https://opensource.org/licenses/MIT.
+#
+
+listeners.ssl {
+	bind = "tls+nmq-tcp://0.0.0.0:8883"
+	keyfile = "pkcs11:token=NanoMQ;object=broker-key;type=private"
+	certfile = "pkcs11:token=NanoMQ;object=broker-cert;type=cert"
+	cacertfile = "pkcs11:token=NanoMQ;object=broker-ca;type=cert"
+}

--- a/src/supplemental/tls/openssl/CMakeLists.txt
+++ b/src/supplemental/tls/openssl/CMakeLists.txt
@@ -1,4 +1,60 @@
+# Copyright 2026 Liebherr-Digital Development Center (LDC) <peter.bestler@liebherr.de>
+#
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).
+
 include(FindThreads)
+
+function(nng_require_openssl3_for_pkcs11_provider)
+    if (NOT NNG_REQUIRE_PKCS11_PROVIDER)
+        return()
+    endif ()
+
+    set(NNG_OPENSSL_VERSION "")
+    foreach(_version_var
+        OpenSSL_VERSION
+        OPENSSL_VERSION
+        OpenSSL_VERSION_STRING
+        OPENSSL_VERSION_STRING)
+        if (DEFINED ${_version_var} AND
+            NOT "${${_version_var}}" STREQUAL "")
+            set(NNG_OPENSSL_VERSION "${${_version_var}}")
+            break()
+        endif ()
+    endforeach ()
+
+    if (NNG_OPENSSL_VERSION STREQUAL "")
+        foreach(_openssl_target OpenSSL::SSL OpenSSL::Crypto openssl)
+            if (TARGET ${_openssl_target})
+                foreach(_version_prop VERSION OpenSSL_VERSION OPENSSL_VERSION)
+                    get_target_property(NNG_OPENSSL_VERSION
+                        ${_openssl_target} ${_version_prop})
+                    if (NOT NNG_OPENSSL_VERSION STREQUAL
+                        "NNG_OPENSSL_VERSION-NOTFOUND" AND
+                        NOT "${NNG_OPENSSL_VERSION}" STREQUAL "")
+                        break()
+                    endif ()
+                    set(NNG_OPENSSL_VERSION "")
+                endforeach ()
+            endif ()
+            if (NOT "${NNG_OPENSSL_VERSION}" STREQUAL "")
+                break()
+            endif ()
+        endforeach ()
+    endif ()
+
+    if (NNG_OPENSSL_VERSION STREQUAL "")
+        message(FATAL_ERROR
+            "NNG_REQUIRE_PKCS11_PROVIDER could not determine the OpenSSL "
+            "version at configure time.")
+    endif ()
+    if (NNG_OPENSSL_VERSION VERSION_LESS "3.0.0")
+        message(FATAL_ERROR
+            "NNG_REQUIRE_PKCS11_PROVIDER requires OpenSSL >= 3.0, found "
+            "${NNG_OPENSSL_VERSION}.")
+    endif ()
+endfunction()
 
 if (NNG_TLS_ENGINE STREQUAL "open")
     message(NOTICE "
@@ -23,9 +79,14 @@ if (NNG_TLS_ENGINE STREQUAL "open")
         endif()
         nng_link_libraries_public(OpenSSL::SSL OpenSSL::Crypto)
     endif()
+    nng_require_openssl3_for_pkcs11_provider()
 
     nng_defines(NNG_TLS_ENGINE_INIT=nng_tls_engine_init_open)
     nng_defines(NNG_TLS_ENGINE_FINI=nng_tls_engine_fini_open)
     nng_defines(NNG_SUPP_TLS)
     nng_defines(NNG_TLS_ENGINE_OPENSSL)
+
+    if (NNG_TEST_PKCS11_PROVIDER)
+        nng_test(pkcs11_test)
+    endif ()
 endif ()

--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -165,6 +165,8 @@ static bool open_is_pkcs11_uri(const char *value);
 static int  open_check_pkcs11_provider(void);
 static int open_load_x509_from_uri(
     nng_tls_engine_config *cfg, const char *uri, X509 **xcertp);
+static int open_load_ca_certs_from_uri(
+    nng_tls_engine_config *cfg, const char *uri, X509_STORE *xstore);
 static int open_load_pkey_from_uri(
     nng_tls_engine_config *cfg, const char *uri, EVP_PKEY **pkeyp);
 
@@ -689,21 +691,9 @@ open_config_ca_chain(
 	}
 
 	if (open_is_pkcs11_uri(certs)) {
-		X509 *      cert  = NULL;
 		X509_STORE *store = SSL_CTX_get_cert_store(cfg->ctx);
-		int         rv;
 
-		if ((rv = open_load_x509_from_uri(cfg, certs, &cert)) != 0) {
-			return (rv);
-		}
-		if (X509_STORE_add_cert(store, cert) == 0) {
-			log_error("NNG-TLS-CFG-CACHAIN"
-			          "Failed to add PKCS#11 certificate to store");
-			X509_free(cert);
-			return (NNG_ECRYPTO);
-		}
-		X509_free(cert);
-		return (0);
+		return (open_load_ca_certs_from_uri(cfg, certs, store));
 	}
 
 	len = strlen(certs);
@@ -926,6 +916,76 @@ out:
 	NNI_ARG_UNUSED(uri);
 	NNI_ARG_UNUSED(xcertp);
 	log_error("NNG-TLS-CFG-OWNCHAIN"
+	          "PKCS#11 URI support requires OpenSSL >= 3");
+	return (NNG_ENOTSUP);
+#endif
+}
+
+static int
+open_load_ca_certs_from_uri(
+    nng_tls_engine_config *cfg, const char *uri, X509_STORE *xstore)
+{
+#if NNG_OPENSSL_HAVE_PKCS11
+	OSSL_STORE_CTX * store = NULL;
+	OSSL_STORE_INFO *info  = NULL;
+	UI_METHOD *      ui    = NULL;
+	X509 *           xcert = NULL;
+	bool             found = false;
+	int              rv;
+
+	if ((rv = open_store_uri(cfg, uri, &store, &ui)) != 0) {
+		return (rv);
+	}
+
+	while ((info = OSSL_STORE_load(store)) != NULL) {
+		if (OSSL_STORE_INFO_get_type(info) == OSSL_STORE_INFO_CERT) {
+			xcert = OSSL_STORE_INFO_get1_CERT(info);
+			if (xcert == NULL) {
+				log_error("NNG-TLS-CFG-CACHAIN"
+				          "Failed to load PKCS#11 certificate");
+				rv = NNG_ECRYPTO;
+				goto out;
+			}
+			if (X509_STORE_add_cert(xstore, xcert) == 0) {
+				log_error("NNG-TLS-CFG-CACHAIN"
+				          "Failed to add PKCS#11 certificate to store");
+				rv = NNG_ECRYPTO;
+				goto out;
+			}
+			X509_free(xcert);
+			xcert = NULL;
+			found = true;
+		}
+		OSSL_STORE_INFO_free(info);
+		info = NULL;
+	}
+
+	if (OSSL_STORE_error(store)) {
+		open_log_ssl_error(
+		    "NNG-TLS-CFG-CACHAIN OSSL_STORE_load", 0);
+		rv = NNG_ECRYPTO;
+	} else if (!found) {
+		log_error("NNG-TLS-CFG-CACHAIN"
+		          "No certificate found in PKCS#11 URI");
+		rv = NNG_ECRYPTO;
+	} else {
+		rv = 0;
+	}
+
+out:
+	if (info != NULL) {
+		OSSL_STORE_INFO_free(info);
+	}
+	if (xcert != NULL) {
+		X509_free(xcert);
+	}
+	open_store_close(store, ui);
+	return (rv);
+#else
+	NNI_ARG_UNUSED(cfg);
+	NNI_ARG_UNUSED(uri);
+	NNI_ARG_UNUSED(xstore);
+	log_error("NNG-TLS-CFG-CACHAIN"
 	          "PKCS#11 URI support requires OpenSSL >= 3");
 	return (NNG_ENOTSUP);
 #endif

--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -679,6 +679,7 @@ open_config_auth_mode(nng_tls_engine_config *cfg, nng_tls_auth_mode mode)
 	return (NNG_EINVAL);
 }
 
+/** Adds PEM or PKCS#11 CA certificates to the OpenSSL trust store. */
 static int
 open_config_ca_chain(
     nng_tls_engine_config *cfg, const char *certs, const char *crl)
@@ -741,6 +742,7 @@ open_config_ca_chain(
 	return (0);
 }
 
+/** Supplies the configured PEM password or PKCS#11 PIN to OpenSSL. */
 static int
 open_get_password(char *passwd, int size, int rw, void *ctx)
 {
@@ -761,6 +763,7 @@ open_get_password(char *passwd, int size, int rw, void *ctx)
 	return ((int) len);
 }
 
+/** Returns whether value is a PKCS#11 URI, matched case-insensitively. */
 static bool
 open_is_pkcs11_uri(const char *value)
 {
@@ -768,6 +771,7 @@ open_is_pkcs11_uri(const char *value)
 	    (nni_strncasecmp(value, "pkcs11:", sizeof("pkcs11:") - 1) == 0));
 }
 
+/** Loads and caches the OpenSSL PKCS#11 provider availability status. */
 static int
 open_check_pkcs11_provider(void)
 {
@@ -814,6 +818,7 @@ out:
 }
 
 #if NNG_OPENSSL_HAVE_PKCS11
+/** Opens an OpenSSL object store for a PKCS#11 URI and optional PIN. */
 static int
 open_store_uri(nng_tls_engine_config *cfg, const char *uri,
     OSSL_STORE_CTX **storep, UI_METHOD **uip)
@@ -848,6 +853,7 @@ open_store_uri(nng_tls_engine_config *cfg, const char *uri,
 	return (0);
 }
 
+/** Closes an OpenSSL object store and releases its PIN UI method. */
 static void
 open_store_close(OSSL_STORE_CTX *store, UI_METHOD *ui)
 {
@@ -860,6 +866,7 @@ open_store_close(OSSL_STORE_CTX *store, UI_METHOD *ui)
 }
 #endif
 
+/** Loads the first certificate resolved by a PKCS#11 URI. */
 static int
 open_load_x509_from_uri(
     nng_tls_engine_config *cfg, const char *uri, X509 **xcertp)
@@ -921,6 +928,7 @@ out:
 #endif
 }
 
+/** Loads every certificate resolved by a PKCS#11 URI into a trust store. */
 static int
 open_load_ca_certs_from_uri(
     nng_tls_engine_config *cfg, const char *uri, X509_STORE *xstore)
@@ -991,6 +999,7 @@ out:
 #endif
 }
 
+/** Loads the first private key resolved by a PKCS#11 URI. */
 static int
 open_load_pkey_from_uri(
     nng_tls_engine_config *cfg, const char *uri, EVP_PKEY **pkeyp)
@@ -1052,6 +1061,7 @@ out:
 #endif
 }
 
+/** Configures a certificate and key from matching PEM data or PKCS#11 URIs. */
 static int
 open_config_own_cert(nng_tls_engine_config *cfg, const char *cert,
     const char *key, const char *pass)
@@ -1208,6 +1218,7 @@ static nng_tls_engine open_engine = {
 	.fips_mode   = false, // commercial users only
 };
 
+/** Registers the OpenSSL TLS engine with NNG. */
 int
 nng_tls_engine_init_open(void)
 {
@@ -1232,6 +1243,7 @@ nng_tls_engine_init_open(void)
 	return (nng_tls_engine_register(&open_engine));
 }
 
+/** Unregisters the OpenSSL TLS engine and releases its PKCS#11 provider. */
 void
 nng_tls_engine_fini_open(void)
 {

--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -1,5 +1,6 @@
 //
 // Copyright 2024 NanoMQ Team, Inc. <wangwei@emqx.io>
+// Copyright 2026 Liebherr-Digital Development Center (LDC) <peter.bestler@liebherr.de>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -90,6 +91,15 @@ print_hex(char *str, const uint8_t *data, size_t len)
 #include <openssl/bio.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#if !defined(LIBRESSL_VERSION_NUMBER) && \
+    OPENSSL_VERSION_NUMBER >= 0x30000000L
+#define NNG_OPENSSL_HAVE_PKCS11 1
+#include <openssl/provider.h>
+#include <openssl/store.h>
+#include <openssl/ui.h>
+#else
+#define NNG_OPENSSL_HAVE_PKCS11 0
+#endif
 
 #include "core/nng_impl.h"
 #include "nng/nng.h"
@@ -151,6 +161,19 @@ struct nng_tls_engine_config {
 };
 
 static int open_conn_handshake(nng_tls_engine_conn *ec);
+static bool open_is_pkcs11_uri(const char *value);
+static int  open_check_pkcs11_provider(void);
+static int open_load_x509_from_uri(
+    nng_tls_engine_config *cfg, const char *uri, X509 **xcertp);
+static int open_load_pkey_from_uri(
+    nng_tls_engine_config *cfg, const char *uri, EVP_PKEY **pkeyp);
+
+#if NNG_OPENSSL_HAVE_PKCS11
+static nni_mtx        open_pkcs11_lock = NNI_MTX_INITIALIZER;
+static OSSL_PROVIDER *open_pkcs11_provider = NULL;
+static bool           open_pkcs11_checked  = false;
+static int            open_pkcs11_status   = NNG_ENOTSUP;
+#endif
 
 /************************* SSL Connection ***********************/
 
@@ -661,8 +684,28 @@ open_config_ca_chain(
 	size_t len;
 	trace("start");
 	if (certs == NULL) {
-		log_info("open_config_ca_chain" "NULL certs detected!");
+		log_error("NNG-TLS-CFG-CACHAIN" "No certificates supplied");
+		return (NNG_EINVAL);
 	}
+
+	if (open_is_pkcs11_uri(certs)) {
+		X509 *      cert  = NULL;
+		X509_STORE *store = SSL_CTX_get_cert_store(cfg->ctx);
+		int         rv;
+
+		if ((rv = open_load_x509_from_uri(cfg, certs, &cert)) != 0) {
+			return (rv);
+		}
+		if (X509_STORE_add_cert(store, cert) == 0) {
+			log_error("NNG-TLS-CFG-CACHAIN"
+			          "Failed to add PKCS#11 certificate to store");
+			X509_free(cert);
+			return (NNG_ECRYPTO);
+		}
+		X509_free(cert);
+		return (0);
+	}
+
 	len = strlen(certs);
 
 	BIO *bio = BIO_new_mem_buf(certs, len);
@@ -708,44 +751,262 @@ open_config_ca_chain(
 	return (0);
 }
 
-#if NNG_OPENSSL_HAVE_PASSWORD
 static int
 open_get_password(char *passwd, int size, int rw, void *ctx)
 {
-	// password is *not* NUL terminated in wolf
-	trace("start");
 	nng_tls_engine_config *cfg = ctx;
 	size_t                 len;
 
 	(void) rw;
 
-	if (cfg->pass == NULL) {
+	if ((cfg == NULL) || (cfg->pass == NULL) || (size <= 0)) {
 		return (0);
 	}
-	len = strlen(cfg->pass); // Our "ctx" is really the password.
-	if (len > (size_t) size) {
-		len = size;
+	len = strlen(cfg->pass);
+	if (len >= (size_t) size) {
+		len = (size_t) size - 1;
 	}
 	memcpy(passwd, cfg->pass, len);
-	trace("end");
-	return (len);
+	passwd[len] = '\0';
+	return ((int) len);
+}
+
+static bool
+open_is_pkcs11_uri(const char *value)
+{
+	return ((value != NULL) &&
+	    (nni_strncasecmp(value, "pkcs11:", sizeof("pkcs11:") - 1) == 0));
+}
+
+static int
+open_check_pkcs11_provider(void)
+{
+#if NNG_OPENSSL_HAVE_PKCS11
+	int rv;
+
+	nni_mtx_lock(&open_pkcs11_lock);
+
+	if (open_pkcs11_checked) {
+		rv = open_pkcs11_status;
+		goto out;
+	}
+
+	open_pkcs11_status = NNG_ECRYPTO;
+	if (!OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL)) {
+		log_error("NNG-TLS-CFG-OWNCHAIN"
+		          "Failed to initialize OpenSSL configuration for "
+		          "PKCS#11 support");
+		goto done;
+	}
+
+	open_pkcs11_provider = OSSL_PROVIDER_load(NULL, "pkcs11");
+	if (open_pkcs11_provider == NULL) {
+		log_error("NNG-TLS-CFG-OWNCHAIN"
+		          "Failed to load OpenSSL pkcs11 provider; configure "
+		          "openssl.cnf or OPENSSL_MODULES");
+		goto done;
+	}
+
+	open_pkcs11_status = 0;
+
+done:
+	open_pkcs11_checked = true;
+	rv                  = open_pkcs11_status;
+
+out:
+	nni_mtx_unlock(&open_pkcs11_lock);
+	return (rv);
+#else
+	log_error("NNG-TLS-CFG-OWNCHAIN"
+	          "PKCS#11 URI support requires OpenSSL >= 3");
+	return (NNG_ENOTSUP);
+#endif
+}
+
+#if NNG_OPENSSL_HAVE_PKCS11
+static int
+open_store_uri(nng_tls_engine_config *cfg, const char *uri,
+    OSSL_STORE_CTX **storep, UI_METHOD **uip)
+{
+	OSSL_STORE_CTX *store;
+	UI_METHOD      *ui = NULL;
+	int             rv;
+
+	if ((rv = open_check_pkcs11_provider()) != 0) {
+		return (rv);
+	}
+	if ((cfg != NULL) && (cfg->pass != NULL) &&
+	    ((ui = UI_UTIL_wrap_read_pem_callback(
+	          open_get_password, 0)) == NULL)) {
+		log_error("NNG-TLS-CFG-OWNCHAIN"
+		          "Failed to create PKCS#11 PIN callback");
+		return (NNG_ENOMEM);
+	}
+	store = OSSL_STORE_open(uri, ui, cfg, NULL, NULL);
+	if (store == NULL) {
+		log_error("NNG-TLS-CFG-OWNCHAIN"
+		          "Failed to open PKCS#11 URI: %s",
+		    uri);
+		open_log_ssl_error("NNG-TLS-CFG-OWNCHAIN OSSL_STORE_open", 0);
+		if (ui != NULL) {
+			UI_destroy_method(ui);
+		}
+		return (NNG_ECRYPTO);
+	}
+	*storep = store;
+	*uip    = ui;
+	return (0);
+}
+
+static void
+open_store_close(OSSL_STORE_CTX *store, UI_METHOD *ui)
+{
+	if ((store != NULL) && (OSSL_STORE_close(store) == 0)) {
+		open_log_ssl_error("NNG-TLS-CFG-OWNCHAIN OSSL_STORE_close", 0);
+	}
+	if (ui != NULL) {
+		UI_destroy_method(ui);
+	}
 }
 #endif
+
+static int
+open_load_x509_from_uri(
+    nng_tls_engine_config *cfg, const char *uri, X509 **xcertp)
+{
+#if NNG_OPENSSL_HAVE_PKCS11
+	OSSL_STORE_CTX * store = NULL;
+	OSSL_STORE_INFO *info  = NULL;
+	UI_METHOD *      ui    = NULL;
+	X509 *           xcert = NULL;
+	int              rv;
+
+	if ((rv = open_store_uri(cfg, uri, &store, &ui)) != 0) {
+		return (rv);
+	}
+
+	while ((info = OSSL_STORE_load(store)) != NULL) {
+		if (OSSL_STORE_INFO_get_type(info) == OSSL_STORE_INFO_CERT) {
+			xcert = OSSL_STORE_INFO_get1_CERT(info);
+			OSSL_STORE_INFO_free(info);
+			info = NULL;
+			break;
+		}
+		OSSL_STORE_INFO_free(info);
+		info = NULL;
+	}
+
+	if (xcert == NULL) {
+		log_error("NNG-TLS-CFG-OWNCHAIN"
+		          "No certificate found in PKCS#11 URI: %s",
+		    uri);
+		if (OSSL_STORE_error(store)) {
+			open_log_ssl_error(
+			    "NNG-TLS-CFG-OWNCHAIN OSSL_STORE_load", 0);
+		}
+		rv = NNG_ECRYPTO;
+		goto out;
+	}
+
+	*xcertp = xcert;
+	xcert   = NULL;
+	rv      = 0;
+
+out:
+	if (info) {
+		OSSL_STORE_INFO_free(info);
+	}
+	open_store_close(store, ui);
+	if (xcert) {
+		X509_free(xcert);
+	}
+	return (rv);
+#else
+	NNI_ARG_UNUSED(cfg);
+	NNI_ARG_UNUSED(uri);
+	NNI_ARG_UNUSED(xcertp);
+	log_error("NNG-TLS-CFG-OWNCHAIN"
+	          "PKCS#11 URI support requires OpenSSL >= 3");
+	return (NNG_ENOTSUP);
+#endif
+}
+
+static int
+open_load_pkey_from_uri(
+    nng_tls_engine_config *cfg, const char *uri, EVP_PKEY **pkeyp)
+{
+#if NNG_OPENSSL_HAVE_PKCS11
+	OSSL_STORE_CTX * store = NULL;
+	OSSL_STORE_INFO *info  = NULL;
+	UI_METHOD *      ui    = NULL;
+	EVP_PKEY *       pkey  = NULL;
+	int              rv;
+
+	if ((rv = open_store_uri(cfg, uri, &store, &ui)) != 0) {
+		return (rv);
+	}
+
+	while ((info = OSSL_STORE_load(store)) != NULL) {
+		if (OSSL_STORE_INFO_get_type(info) == OSSL_STORE_INFO_PKEY) {
+			pkey = OSSL_STORE_INFO_get1_PKEY(info);
+			OSSL_STORE_INFO_free(info);
+			info = NULL;
+			break;
+		}
+		OSSL_STORE_INFO_free(info);
+		info = NULL;
+	}
+
+	if (pkey == NULL) {
+		log_error("NNG-TLS-CFG-OWNCHAIN"
+		          "No private key found in PKCS#11 URI: %s",
+		    uri);
+		if (OSSL_STORE_error(store)) {
+			open_log_ssl_error(
+			    "NNG-TLS-CFG-OWNCHAIN OSSL_STORE_load", 0);
+		}
+		rv = NNG_ECRYPTO;
+		goto out;
+	}
+
+	*pkeyp = pkey;
+	pkey   = NULL;
+	rv     = 0;
+
+out:
+	if (info) {
+		OSSL_STORE_INFO_free(info);
+	}
+	open_store_close(store, ui);
+	if (pkey) {
+		EVP_PKEY_free(pkey);
+	}
+	return (rv);
+#else
+	NNI_ARG_UNUSED(cfg);
+	NNI_ARG_UNUSED(uri);
+	NNI_ARG_UNUSED(pkeyp);
+	log_error("NNG-TLS-CFG-OWNCHAIN"
+	          "PKCS#11 URI support requires OpenSSL >= 3");
+	return (NNG_ENOTSUP);
+#endif
+}
 
 static int
 open_config_own_cert(nng_tls_engine_config *cfg, const char *cert,
     const char *key, const char *pass)
 {
-	int len;
-	int rv = 0;
-	BIO *biokey = NULL;
-	BIO *biocert = NULL;
-	X509 *xcert = NULL;
-	EVP_PKEY *pkey = NULL;
+	int       len;
+	int       rv          = 0;
+	bool      cert_pkcs11 = open_is_pkcs11_uri(cert);
+	bool      key_pkcs11  = open_is_pkcs11_uri(key);
+	BIO *     biokey      = NULL;
+	BIO *     biocert     = NULL;
+	X509 *    xcert       = NULL;
+	EVP_PKEY *pkey        = NULL;
+	char *    dup         = NULL;
 	trace("start");
 
-#if NNG_OPENSSL_HAVE_PASSWORD
-	char *dup = NULL;
 	if (pass != NULL) {
 		if ((dup = nng_strdup(pass)) == NULL) {
 			return (NNG_ENOMEM);
@@ -757,22 +1018,33 @@ open_config_own_cert(nng_tls_engine_config *cfg, const char *cert,
 	cfg->pass = dup;
 	SSL_CTX_set_default_passwd_cb_userdata(cfg->ctx, cfg);
 	SSL_CTX_set_default_passwd_cb(cfg->ctx, open_get_password);
-#else
-	(void) pass;
-#endif
 
-	len = strlen(cert);
-	biocert = BIO_new_mem_buf(cert, len);
-	if (!biocert) {
-		log_error("NNG-TLS-CFG-OWNCHAIN" "Failed to create BIO");
-		rv = NNG_ENOMEM;
-		goto error;
-	}
-	xcert = PEM_read_bio_X509(biocert, NULL, 0, NULL);
-	if (!xcert) {
-		log_error("NNG-TLS-CFG-OWNCHAIN" "Failed to load certificate from buffer");
+	if (cert_pkcs11 != key_pkcs11) {
+		log_error("NNG-TLS-CFG-OWNCHAIN"
+		          "PKCS#11 strict mode: cert and key must both be PKCS#11 URIs");
 		rv = NNG_EINVAL;
 		goto error;
+	}
+
+	if (cert_pkcs11) {
+		if ((rv = open_load_x509_from_uri(cfg, cert, &xcert)) != 0) {
+			goto error;
+		}
+	} else {
+		len = strlen(cert);
+		biocert = BIO_new_mem_buf(cert, len);
+		if (!biocert) {
+			log_error("NNG-TLS-CFG-OWNCHAIN" "Failed to create BIO");
+			rv = NNG_ENOMEM;
+			goto error;
+		}
+		xcert = PEM_read_bio_X509(biocert, NULL, 0, NULL);
+		if (!xcert) {
+			log_error("NNG-TLS-CFG-OWNCHAIN"
+			          "Failed to load certificate from buffer");
+			rv = NNG_EINVAL;
+			goto error;
+		}
 	}
 	if (SSL_CTX_use_certificate(cfg->ctx, xcert) <= 0) {
 		log_error("NNG-TLS-CFG-OWNCHAIN" "Failed to set certificate to SSL_CTX");
@@ -780,18 +1052,26 @@ open_config_own_cert(nng_tls_engine_config *cfg, const char *cert,
 		goto error;
 	}
 
-	len = strlen(key);
-	biokey = BIO_new_mem_buf(key, len);
-	if (!biokey) {
-		log_error("NNG-TLS-CFG-OWNCHAIN" "Failed to create key BIO");
-		rv = NNG_ENOMEM;
-		goto error;
-	}
-	pkey = PEM_read_bio_PrivateKey(biokey, NULL, NULL, NULL);
-	if (!pkey) {
-		log_error("NNG-TLS-CFG-OWNCHAIN" "Failed to load key from buffer");
-		rv = NNG_EINVAL;
-		goto error;
+	if (key_pkcs11) {
+		if ((rv = open_load_pkey_from_uri(cfg, key, &pkey)) != 0) {
+			goto error;
+		}
+	} else {
+		len = strlen(key);
+		biokey = BIO_new_mem_buf(key, len);
+		if (!biokey) {
+			log_error("NNG-TLS-CFG-OWNCHAIN" "Failed to create key BIO");
+			rv = NNG_ENOMEM;
+			goto error;
+		}
+		pkey = PEM_read_bio_PrivateKey(
+		    biokey, NULL, open_get_password, cfg);
+		if (!pkey) {
+			log_error("NNG-TLS-CFG-OWNCHAIN"
+			          "Failed to load key from buffer");
+			rv = NNG_EINVAL;
+			goto error;
+		}
 	}
 	if (SSL_CTX_use_PrivateKey(cfg->ctx, pkey) <= 0) {
 		log_error("NNG-TLS-CFG-OWNCHAIN" "Failed to set key to SSL_CTX");
@@ -806,17 +1086,21 @@ open_config_own_cert(nng_tls_engine_config *cfg, const char *cert,
 	}
 
 error:
-	if (xcert)
+	if (xcert) {
 		X509_free(xcert);
-	if (biocert)
+	}
+	if (biocert) {
 		BIO_free(biocert);
-	if (pkey)
+	}
+	if (pkey) {
 		EVP_PKEY_free(pkey);
-	if (biokey)
+	}
+	if (biokey) {
 		BIO_free(biokey);
+	}
 
 	trace("end");
-	return rv;
+	return (rv);
 }
 
 static int
@@ -860,7 +1144,7 @@ static nng_tls_engine open_engine = {
 	.config_ops  = &open_config_ops,
 	.conn_ops    = &open_conn_ops,
 	.name        = "open",
-	.description = "OpenSSL 1.1.1",
+	.description = "OpenSSL",
 	.fips_mode   = false, // commercial users only
 };
 
@@ -892,6 +1176,16 @@ void
 nng_tls_engine_fini_open(void)
 {
 	trace("start");
+#if NNG_OPENSSL_HAVE_PKCS11
+	nni_mtx_lock(&open_pkcs11_lock);
+	if (open_pkcs11_provider != NULL) {
+		OSSL_PROVIDER_unload(open_pkcs11_provider);
+		open_pkcs11_provider = NULL;
+	}
+	open_pkcs11_checked = false;
+	open_pkcs11_status  = NNG_ENOTSUP;
+	nni_mtx_unlock(&open_pkcs11_lock);
+#endif
 	EVP_cleanup();
 	trace("end");
 }

--- a/src/supplemental/tls/openssl/pkcs11_test.c
+++ b/src/supplemental/tls/openssl/pkcs11_test.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <nuts.h>
 
+/** Returns a required nonempty environment variable for PKCS#11 tests. */
 static const char *
 pkcs11_test_env(const char *name)
 {
@@ -20,6 +21,7 @@ pkcs11_test_env(const char *name)
 	return (value);
 }
 
+/** Verifies valid PKCS#11 credentials before exercising an invalid PIN. */
 void
 test_pkcs11_credentials(void)
 {

--- a/src/supplemental/tls/openssl/pkcs11_test.c
+++ b/src/supplemental/tls/openssl/pkcs11_test.c
@@ -1,0 +1,57 @@
+//
+// Copyright 2026 Liebherr-Digital Development Center (LDC) <peter.bestler@liebherr.de>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#include <stdlib.h>
+#include <nuts.h>
+
+static const char *
+pkcs11_test_env(const char *name)
+{
+	const char *value = getenv(name);
+
+	TEST_ASSERT_(value != NULL && value[0] != '\0',
+	    "required environment variable %s is set", name);
+	return (value);
+}
+
+void
+test_pkcs11_credentials(void)
+{
+	const char     *cert_uri;
+	const char     *key_uri;
+	const char     *ca_uri;
+	const char     *pin;
+	nng_tls_config *server_cfg;
+	nng_tls_config *client_cfg;
+	nng_tls_config *invalid_cfg;
+
+	cert_uri = pkcs11_test_env("NNG_PKCS11_CERT_URI");
+	key_uri  = pkcs11_test_env("NNG_PKCS11_KEY_URI");
+	ca_uri   = pkcs11_test_env("NNG_PKCS11_CA_URI");
+	pin      = pkcs11_test_env("NNG_PKCS11_PIN");
+
+	NUTS_PASS(nng_tls_config_alloc(&invalid_cfg, NNG_TLS_MODE_SERVER));
+	NUTS_FAIL(nng_tls_config_own_cert(
+	              invalid_cfg, cert_uri, key_uri, "invalid-pin"),
+	    NNG_ECRYPTO);
+	nng_tls_config_free(invalid_cfg);
+
+	NUTS_PASS(nng_tls_config_alloc(&server_cfg, NNG_TLS_MODE_SERVER));
+	NUTS_PASS(
+	    nng_tls_config_own_cert(server_cfg, cert_uri, key_uri, pin));
+	NUTS_PASS(nng_tls_config_alloc(&client_cfg, NNG_TLS_MODE_CLIENT));
+	NUTS_PASS(nng_tls_config_ca_chain(client_cfg, ca_uri, NULL));
+	nng_tls_config_free(server_cfg);
+	nng_tls_config_free(client_cfg);
+}
+
+NUTS_TESTS = {
+	{ "PKCS#11 credentials", test_pkcs11_credentials },
+	{ NULL, NULL },
+};

--- a/src/supplemental/tls/openssl/pkcs11_test.c
+++ b/src/supplemental/tls/openssl/pkcs11_test.c
@@ -36,12 +36,6 @@ test_pkcs11_credentials(void)
 	ca_uri   = pkcs11_test_env("NNG_PKCS11_CA_URI");
 	pin      = pkcs11_test_env("NNG_PKCS11_PIN");
 
-	NUTS_PASS(nng_tls_config_alloc(&invalid_cfg, NNG_TLS_MODE_SERVER));
-	NUTS_FAIL(nng_tls_config_own_cert(
-	              invalid_cfg, cert_uri, key_uri, "invalid-pin"),
-	    NNG_ECRYPTO);
-	nng_tls_config_free(invalid_cfg);
-
 	NUTS_PASS(nng_tls_config_alloc(&server_cfg, NNG_TLS_MODE_SERVER));
 	NUTS_PASS(
 	    nng_tls_config_own_cert(server_cfg, cert_uri, key_uri, pin));
@@ -49,6 +43,12 @@ test_pkcs11_credentials(void)
 	NUTS_PASS(nng_tls_config_ca_chain(client_cfg, ca_uri, NULL));
 	nng_tls_config_free(server_cfg);
 	nng_tls_config_free(client_cfg);
+
+	NUTS_PASS(nng_tls_config_alloc(&invalid_cfg, NNG_TLS_MODE_SERVER));
+	NUTS_FAIL(nng_tls_config_own_cert(
+	              invalid_cfg, cert_uri, key_uri, "invalid-pin"),
+	    NNG_ECRYPTO);
+	nng_tls_config_free(invalid_cfg);
 }
 
 NUTS_TESTS = {


### PR DESCRIPTION
  Add OpenSSL 3 provider support for PKCS#11 credential URIs.

  This allows NanoMQ bridges to use hardware-backed certificates, private keys,
  and trust anchors for mutual TLS on embedded devices. This is required for
  Liebherr-Digital Development Center (LDC) deployments using PKCS#11.

  The change includes:

  - PKCS#11 URI support in both configuration parsers and environment overrides
  - OpenSSL provider-store loading with PIN support
  - OpenSSL 3/provider validation
  - Parser and URI-handling tests
  - An opt-in SoftHSM integration workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional PKCS#11 support for TLS credentials through OpenSSL 3 or later.
  * TLS certificates, private keys, and CA certificates can now be loaded directly from PKCS#11 URIs.
  * Added configuration support for PKCS#11-backed credentials in legacy and current formats.

* **Bug Fixes**
  * Improved TLS credential loading and handling of invalid file references.
  * Added validation to prevent mismatched PKCS#11 and PEM certificate/key combinations.

* **Tests**
  * Added automated coverage for valid and invalid PKCS#11 credentials, configuration parsing, and TLS connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->