### PR TITLE
* FIX [mqtt_codec] accept SUBSCRIPTION_IDENTIFIER in PUBLISH decode

### DIFF
--- a/include/nng/protocol/mqtt/mqtt_parser.h
+++ b/include/nng/protocol/mqtt/mqtt_parser.h
@@ -117,6 +117,7 @@ NNG_DECL property *decode_properties(
     nng_msg *msg, uint32_t *pos, uint32_t *len, bool copy_value);
 NNG_DECL int      encode_properties(nng_msg *msg, property *prop, uint8_t cmd);
 NNG_DECL int      property_free(property *prop);
+NNG_DECL void     property_remove(property *prop_list, uint8_t prop_id);
 NNG_DECL property_data *property_get_value(property *prop, uint8_t prop_id);
 NNG_DECL void      property_foreach(property *prop, void (*cb)(property *));
 NNG_DECL int       property_dup(property **dup, const property *src);

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -4151,11 +4151,12 @@ check_properties(property *prop, nni_msg *msg)
 				log_warn("SUBSCRIPTION_IDENTIFIER invalid value: %d", p1->data.p_value.varint);
 				return PROTOCOL_ERROR;
 			}
-			// PUBLISH from client to broker shall not contain Subscription Identifier
-			if (type == CMD_PUBLISH) {
-				log_warn("SUBSCRIPTION_IDENTIFIER detected in upstream PUBLISH!");
-				return PROTOCOL_ERROR;
-			}
+			// This codec is direction-agnostic: a server -> client PUBLISH
+			// may legally carry a Subscription Identifier echoing the
+			// subscriber's SUBSCRIBE (MQTT-3.3.4-6). The client -> server
+			// prohibition (MQTT-3.3.4-5) is enforced by direction-aware
+			// callers, e.g. NanoMQ's decode_pub_message() on the broker
+			// ingest path.
 			break;
 
 		default:


### PR DESCRIPTION
Fix issue https://github.com/emqx/NanoMQ_mirror/issues/666

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MQTT compatibility for PUBLISH messages containing Subscription Identifier properties.
  - Server-to-client PUBLISH messages can now carry Subscription Identifiers as permitted by the MQTT specification.
  - Client-to-broker validation continues to enforce the protocol’s restrictions through direction-aware processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->