### PR TITLE
fixes #1619 OpenSSL TLS server can complete before flushing the final…

### DIFF
--- a/include/nng/protocol/mqtt/mqtt_parser.h
+++ b/include/nng/protocol/mqtt/mqtt_parser.h
@@ -111,7 +111,7 @@ NNG_DECL nng_msg *nano_encode_publish_msg(uint8_t proto_ver, uint8_t qos,
     property *prop, const char *topic, const char *topic_suffix);
 // TODO : check duplicated declaration
 NNG_DECL reason_code check_properties(property *prop, nng_msg *msg);
-NNG_DECL reason_code check_out_pub_properties(property *prop);
+NNG_DECL reason_code sanitize_out_pub_properties(property *prop);
 NNG_DECL property *decode_buf_properties(uint8_t *packet, uint32_t packet_len,
     uint32_t *pos, uint32_t *len, bool copy_value);
 NNG_DECL property *decode_properties(

--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -768,8 +768,8 @@ conn_handler(uint8_t *packet, conn_param *cparam, size_t max)
 	// password
 	if (rv == 0 && (cparam->con_flag & 0x40) > 0) {
 		if (cparam->username.body == NULL) {
-			// log_warn("Got password but no username!");
-			// return PROTOCOL_ERROR;
+			log_warn("Got password but no username!");
+			return PROTOCOL_ERROR;
 		}
 		cparam->password.body =
 		    copyn_utf8_str(packet, &pos, &len_of_str, max-pos);

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -4050,9 +4050,9 @@ property_free(property *prop)
 	return 0;
 }
 
-// Check properties for broker-to-client PUBLISH messages only.
+// Purge all invalid properties for broker-to-client PUBLISH messages only.
 reason_code
-check_out_pub_properties(property *prop)
+sanitize_out_pub_properties(property *prop)
 {
     if (prop == NULL) {
         return SUCCESS;
@@ -4061,68 +4061,108 @@ check_out_pub_properties(property *prop)
     // MQTT 5.0 Property ID up to 0x2A (42)
     bool seen_properties[256] = { false };
 
-    for (property *p1 = prop->next; p1 != NULL; p1 = p1->next) {
-        uint8_t prop_id = p1->id;
+    property *prev = prop;
+    property *curr = prop->next;
 
-        // Check if repeated properties exist
+    while (curr != NULL) {
+        uint8_t prop_id = curr->id;
+        bool is_valid = true;
+
+        // 1. Check for duplicates
+        // USER_PROPERTY and SUBSCRIPTION_IDENTIFIER can appear multiple times
         if (prop_id != USER_PROPERTY && prop_id != SUBSCRIPTION_IDENTIFIER) {
             if (seen_properties[prop_id]) {
-                log_warn("Duplicated property ID: 0x%02X in downstream PUBLISH!", prop_id);
-                return PROTOCOL_ERROR;
+                log_warn("Duplicated property ID: 0x%02X found, marking for removal.", prop_id);
+                is_valid = false;
+            } else {
+                seen_properties[prop_id] = true;
             }
-            seen_properties[prop_id] = true;
         }
 
-        // Validate specific PUBLISH properties
-        switch (prop_id) {
-        case PAYLOAD_FORMAT_INDICATOR: // 0x01
-            if (p1->data.p_value.u8 > 1) {
-                log_warn("Invalid boolean value for property 0x%02X: %d", prop_id, p1->data.p_value.u8);
+        // 2. Strict Whitelist & Value Validation for PUBLISH
+        if (is_valid) {
+            switch (prop_id) {
+            case PAYLOAD_FORMAT_INDICATOR: // 0x01
+                if (curr->data.p_value.u8 > 1) {
+                    log_warn("Invalid boolean value for property 0x%02X: %d", prop_id, curr->data.p_value.u8);
+                    is_valid = false;
+                }
+                break;
+
+            case RESPONSE_TOPIC: // 0x08
+                if (memchr((const char *) curr->data.p_value.str.buf, '+', curr->data.p_value.str.length) != NULL ||
+                    memchr((const char *) curr->data.p_value.str.buf, '#', curr->data.p_value.str.length) != NULL) {
+                    log_warn("RESPONSE_TOPIC contains wildcard!");
+                    is_valid = false;
+                }
+                break;
+
+            case SUBSCRIPTION_IDENTIFIER: // 0x0B
+                if (curr->data.p_value.varint == 0 || curr->data.p_value.varint > 268435455) {
+                    log_info("SUBSCRIPTION_IDENTIFIER invalid value: %d", curr->data.p_value.varint);
+                    is_valid = false;
+                }
+                break;
+
+            case TOPIC_ALIAS: // 0x23
+                if (curr->data.p_value.u16 == 0) {
+                    log_info("TOPIC_ALIAS cannot be 0!");
+                    is_valid = false;
+                }
+                break;
+
+            case MESSAGE_EXPIRY_INTERVAL: // 0x02
+            case CONTENT_TYPE:            // 0x03
+            case CORRELATION_DATA:        // 0x09
+            case USER_PROPERTY:           // 0x26
+                break;
+
+            case WILL_DELAY_INTERVAL:     // 0x18
+                log_info("Removing forbidden Will Delay Interval (0x18) from PUBLISH.");
+                is_valid = false;
+                break;
+
+            default:
+                // Any other property is strictly forbidden in a PUBLISH message
+                log_warn("found invalid property ID: 0x%02X from PUBLISH.", prop_id);
+                is_valid = false;
                 return PROTOCOL_ERROR;
             }
-            break;
+        }
 
-        case RESPONSE_TOPIC: // 0x08
-            if (memchr((const char *) p1->data.p_value.str.buf, '+', p1->data.p_value.str.length) != NULL ||
-                memchr((const char *) p1->data.p_value.str.buf, '#', p1->data.p_value.str.length) != NULL) {
-                log_warn("RESPONSE_TOPIC contains wildcard!");
-                return PROTOCOL_ERROR;
+        // 3. Remove invalid properties from the linked list
+        if (!is_valid) {
+            prev->next = curr->next;
+
+            // Free the memory of the string/binary payload inside the property if necessary
+            switch (curr->data.p_type) {
+            case STR:
+                mqtt_buf_free(&curr->data.p_value.str);
+                break;
+            case BINARY:
+                mqtt_buf_free(&curr->data.p_value.binary);
+                break;
+            case STR_PAIR:
+                mqtt_kv_free(&curr->data.p_value.strpair);
+                break;
+            default:
+                break;
             }
-            break;
 
-        case SUBSCRIPTION_IDENTIFIER: // 0x0B
-            // Broker to Client PUBLISH can contain Sub ID. Must be > 0 and <= 268,435,455.
-            if (p1->data.p_value.varint == 0 || p1->data.p_value.varint > 268435455) {
-                log_warn("SUBSCRIPTION_IDENTIFIER invalid value: %d", p1->data.p_value.varint);
-                return PROTOCOL_ERROR;
-            }
-            break;
+            // Free the node itself
+            free(curr);
 
-        case TOPIC_ALIAS: // 0x23
-            if (p1->data.p_value.u16 == 0) {
-                log_warn("TOPIC_ALIAS cannot be 0!");
-                return TOPIC_ALIAS_INVALID;
-            }
-            break;
-
-        case MESSAGE_EXPIRY_INTERVAL: // 0x02
-        case CONTENT_TYPE:            // 0x03
-        case CORRELATION_DATA:        // 0x09
-        case USER_PROPERTY:           // 0x26
-            // Valid PUBLISH properties that require no specific value bound checks here
-            break;
-
-        default:
-            // Any other property is strictly forbidden in a PUBLISH message
-            log_warn("Invalid property ID for PUBLISH message: 0x%02X!", prop_id);
-            return PROTOCOL_ERROR;
+            // Advance curr without moving prev
+            curr = prev->next;
+        } else {
+            prev = curr;
+            curr = curr->next;
         }
     }
 
     return SUCCESS;
 }
 
-// Check if repeated properties exist, for broker use only.
 // Check if repeated properties exist and validate property bounds, for broker use only.
 // msg as NULL indicates it is a CONNECT aciton
 reason_code

--- a/src/supplemental/mqtt/mqtt_codec.c
+++ b/src/supplemental/mqtt/mqtt_codec.c
@@ -4135,19 +4135,21 @@ sanitize_out_pub_properties(property *prop)
             prev->next = curr->next;
 
             // Free the memory of the string/binary payload inside the property if necessary
-            switch (curr->data.p_type) {
-            case STR:
-                mqtt_buf_free(&curr->data.p_value.str);
-                break;
-            case BINARY:
-                mqtt_buf_free(&curr->data.p_value.binary);
-                break;
-            case STR_PAIR:
-                mqtt_kv_free(&curr->data.p_value.strpair);
-                break;
-            default:
-                break;
-            }
+			if (curr->data.is_copy) {
+				switch (curr->data.p_type) {
+				case STR:
+					mqtt_buf_free(&curr->data.p_value.str);
+					break;
+				case BINARY:
+					mqtt_buf_free(&curr->data.p_value.binary);
+					break;
+				case STR_PAIR:
+					mqtt_kv_free(&curr->data.p_value.strpair);
+					break;
+				default:
+					break;
+				}
+			}
 
             // Free the node itself
             free(curr);

--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -528,10 +528,13 @@ static int
 open_conn_handshake(nng_tls_engine_conn *ec)
 {
 	int rv;
+	int ensz, sz;
+
 	if (ec->ok == 1) {
 		log_warn("handshake is already done");
 		return 0;
 	}
+
 	log_info("Doing handshake ...");
 	rv = SSL_do_handshake(ec->ssl);
 	if (rv != 1) {
@@ -539,21 +542,15 @@ open_conn_handshake(nng_tls_engine_conn *ec)
 		if (rv == SSL_ERROR_WANT_READ || rv == SSL_ERROR_WANT_WRITE) {
 			log_warn("NNG-TLS-CONN-HANDSHAKE"
 				"openssl handshake still in process rv%d", rv);
-			// continue
-		} else if (rv == SSL_ERROR_NONE) {
-			log_warn("NNG-TLS-CONN-HANDSHAKE" "should never reach here");
 		} else {
-			log_warn("NNG-TLS-CONN-HANDSHAKE"
-				"openssl handshake still in process rv%d", rv);
+			log_error("NNG-TLS-CONN-HANDSHAKE"
+				"openssl handshake error %d", rv);
 			ERR_print_errors_fp(stderr);
 			return NNG_ECRYPTO;
 		}
-	} else {
-		goto finished;
 	}
 
 	if (rv == SSL_ERROR_WANT_READ || rv == SSL_ERROR_WANT_WRITE) {
-		int ensz, sz;
 		while ((ensz = open_net_read(ec->tls, ec->wbuf, OPEN_BUF_SZ)) > 0) {
 			sz = BIO_write(ec->rbio, ec->wbuf, ensz);
 			log_warn("NNG-TLS-CONN-HANDSHAKE" "BIO write sz%d/%d", sz, ensz);
@@ -569,76 +566,45 @@ open_conn_handshake(nng_tls_engine_conn *ec)
 				}
 				continue;
 			}
-			rv = SSL_do_handshake(ec->ssl);
-			if (rv != 1) {
-				rv = SSL_get_error(ec->ssl, rv);
-				if (rv == SSL_ERROR_WANT_READ || rv == SSL_ERROR_WANT_WRITE) {
-					continue;
-				} else if (rv == SSL_ERROR_NONE) {
-					log_warn("NNG-TLS-CONN-HANDSHAKE" "should never reach here");
-				} else {
-					log_error("NNG-TLS-CONN-HANDSHAKE"
-						"openssl handshake error %d", rv);
-					ERR_print_errors_fp(stderr);
-					return NNG_ECRYPTO;
-				}
-			} else {
-				goto finished;
-			}
+			SSL_do_handshake(ec->ssl);
 		}
 		if (ensz < 0) {
 			if (ensz != 0 - SSL_ERROR_WANT_READ && ensz != 0 - SSL_ERROR_WANT_WRITE)
 				return (NNG_ECLOSED);
 		}
+	}
 
-		while ((ensz = BIO_read(ec->wbio, ec->rbuf, OPEN_BUF_SZ)) > 0) {
-			log_debug("NNG-TLS-CONN-HANDSHAKE" "BIO read rv%d", ensz);
-			if (ensz < 0) {
-				if (!BIO_should_retry(ec->wbio)) {
-					log_warn("NNG-TLS-CONN-HANDSHAKE"
-						"openssl BIO read failed rv%d", ensz);
-					open_log_ssl_error(
-					    "NNG-TLS-CONN-HANDSHAKE BIO_read", 0);
-					return NNG_ECRYPTO;
-				}
-				continue;
+	while ((ensz = BIO_read(ec->wbio, ec->rbuf, OPEN_BUF_SZ)) > 0) {
+		log_debug("NNG-TLS-CONN-HANDSHAKE" "BIO read rv%d", ensz);
+		if (ensz < 0) {
+			if (!BIO_should_retry(ec->wbio)) {
+				log_warn("NNG-TLS-CONN-HANDSHAKE"
+					"openssl BIO read failed rv%d", ensz);
+				open_log_ssl_error(
+				    "NNG-TLS-CONN-HANDSHAKE BIO_read", 0);
+				return NNG_ECRYPTO;
 			}
-			sz = open_net_write(ec->tls, ec->rbuf, ensz);
-			log_warn("NNG-TLS-CONN-HANDSHAKE" "tcp write want%d real%d", ensz, sz);
-			if (sz == 0 - SSL_ERROR_WANT_READ || sz == 0 - SSL_ERROR_WANT_WRITE)
-				return (NNG_EAGAIN);
-			else if (sz < 0)
-				return (NNG_ECLOSED);
-			rv = SSL_do_handshake(ec->ssl);
-			if (rv != 1) {
-				rv = SSL_get_error(ec->ssl, rv);
-				if (rv == SSL_ERROR_WANT_READ || rv == SSL_ERROR_WANT_WRITE) {
-					continue;
-				} else if (rv == SSL_ERROR_NONE) {
-					log_warn("NNG-TLS-CONN-HANDSHAKE" "should never reach here");
-				} else {
-					log_error("NNG-TLS-CONN-HANDSHAKE"
-						"openssl handshake error %d", rv);
-					ERR_print_errors_fp(stderr);
-					return NNG_ECRYPTO;
-				}
-			} else {
-				goto finished;
-			}
+			continue;
 		}
+		sz = open_net_write(ec->tls, ec->rbuf, ensz);
+		log_warn("NNG-TLS-CONN-HANDSHAKE" "tcp write want%d real%d", ensz, sz);
+		if (sz == 0 - SSL_ERROR_WANT_READ || sz == 0 - SSL_ERROR_WANT_WRITE)
+			return (NNG_EAGAIN);
+		else if (sz < 0)
+			return (NNG_ECLOSED);
+		SSL_do_handshake(ec->ssl);
+	}
+
+	if (!SSL_is_init_finished(ec->ssl)) {
 		log_info("Wait for next handshake ...");
 		return NNG_EAGAIN;
 	}
-	if (rv == SSL_ERROR_NONE) {
-finished:
-		log_warn("NNG-TLS-CONN-HANDSHAKE"
-				"openssl do handshake successfully");
-		g_print_handshake = false;
-		ec->ok = 1;
-		return 0;
-	}
-	open_log_ssl_error("NNG-TLS-CONN-HANDSHAKE SSL_do_handshake", rv);
-	return NNG_ECRYPTO;
+
+	log_warn("NNG-TLS-CONN-HANDSHAKE"
+			"openssl do handshake successfully");
+	g_print_handshake = false;
+	ec->ok = 1;
+	return 0;
 }
 
 static int
@@ -1000,8 +966,11 @@ open_config_ca_chain(
 #else
 	if (certs == NULL) {
 		log_info("open_config_ca_chain" "NULL certs detected!");
+		len = 0;
+	} else {
+		len = strlen(certs);
 	}
-	len = strlen(certs);
+
 #endif //TLS_EXTERN_PRIVATE_KEY
 	log_warn("cacertlen:%d", len);
 
@@ -1373,21 +1342,24 @@ open_config_option(nng_tls_engine_config *cfg, const char *name, void *v, size_t
 		size_t alpn_len = 0;
 		char * alpn_str = NULL;
 		size_t alpn_idx = 0;
-		for (char *proto = alpn_list[0]; proto != NULL; proto = *(++ alpn_list))
-			alpn_len += (1+strlen(proto));
+		for (char **p = alpn_list; *p != NULL; ++p) {
+			size_t proto_len = strlen(*p);
+			if (proto_len == 0 || proto_len > 255) {
+				log_warn("proto length over 255 or eq 0 is NOT supported (%s). Skip", *p);
+				return NNG_EINVAL;
+			}
+			alpn_len += (1 + proto_len);
+		}
 		if (alpn_len == 0)
 			return NNG_EINVAL;
 		if ((alpn_str = nng_alloc(sizeof(char) * (alpn_len + 1))) == NULL)
 			return NNG_ENOMEM;
-		alpn_list = v;
-		for (char *proto = alpn_list[0]; proto != NULL; proto = *(++ alpn_list)){
-			if (strlen(proto) > 255 || strlen(proto) == 0) {
-				log_warn("proto length over 255 or eq 0 is NOT supported (%s). Skip", proto);
-				continue;
-			}
-			alpn_str[alpn_idx++] = (unsigned char)strlen(proto);
-			memcpy(alpn_str + alpn_idx, proto, strlen(proto));
-			alpn_idx += strlen(proto);
+
+		for (char **p = alpn_list; *p != NULL; ++p) {
+			size_t proto_len     = strlen(*p);
+			alpn_str[alpn_idx++] = (unsigned char) proto_len;
+			memcpy(alpn_str + alpn_idx, *p, proto_len);
+			alpn_idx += proto_len;
 		}
 		alpn_str[alpn_idx] = '\0';
 		if (cfg->alpns)

--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -527,110 +527,142 @@ open_conn_close(nng_tls_engine_conn *ec)
 }
 
 static int
+open_flush_wbio(nng_tls_engine_conn *ec)
+{
+	int rv;
+
+	if (ec->wnext != NULL) {
+		char *wnext = ec->wnext;
+		rv = open_net_write(ec->tls, wnext, ec->wnsz);
+		if (rv > 0) {
+			if (rv != ec->wnsz) {
+				int   remain    = ec->wnsz - rv;
+				char *new_wnext = nng_alloc(remain);
+				if (new_wnext == NULL) {
+					return NNG_ENOMEM;
+				}
+				memcpy(new_wnext, wnext + rv, remain);
+				ec->wnext = new_wnext;
+				ec->wnsz  = remain;
+				nng_free(wnext, 0);
+				return NNG_EAGAIN;
+			}
+			nng_free(wnext, 0);
+			ec->wnext = NULL;
+			ec->wnsz  = 0;
+		} else if (rv == 0 - SSL_ERROR_WANT_READ ||
+		    rv == 0 - SSL_ERROR_WANT_WRITE) {
+			return NNG_EAGAIN;
+		} else {
+			return NNG_ECLOSED;
+		}
+	}
+
+	int ensz;
+	while ((ensz = BIO_read(ec->wbio, ec->rbuf, OPEN_BUF_SZ)) > 0) {
+		rv = open_net_write(ec->tls, ec->rbuf, ensz);
+		if (rv > 0) {
+			if (rv != ensz) {
+				int remain = ensz - rv;
+				ec->wnext  = nng_alloc(remain);
+				if (ec->wnext == NULL) {
+					return NNG_ENOMEM;
+				}
+				memcpy(ec->wnext, ec->rbuf + rv, remain);
+				ec->wnsz = remain;
+				return NNG_EAGAIN;
+			}
+		} else if (rv == 0 - SSL_ERROR_WANT_READ ||
+		    rv == 0 - SSL_ERROR_WANT_WRITE) {
+			ec->wnext = nng_alloc(ensz);
+			if (ec->wnext == NULL) {
+				return NNG_ENOMEM;
+			}
+			memcpy(ec->wnext, ec->rbuf, ensz);
+			ec->wnsz = ensz;
+			return NNG_EAGAIN;
+		} else {
+			return NNG_ECLOSED;
+		}
+	}
+
+	return 0;
+}
+
+static int
 open_conn_handshake(nng_tls_engine_conn *ec)
 {
 	int rv;
-	int ensz, sz;
+	int ssl_err;
+	int ensz;
+	int written;
 
 	if (ec->ok == 1) {
-		log_warn("handshake is already done");
 		return 0;
 	}
 
 	log_info("Doing handshake ...");
-	rv = SSL_do_handshake(ec->ssl);
-	if (rv != 1) {
-		rv = SSL_get_error(ec->ssl, rv);
-		if (rv == SSL_ERROR_WANT_READ || rv == SSL_ERROR_WANT_WRITE) {
-			log_warn("NNG-TLS-CONN-HANDSHAKE "
-			         "openssl handshake still in process rv%d",
-			    rv);
-		} else {
-			log_error("NNG-TLS-CONN-HANDSHAKE "
-			          "openssl handshake error %d",
-			    rv);
-			ERR_print_errors_fp(stderr);
-			return NNG_ECRYPTO;
-		}
-	} else {
-		log_warn("NNG-TLS-CONN-HANDSHAKE openssl do handshake "
-		         "successfully");
-		g_print_handshake = false;
-		ec->ok            = 1;
-		return 0;
-	}
 
-	if (rv == SSL_ERROR_WANT_READ || rv == SSL_ERROR_WANT_WRITE) {
-		while (
-		    (ensz = BIO_read(ec->wbio, ec->rbuf, OPEN_BUF_SZ)) > 0) {
-			log_debug("NNG-TLS-CONN-HANDSHAKE "
-			          "BIO read rv%d",
-			    ensz);
-			sz = open_net_write(ec->tls, ec->rbuf, ensz);
-			log_warn("NNG-TLS-CONN-HANDSHAKE "
-			         "tcp write want%d real%d",
-			    ensz, sz);
-
-			if (sz == 0 - SSL_ERROR_WANT_READ ||
-			    sz == 0 - SSL_ERROR_WANT_WRITE) {
-				return (NNG_EAGAIN);
-			} else if (sz < 0) {
-				return (NNG_ECLOSED);
-			}
-
-			SSL_do_handshake(ec->ssl);
-			if (SSL_is_init_finished(ec->ssl)) {
-				goto finished;
-			}
+	for (;;) {
+		rv = open_flush_wbio(ec);
+		if (rv != 0) {
+			return rv;
 		}
 
-		while ((ensz = open_net_read(ec->tls, ec->wbuf, OPEN_BUF_SZ)) >
-		    0) {
-			sz = BIO_write(ec->rbio, ec->wbuf, ensz);
-			log_warn("NNG-TLS-CONN-HANDSHAKE "
-			         "BIO write sz%d/%d",
-			    sz, ensz);
-			if (sz < 0) {
-				log_debug("NNG-TLS-CONN-HANDSHAKE "
-				          "bio write failed %d",
-				    sz);
-				if (!BIO_should_retry(ec->rbio)) {
-					log_warn(
-					    "NNG-TLS-CONN-HANDSHAKE "
-					    "openssl BIO write failed rv%d",
-					    ensz);
-					open_log_ssl_error(
-					    "NNG-TLS-CONN-HANDSHAKE BIO_write",
-					    0);
-					return NNG_ECRYPTO;
+		ERR_clear_error();
+		rv = SSL_do_handshake(ec->ssl);
+
+		int flush_rv = open_flush_wbio(ec);
+
+		if (rv == 1) {
+			log_info("NNG-TLS-CONN-HANDSHAKE", "OpenSSL handshake completed successfully");
+			g_print_handshake = false;
+			ec->ok            = 1;
+			return 0;
+		}
+
+		if (flush_rv != 0 && flush_rv != NNG_EAGAIN) {
+			return flush_rv;
+		}
+
+		ssl_err = SSL_get_error(ec->ssl, rv);
+
+		if (ssl_err == SSL_ERROR_WANT_READ) {
+			int bytes_read = 0;
+			while ((ensz = open_net_read(ec->tls, ec->wbuf, OPEN_BUF_SZ)) > 0) {
+				written = 0;
+				while (written < ensz) {
+					int sz = BIO_write(ec->rbio, ec->wbuf + written, ensz - written);
+					if (sz <= 0) {
+						if (!BIO_should_retry(ec->rbio)) {
+							log_warn("NNG-TLS-CONN-HANDSHAKE", "OpenSSL BIO_write failed");
+							open_log_ssl_error("open_conn_handshake BIO_write", 0);
+							return NNG_ECRYPTO;
+						}
+						break;
+					}
+					written += sz;
 				}
+				bytes_read += ensz;
+			}
+
+			if (bytes_read > 0) {
 				continue;
 			}
 
-			SSL_do_handshake(ec->ssl);
-			if (SSL_is_init_finished(ec->ssl)) {
-				goto finished;
+			if (ensz == 0 - SSL_ERROR_WANT_READ || ensz == 0 - SSL_ERROR_WANT_WRITE) {
+				return NNG_EAGAIN;
+			} else {
+				return NNG_ECLOSED;
 			}
-		}
-
-		if (ensz < 0) {
-			if (ensz != 0 - SSL_ERROR_WANT_READ &&
-			    ensz != 0 - SSL_ERROR_WANT_WRITE) {
-				return (NNG_ECLOSED);
-			}
-		}
-
-		if (!SSL_is_init_finished(ec->ssl)) {
-			log_info("Wait for next handshake ...");
+		} else if (ssl_err == SSL_ERROR_WANT_WRITE) {
 			return NNG_EAGAIN;
+		} else {
+			log_error("NNG-TLS-CONN-HANDSHAKE", "OpenSSL do_handshake failed rv=%d ssl_err=%d", rv, ssl_err);
+			open_log_ssl_error("NNG-TLS-CONN-HANDSHAKE SSL_do_handshake", ssl_err);
+			return NNG_ECRYPTO;
 		}
 	}
-
-finished:
-	log_warn("NNG-TLS-CONN-HANDSHAKE openssl do handshake successfully");
-	g_print_handshake = false;
-	ec->ok            = 1;
-	return 0;
 }
 
 static int

--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -19,6 +19,8 @@
 #include <openssl/crypto.h>
 #include <openssl/x509v3.h>
 
+#include "nng/supplemental/tls/tls.h"
+
 // Follow the suggestion from Sliepen. https://stackoverflow.com/questions/69079419/how-i-can-read-more-than-16384-bytes-using-openssl-tls
 #define OPEN_BUF_SZ 16000
 
@@ -990,10 +992,9 @@ open_config_ca_chain(
 #else
 	if (certs == NULL) {
 		log_info("open_config_ca_chain" "NULL certs detected!");
-		len = 0;
-	} else {
-		len = strlen(certs);
+		return (NNG_EINVAL);
 	}
+	len = strlen(certs);
 
 #endif //TLS_EXTERN_PRIVATE_KEY
 	log_warn("cacertlen:%d", len);
@@ -1329,11 +1330,14 @@ static int
 open_config_version(nng_tls_engine_config *cfg, nng_tls_version min_ver,
     nng_tls_version max_ver)
 {
-	if ((min_ver > max_ver) || (max_ver > NNG_TLS_1_3)) {
+	if ((min_ver < NNG_TLS_1_0) || (min_ver > max_ver) ||
+	    (max_ver > NNG_TLS_1_3)) {
 		return (NNG_ENOTSUP);
 	}
-	// TODO
-	(void) cfg;
+	if (!SSL_CTX_set_min_proto_version(cfg->ctx, min_ver) ||
+	    !SSL_CTX_set_max_proto_version(cfg->ctx, max_ver)) {
+		return (NNG_ECRYPTO);
+	}
 
 	return (0);
 }

--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -658,7 +658,10 @@ open_conn_handshake(nng_tls_engine_conn *ec)
 		} else if (ssl_err == SSL_ERROR_WANT_WRITE) {
 			return NNG_EAGAIN;
 		} else {
-			log_error("NNG-TLS-CONN-HANDSHAKE", "OpenSSL do_handshake failed rv=%d ssl_err=%d", rv, ssl_err);
+			log_error(
+			    "NNG-TLS-CONN-HANDSHAKE"
+			    " OpenSSL do_handshake failed rv=%d ssl_err=%d",
+			    rv, ssl_err);
 			open_log_ssl_error("NNG-TLS-CONN-HANDSHAKE SSL_do_handshake", ssl_err);
 			return NNG_ECRYPTO;
 		}

--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -540,70 +540,94 @@ open_conn_handshake(nng_tls_engine_conn *ec)
 	if (rv != 1) {
 		rv = SSL_get_error(ec->ssl, rv);
 		if (rv == SSL_ERROR_WANT_READ || rv == SSL_ERROR_WANT_WRITE) {
-			log_warn("NNG-TLS-CONN-HANDSHAKE"
-				"openssl handshake still in process rv%d", rv);
+			log_warn("NNG-TLS-CONN-HANDSHAKE "
+			         "openssl handshake still in process rv%d",
+			    rv);
 		} else {
-			log_error("NNG-TLS-CONN-HANDSHAKE"
-				"openssl handshake error %d", rv);
+			log_error("NNG-TLS-CONN-HANDSHAKE "
+			          "openssl handshake error %d",
+			    rv);
 			ERR_print_errors_fp(stderr);
 			return NNG_ECRYPTO;
 		}
+	} else {
+		log_warn("NNG-TLS-CONN-HANDSHAKE openssl do handshake "
+		         "successfully");
+		g_print_handshake = false;
+		ec->ok            = 1;
+		return 0;
 	}
 
 	if (rv == SSL_ERROR_WANT_READ || rv == SSL_ERROR_WANT_WRITE) {
-		while ((ensz = open_net_read(ec->tls, ec->wbuf, OPEN_BUF_SZ)) > 0) {
+		while (
+		    (ensz = BIO_read(ec->wbio, ec->rbuf, OPEN_BUF_SZ)) > 0) {
+			log_debug("NNG-TLS-CONN-HANDSHAKE "
+			          "BIO read rv%d",
+			    ensz);
+			sz = open_net_write(ec->tls, ec->rbuf, ensz);
+			log_warn("NNG-TLS-CONN-HANDSHAKE "
+			         "tcp write want%d real%d",
+			    ensz, sz);
+
+			if (sz == 0 - SSL_ERROR_WANT_READ ||
+			    sz == 0 - SSL_ERROR_WANT_WRITE) {
+				return (NNG_EAGAIN);
+			} else if (sz < 0) {
+				return (NNG_ECLOSED);
+			}
+
+			SSL_do_handshake(ec->ssl);
+			if (SSL_is_init_finished(ec->ssl)) {
+				goto finished;
+			}
+		}
+
+		while ((ensz = open_net_read(ec->tls, ec->wbuf, OPEN_BUF_SZ)) >
+		    0) {
 			sz = BIO_write(ec->rbio, ec->wbuf, ensz);
-			log_warn("NNG-TLS-CONN-HANDSHAKE" "BIO write sz%d/%d", sz, ensz);
+			log_warn("NNG-TLS-CONN-HANDSHAKE "
+			         "BIO write sz%d/%d",
+			    sz, ensz);
 			if (sz < 0) {
-				log_debug("NNG-TLS-CONN-HANDSHAKE"
-					"bio write failed %d", sz);
+				log_debug("NNG-TLS-CONN-HANDSHAKE "
+				          "bio write failed %d",
+				    sz);
 				if (!BIO_should_retry(ec->rbio)) {
-					log_warn("NNG-TLS-CONN-HANDSHAKE"
-						"openssl BIO write failed rv%d", ensz);
+					log_warn(
+					    "NNG-TLS-CONN-HANDSHAKE "
+					    "openssl BIO write failed rv%d",
+					    ensz);
 					open_log_ssl_error(
-					    "NNG-TLS-CONN-HANDSHAKE BIO_write", 0);
+					    "NNG-TLS-CONN-HANDSHAKE BIO_write",
+					    0);
 					return NNG_ECRYPTO;
 				}
 				continue;
 			}
+
 			SSL_do_handshake(ec->ssl);
-		}
-		if (ensz < 0) {
-			if (ensz != 0 - SSL_ERROR_WANT_READ && ensz != 0 - SSL_ERROR_WANT_WRITE)
-				return (NNG_ECLOSED);
-		}
-	}
-
-	while ((ensz = BIO_read(ec->wbio, ec->rbuf, OPEN_BUF_SZ)) > 0) {
-		log_debug("NNG-TLS-CONN-HANDSHAKE" "BIO read rv%d", ensz);
-		if (ensz < 0) {
-			if (!BIO_should_retry(ec->wbio)) {
-				log_warn("NNG-TLS-CONN-HANDSHAKE"
-					"openssl BIO read failed rv%d", ensz);
-				open_log_ssl_error(
-				    "NNG-TLS-CONN-HANDSHAKE BIO_read", 0);
-				return NNG_ECRYPTO;
+			if (SSL_is_init_finished(ec->ssl)) {
+				goto finished;
 			}
-			continue;
 		}
-		sz = open_net_write(ec->tls, ec->rbuf, ensz);
-		log_warn("NNG-TLS-CONN-HANDSHAKE" "tcp write want%d real%d", ensz, sz);
-		if (sz == 0 - SSL_ERROR_WANT_READ || sz == 0 - SSL_ERROR_WANT_WRITE)
-			return (NNG_EAGAIN);
-		else if (sz < 0)
-			return (NNG_ECLOSED);
-		SSL_do_handshake(ec->ssl);
+
+		if (ensz < 0) {
+			if (ensz != 0 - SSL_ERROR_WANT_READ &&
+			    ensz != 0 - SSL_ERROR_WANT_WRITE) {
+				return (NNG_ECLOSED);
+			}
+		}
+
+		if (!SSL_is_init_finished(ec->ssl)) {
+			log_info("Wait for next handshake ...");
+			return NNG_EAGAIN;
+		}
 	}
 
-	if (!SSL_is_init_finished(ec->ssl)) {
-		log_info("Wait for next handshake ...");
-		return NNG_EAGAIN;
-	}
-
-	log_warn("NNG-TLS-CONN-HANDSHAKE"
-			"openssl do handshake successfully");
+finished:
+	log_warn("NNG-TLS-CONN-HANDSHAKE openssl do handshake successfully");
 	g_print_handshake = false;
-	ec->ok = 1;
+	ec->ok            = 1;
 	return 0;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TLS handshake reliability and error reporting during network reads and writes.
  - TLS configuration now validates minimum and maximum protocol versions.
  - Invalid or oversized ALPN protocol entries are rejected consistently.
  - Invalid CA certificate configuration is reported clearly.
  - MQTT CONNECT packets containing a password without a username are rejected.
  - Invalid broker-to-client MQTT PUBLISH properties are removed before delivery, while unknown properties continue to produce a protocol error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->