### PR TITLE
fix(tests): serve the chunked HTTP response locally

### DIFF
--- a/tests/httpclient.c
+++ b/tests/httpclient.c
@@ -19,6 +19,7 @@
 #include <nng/supplemental/tls/tls.h>
 
 #include "core/nng_impl.h"
+#include "supplemental/http/http_api.h"
 
 #include "supplemental/sha1/sha1.c"
 #include "supplemental/sha1/sha1.h"
@@ -56,6 +57,143 @@ static const char *chunked_reply[] = {
 	"\n\r\n",
 	NULL,
 };
+
+// The reply above is served over TCP, which does not preserve write
+// boundaries, so that exchange cannot guarantee that
+// nni_http_chunks_parse() ever had to resume mid token.  The streams below
+// are handed to the parser directly instead, in every piece size from a
+// single byte up to the whole stream, which does guarantee it.  Between
+// them they cover single and multi digit sizes, both hex letter cases,
+// chunk extensions, several trailer fields and no trailer at all.
+#define CHUNK_A "The quick brown fox jumps over " // 31 == 0x1f
+#define CHUNK_B "the lazy dog!!!"                 // 15 == 0xF
+#define CHUNK_C " Pack my box XYZ"                // 16 == 0x10
+
+static const char chunked_multi[] = "1f\r\n" CHUNK_A "\r\nF\r\n" CHUNK_B
+                                    "\r\n10\r\n" CHUNK_C
+                                    "\r\n0\r\nX-A: 1\r\nX-B: 2\r\n\r\n";
+static const char chunked_multi_body[] = CHUNK_A CHUNK_B CHUNK_C;
+
+static const char chunked_ext[]      = "1F;a=b;c\r\n" CHUNK_A "\r\n0\r\n\r\n";
+static const char chunked_ext_body[] = CHUNK_A;
+
+// Malformed streams; the parser has to reject every one of these.
+static const char *chunked_bad[] = {
+	"2\r\nabXX0\r\n\r\n",               // data not followed by CRLF
+	"2\r\nab\r\nzz\r\n\r\n",            // bad hex digit in a size line
+	"8;x\nchunked \r\n0\r\n\r\n",       // bare LF in a chunk extension
+	"1\r\na\r\n0\r\nX-\x01: 1\r\n\r\n", // control byte in the trailer
+	"8\rXchunked \r\n0\r\n\r\n",        // CR in a size line, no LF
+	"\r\n0\r\n\r\n",                    // size line starts with CR
+	";x=y\r\n0\r\n\r\n",                // size line starts with an extension
+	NULL,
+};
+
+// Parses one stream in fixed size pieces, so that the parser has to resume
+// wherever the piece boundaries fall.  Collects the chunk data into out.
+// A parse that finishes early, or that stops making progress, is a failure.
+static int
+chunk_feed(const char *str, size_t n, size_t piece, char *out, size_t outsz,
+    size_t *outlen)
+{
+	nni_http_chunks *cl;
+	nni_http_chunk * ch  = NULL;
+	size_t           i   = 0;
+	size_t           off = 0;
+	int              rv  = NNG_EAGAIN;
+
+	*outlen = 0;
+	if ((rv = nni_http_chunks_init(&cl, 0)) != 0) {
+		return (rv);
+	}
+	while (i < n) {
+		size_t len = 0;
+		size_t k   = piece < (n - i) ? piece : (n - i);
+
+		rv = nni_http_chunks_parse(cl, (void *) (str + i), k, &len);
+		if ((rv != 0) && (rv != NNG_EAGAIN)) {
+			nni_http_chunks_free(cl);
+			return (rv);
+		}
+		if ((rv == NNG_EAGAIN) && (len == 0)) {
+			nni_http_chunks_free(cl); // no forward progress
+			return (NNG_ESTATE);
+		}
+		i += len;
+		if (rv == 0) {
+			break;
+		}
+	}
+	// A finished parse has to land exactly on the end of the stream;
+	// stopping short means the parser lost track of where it was.
+	if ((rv == 0) && (i != n)) {
+		nni_http_chunks_free(cl);
+		return (NNG_ESTATE);
+	}
+	while ((rv == 0) &&
+	    ((ch = nni_http_chunks_iter(cl, ch)) != NULL)) {
+		if ((off + nni_http_chunk_size(ch)) > outsz) {
+			nni_http_chunks_free(cl);
+			return (NNG_EMSGSIZE);
+		}
+		memcpy(out + off, nni_http_chunk_data(ch),
+		    nni_http_chunk_size(ch));
+		off += nni_http_chunk_size(ch);
+	}
+	*outlen = off;
+	nni_http_chunks_free(cl);
+	return (rv);
+}
+
+// Runs one good stream through every piece size.  Returns the piece size
+// that failed, or zero if all of them parsed to the expected body.
+static size_t
+chunk_check_splits(const char *wire, const char *body)
+{
+	char   out[128];
+	size_t n = strlen(wire);
+	size_t piece;
+
+	for (piece = 1; piece <= n; piece++) {
+		size_t len = 0;
+		int    rv;
+
+		rv = chunk_feed(wire, n, piece, out, sizeof(out), &len);
+		if (rv != 0) {
+			printf("piece %u: parse failed: %s\n",
+			    (unsigned) piece, nng_strerror(rv));
+			return (piece);
+		}
+		if ((len != strlen(body)) || (memcmp(out, body, len) != 0)) {
+			printf("piece %u: body mismatch, got %u bytes\n",
+			    (unsigned) piece, (unsigned) len);
+			return (piece);
+		}
+	}
+	return (0);
+}
+
+// Returns the piece size at which a malformed stream was wrongly accepted,
+// or zero if it was rejected at every piece size.
+static size_t
+chunk_check_rejected(const char *wire)
+{
+	char   out[128];
+	size_t n = strlen(wire);
+	size_t piece;
+
+	for (piece = 1; piece <= n; piece++) {
+		size_t len = 0;
+
+		if (chunk_feed(wire, n, piece, out, sizeof(out), &len) !=
+		    NNG_EPROTO) {
+			printf("piece %u: bad stream was not rejected\n",
+			    (unsigned) piece);
+			return (piece);
+		}
+	}
+	return (0);
+}
 
 // Consumes a request, up to and including the end of its headers.
 static int
@@ -399,5 +537,28 @@ TestMain("HTTP Client", {
 			So(len == strlen(chunked_body));
 			So(memcmp(data, chunked_body, len) == 0);
 		});
+	});
+
+	Convey("Chunk parser resumes at every boundary", {
+		char        wire[256];
+		const char *chunks;
+		int         i;
+
+		wire[0] = '\0';
+		for (i = 0; chunked_reply[i] != NULL; i++) {
+			So(strlen(wire) + strlen(chunked_reply[i]) <
+			    sizeof(wire));
+			strcat(wire, chunked_reply[i]);
+		}
+		So((chunks = strstr(wire, "\r\n\r\n")) != NULL);
+		chunks += 4; // skip the status line and headers
+
+		So(chunk_check_splits(chunks, chunked_body) == 0);
+		So(chunk_check_splits(chunked_multi, chunked_multi_body) == 0);
+		So(chunk_check_splits(chunked_ext, chunked_ext_body) == 0);
+
+		for (i = 0; chunked_bad[i] != NULL; i++) {
+			So(chunk_check_rejected(chunked_bad[i]) == 0);
+		}
 	});
 })

--- a/tests/httpclient.c
+++ b/tests/httpclient.c
@@ -30,9 +30,86 @@ const uint8_t example_sum[20] = { 0x4a, 0x3c, 0xe8, 0xee, 0x11, 0xe0, 0x91,
 	0xdd, 0x79, 0x23, 0xf4, 0xd8, 0xc6, 0xe5, 0xb5, 0xe4, 0x1e, 0xc7, 0xc0,
 	0x47 };
 
-const uint8_t chunked_sum[20] = { 0x9b, 0x06, 0xfb, 0xee, 0x51, 0xc6, 0x42,
-	0x69, 0x1c, 0xb3, 0xaa, 0x38, 0xce, 0xb8, 0x0b, 0x3a, 0xc8, 0x3b, 0x96,
-	0x68 };
+// The chunked transfer test serves its own response: our HTTP server always
+// emits a Content-Length, and the public demo site this test used to fetch
+// (anglesharp.azurewebsites.net) no longer resolves.  A raw TCP listener
+// lets us hand the client a hand written chunked response instead.
+static const char chunked_body[] = "chunked transfer works fine!!";
+
+// The reply goes out in pieces, each one written separately with Nagle
+// disabled and a short pause in between, so that they land in separate
+// reads.  The split points are deliberately awkward -- inside a header
+// value, between the CR and the LF that ends the headers, inside a chunk
+// size line, inside chunk data, and inside the trailer -- so the parser has
+// to carry state across reads the way it had to when this response still
+// came off the wire from a remote server.  The sizes cover a single digit as
+// well as lower and upper case hex, the first chunk carries a chunk
+// extension, and a trailer field follows the last chunk;
+// nni_http_chunks_parse() handles all of those.
+static const char *chunked_reply[] = {
+	"HTTP/1.1 200 OK\r\nContent-Type: text/pl",
+	"ain\r\nTransfer-Encoding: chunked\r\n\r",
+	"\n8;nng=1\r",
+	"\nchunked ",
+	"\r\na\r\ntransfer w\r\nB\r\norks fine!",
+	"!\r\n0\r\nX-Chunk-Trailer: nng\r",
+	"\n\r\n",
+	NULL,
+};
+
+// Consumes a request, up to and including the end of its headers.
+static int
+raw_read_req(nng_stream *s, nng_aio *aio)
+{
+	char   buf[1024];
+	size_t got = 0;
+
+	while (got < sizeof(buf) - 1) {
+		nng_iov iov;
+		int     rv;
+
+		iov.iov_buf = buf + got;
+		iov.iov_len = sizeof(buf) - 1 - got;
+		if ((rv = nng_aio_set_iov(aio, 1, &iov)) != 0) {
+			return (rv);
+		}
+		nng_stream_recv(s, aio);
+		nng_aio_wait(aio);
+		if ((rv = nng_aio_result(aio)) != 0) {
+			return (rv);
+		}
+		got += nng_aio_count(aio);
+		buf[got] = '\0';
+		if (strstr(buf, "\r\n\r\n") != NULL) {
+			return (0);
+		}
+	}
+	return (NNG_EMSGSIZE);
+}
+
+// Writes the whole buffer, tolerating short sends.
+static int
+raw_write_all(nng_stream *s, nng_aio *aio, const char *data, size_t len)
+{
+	while (len > 0) {
+		nng_iov iov;
+		int     rv;
+
+		iov.iov_buf = (void *) data;
+		iov.iov_len = len;
+		if ((rv = nng_aio_set_iov(aio, 1, &iov)) != 0) {
+			return (rv);
+		}
+		nng_stream_send(s, aio);
+		nng_aio_wait(aio);
+		if ((rv = nng_aio_result(aio)) != 0) {
+			return (rv);
+		}
+		data += nng_aio_count(aio);
+		len -= nng_aio_count(aio);
+	}
+	return (0);
+}
 
 TestMain("HTTP Client", {
 	Convey("Given a TCP connection to example.com", {
@@ -245,47 +322,82 @@ TestMain("HTTP Client", {
 	});
 
 	Convey("Given a client (chunked)", {
-		nng_aio *        aio;
-		nng_http_client *cli;
-		nng_url *        url;
+		nng_aio *            aio;
+		nng_aio *            saio;
+		nng_http_client *    cli;
+		nng_url *            url;
+		nng_stream_listener *l;
+		char                 portbuf[16];
+		char                 urlstr[64];
+		char                 tcpstr[64];
+
+		trantest_next_address(portbuf, "");
+		snprintf(urlstr, sizeof(urlstr), "http://127.0.0.1:%s/Chunked",
+		    portbuf);
+		snprintf(
+		    tcpstr, sizeof(tcpstr), "tcp://127.0.0.1:%s", portbuf);
 
 		So(nng_aio_alloc(&aio, NULL, NULL) == 0);
-
-		So(nng_url_parse(&url,
-		       "http://anglesharp.azurewebsites.net/Chunked") == 0);
-		//		       "https://jigsaw.w3.org/HTTP/ChunkedScript")
-		//== 0);
-
+		So(nng_aio_alloc(&saio, NULL, NULL) == 0);
+		So(nng_url_parse(&url, urlstr) == 0);
+		So(nng_stream_listener_alloc(&l, tcpstr) == 0);
+		So(nng_stream_listener_set_bool(
+		       l, NNG_OPT_TCP_NODELAY, true) == 0);
+		So(nng_stream_listener_listen(l) == 0);
 		So(nng_http_client_alloc(&cli, url) == 0);
-		nng_aio_set_timeout(aio, 10000); // 10 sec timeout
+		nng_aio_set_timeout(aio, 10000);  // 10 sec timeout
+		nng_aio_set_timeout(saio, 10000); // 10 sec timeout
 
 		Reset({
 			nng_http_client_free(cli);
+			nng_stream_listener_free(l);
 			nng_url_free(url);
+			nng_aio_free(saio);
 			nng_aio_free(aio);
 		});
 
 		Convey("One off exchange works", {
 			nng_http_req *req;
 			nng_http_res *res;
+			nng_stream *  s = NULL;
+			const char *  cstr;
 			void *        data;
 			size_t        len;
-			uint8_t       digest[20];
+			int           i;
 
 			So(nng_http_req_alloc(&req, url) == 0);
 			So(nng_http_res_alloc(&res) == 0);
 			Reset({
+				if (s != NULL) {
+					nng_stream_close(s);
+					nng_stream_free(s);
+				}
 				nng_http_req_free(req);
 				nng_http_res_free(res);
 			});
 
 			nng_http_client_transact(cli, req, res, aio);
+
+			nng_stream_listener_accept(l, saio);
+			nng_aio_wait(saio);
+			So(nng_aio_result(saio) == 0);
+			So((s = nng_aio_get_output(saio, 0)) != NULL);
+			So(raw_read_req(s, saio) == 0);
+			for (i = 0; chunked_reply[i] != NULL; i++) {
+				So(raw_write_all(s, saio, chunked_reply[i],
+				       strlen(chunked_reply[i])) == 0);
+				nng_msleep(5);
+			}
+
 			nng_aio_wait(aio);
 			So(nng_aio_result(aio) == 0);
 			So(nng_http_res_get_status(res) == 200);
+			cstr = nng_http_res_get_header(res, "Content-Type");
+			So(cstr != NULL);
+			So(strcmp(cstr, "text/plain") == 0);
 			nng_http_res_get_data(res, &data, &len);
-			nni_sha1(data, len, digest);
-			So(memcmp(digest, chunked_sum, 20) == 0);
+			So(len == strlen(chunked_body));
+			So(memcmp(data, chunked_body, len) == 0);
 		});
 	});
 })


### PR DESCRIPTION
`anglesharp.azurewebsites.net` no longer resolves (NXDOMAIN), so the chunked
transfer test in `nng.httpclient` failed in every build and sanitizer job.

The test now serves the reply itself from a raw `nng_stream_listener` — our HTTP
server always emits a `Content-Length`, so it can't be used here. The client
path is unchanged; the body is now known and compared byte for byte instead of
against the SHA-1 of a third party page (`chunked_sum` goes away).

The reply is written in pieces with Nagle disabled, split inside a header value,
between the CR/LF ending the headers, inside a chunk size line, inside chunk
data and inside the trailer, so `nni_http_chunks_parse()` still has to resume
mid token as it did against the remote server. Also covers single digit plus
lower/upper case chunk sizes, a chunk extension and a trailer field.

**Testing:** passes in the plain, ASan, UBSan and TSan builds. The
`stack-use-after-scope` ASan reports for the first Convey block is pre-existing
(reproduces on `HEAD~`, from convey's `Reset()` unwinding).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved chunked-transfer HTTP testing with a local server that simulates fragmented responses.
  - Added byte-for-byte response validation for more precise verification.
  - Added deterministic coverage for valid and malformed chunked response streams.
  - Removed reliance on an external demo service, making test results more consistent and reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->