### PR TITLE
fix(tls): allow a PEM certificate with a PKCS#11 key

### DIFF
--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -1057,7 +1057,15 @@ out:
 #endif
 }
 
-/** Configures a certificate and key from matching PEM data or PKCS#11 URIs. */
+/**
+ * Configures our identity certificate and private key.
+ *
+ * The certificate and the key are resolved independently: each may be
+ * either PEM data or a PKCS#11 URI. This allows a certificate to stay in
+ * the filesystem while its key lives on a token, which is the common HSM
+ * deployment. OpenSSL confirms that the two belong together via
+ * SSL_CTX_check_private_key() below.
+ */
 static int
 open_config_own_cert(nng_tls_engine_config *cfg, const char *cert,
     const char *key, const char *pass)
@@ -1084,13 +1092,6 @@ open_config_own_cert(nng_tls_engine_config *cfg, const char *cert,
 	cfg->pass = dup;
 	SSL_CTX_set_default_passwd_cb_userdata(cfg->ctx, cfg);
 	SSL_CTX_set_default_passwd_cb(cfg->ctx, open_get_password);
-
-	if (cert_pkcs11 != key_pkcs11) {
-		log_error("NNG-TLS-CFG-OWNCHAIN"
-		          "PKCS#11 strict mode: cert and key must both be PKCS#11 URIs");
-		rv = NNG_EINVAL;
-		goto error;
-	}
 
 	if (cert_pkcs11) {
 		if ((rv = open_load_x509_from_uri(cfg, cert, &xcert)) != 0) {

--- a/src/supplemental/tls/openssl/pkcs11_test.c
+++ b/src/supplemental/tls/openssl/pkcs11_test.c
@@ -21,6 +21,46 @@ pkcs11_test_env(const char *name)
 	return (value);
 }
 
+/** Returns an optional environment variable, or NULL when unset or empty. */
+static const char *
+pkcs11_test_env_opt(const char *name)
+{
+	const char *value = getenv(name);
+
+	return (((value != NULL) && (value[0] != '\0')) ? value : NULL);
+}
+
+/** Reads a whole file into a NUL-terminated buffer the caller frees. */
+static char *
+pkcs11_test_read_file(const char *path)
+{
+	FILE  *fp;
+	char  *buf;
+	long   len;
+	size_t got;
+
+	if ((fp = fopen(path, "rb")) == NULL) {
+		return (NULL);
+	}
+	if ((fseek(fp, 0, SEEK_END) != 0) || ((len = ftell(fp)) < 0) ||
+	    (fseek(fp, 0, SEEK_SET) != 0)) {
+		fclose(fp);
+		return (NULL);
+	}
+	if ((buf = malloc((size_t) len + 1)) == NULL) {
+		fclose(fp);
+		return (NULL);
+	}
+	got = fread(buf, 1, (size_t) len, fp);
+	fclose(fp);
+	if (got != (size_t) len) {
+		free(buf);
+		return (NULL);
+	}
+	buf[len] = '\0';
+	return (buf);
+}
+
 /** Verifies valid PKCS#11 credentials before exercising an invalid PIN. */
 void
 test_pkcs11_credentials(void)
@@ -53,7 +93,42 @@ test_pkcs11_credentials(void)
 	nng_tls_config_free(invalid_cfg);
 }
 
+/**
+ * Verifies a PEM certificate paired with a PKCS#11 private key.
+ *
+ * This is the common HSM deployment: the certificate stays in the
+ * filesystem while only the key lives on the token. Requires
+ * NNG_PKCS11_CERT_PEM to name a PEM file holding the certificate that
+ * belongs to NNG_PKCS11_KEY_URI; the check is skipped when that fixture is
+ * not configured.
+ */
+void
+test_pkcs11_mixed_credentials(void)
+{
+	const char     *cert_path;
+	const char     *key_uri;
+	const char     *pin;
+	char           *cert_pem;
+	nng_tls_config *cfg;
+
+	if ((cert_path = pkcs11_test_env_opt("NNG_PKCS11_CERT_PEM")) == NULL) {
+		return;
+	}
+	key_uri = pkcs11_test_env("NNG_PKCS11_KEY_URI");
+	pin     = pkcs11_test_env("NNG_PKCS11_PIN");
+
+	cert_pem = pkcs11_test_read_file(cert_path);
+	TEST_ASSERT_(cert_pem != NULL, "certificate file %s is readable",
+	    cert_path);
+
+	NUTS_PASS(nng_tls_config_alloc(&cfg, NNG_TLS_MODE_SERVER));
+	NUTS_PASS(nng_tls_config_own_cert(cfg, cert_pem, key_uri, pin));
+	nng_tls_config_free(cfg);
+	free(cert_pem);
+}
+
 NUTS_TESTS = {
 	{ "PKCS#11 credentials", test_pkcs11_credentials },
+	{ "PKCS#11 mixed credentials", test_pkcs11_mixed_credentials },
 	{ NULL, NULL },
 };


### PR DESCRIPTION
Follow-up to #1628.

`open_config_own_cert()` currently rejects any configuration in which only one of
the certificate and the key is a PKCS#11 URI:

```c
if (cert_pkcs11 != key_pkcs11) {
        log_error("NNG-TLS-CFG-OWNCHAIN"
                  "PKCS#11 strict mode: cert and key must both be PKCS#11 URIs");
        rv = NNG_EINVAL;
        goto error;
}
```

That rules out the most common HSM deployment, where the certificate stays a PEM
file in the filesystem and only the private key lives on the token.

Nothing in the engine actually requires the two to share a source:

- both branches of the function already resolve the certificate and the key
  independently;
- `open_store_uri()` performs the provider check for whichever credential is a
  URI, so the OpenSSL 3 / `pkcs11` provider requirement still holds when only the
  key is one;
- the PIN callback is installed before either credential is loaded;
- `SSL_CTX_check_private_key()` still verifies that the certificate and the key
  belong together, so a genuine mismatch is caught with `NNG_ECRYPTO`.

This drops the pairing check and covers the mixed case in `pkcs11_test`.

## Testing

Built with `-DNNG_ENABLE_TLS=ON -DNNG_TLS_ENGINE=open
-DNNG_TEST_PKCS11_PROVIDER=ON -DNNG_REQUIRE_PKCS11_PROVIDER=ON`; no new warnings
in the changed files.

`tls_test` shows the same five failures before and after this change — `tls large
message`, `tls garbled cert`, and the three PSK cases — verified by rebuilding and
rerunning against the unmodified parent commit. They are pre-existing gaps in the
OpenSSL engine and unrelated to this change. `tls mutual auth` stays green.

The new `test_pkcs11_mixed_credentials` is gated on an optional
`NNG_PKCS11_CERT_PEM` naming the PEM certificate that belongs to
`NNG_PKCS11_KEY_URI`. It returns early when that fixture is unset, so existing
token setups are unaffected.

One point worth a reviewer's attention: `SSL_CTX_check_private_key()` needs the
public part of the token key to be readable. `pkcs11-provider` exposes it in the
normal case, but a token holding a private-only object without a public
counterpart could trip this. That is exactly the path the new test exercises, and
I could not verify it against real hardware here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TLS configurations can now independently use PEM data or PKCS#11 URIs for certificates and private keys.
  * Certificate and key compatibility is validated before establishing a secure connection.

* **Tests**
  * Added coverage for mixed PEM certificate and PKCS#11 key configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->