### PR TITLE
 Fix ACL-deny kick frame carries reason Not authorized

### DIFF
--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -1196,6 +1196,7 @@ nano_dismsg_composer(reason_code code, char* rstr, uint8_t *ref, property *prop)
 		buf[0] = (uint8_t)PROTOCOL_ERROR;
 		nng_msg_append(msg, buf, 1);
 		break;
+	case NOT_AUTHORIZED:
 	case BANNED:
 		buf[0] = (uint8_t)NOT_AUTHORIZED;
 		nng_msg_append(msg, buf, 1);

--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -1196,6 +1196,10 @@ nano_dismsg_composer(reason_code code, char* rstr, uint8_t *ref, property *prop)
 		buf[0] = (uint8_t)PROTOCOL_ERROR;
 		nng_msg_append(msg, buf, 1);
 		break;
+	case BANNED:
+		buf[0] = (uint8_t)NOT_AUTHORIZED;
+		nng_msg_append(msg, buf, 1);
+		break;
 	default:
 		buf[0] = (uint8_t)UNSPECIFIED_ERROR;
 		nng_msg_append(msg, buf, 1);


### PR DESCRIPTION
Fix issue https://github.com/emqx/NanoMQ_mirror/issues/655.

