### PR TITLE
Present the full certificate chain from certfile

### DIFF
--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -91,6 +91,7 @@ print_hex(char *str, const uint8_t *data, size_t len)
 #include <openssl/bio.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#include <openssl/pem.h>
 #if !defined(LIBRESSL_VERSION_NUMBER) && \
     OPENSSL_VERSION_NUMBER >= 0x30000000L
 #define NNG_OPENSSL_HAVE_PKCS11 1
@@ -1137,6 +1138,16 @@ open_config_own_cert(nng_tls_engine_config *cfg, const char *cert,
 			}
 			// ownership transferred to cfg->ctx on success
 		}
+		// PEM_R_NO_START_LINE means we simply ran out of certs;
+		// anything else means a malformed trailing certificate.
+		if (ERR_GET_REASON(ERR_peek_last_error()) !=
+		    PEM_R_NO_START_LINE) {
+			open_log_ssl_error(
+			    "NNG-TLS-CFG-OWNCHAIN PEM_read_bio_X509", 0);
+			rv = NNG_ECRYPTO;
+			goto error;
+		}
+		ERR_clear_error();
 	}
 
 	if (key_pkcs11) {

--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -1118,6 +1118,27 @@ open_config_own_cert(nng_tls_engine_config *cfg, const char *cert,
 		goto error;
 	}
 
+	// certfile may contain intermediate CA certs after the leaf; load
+	// them as the server's own chain (independent of cacertfile/CA store,
+	// which is only for verifying peer certs) so the full chain is
+	// always presented to clients, matching what SSL_CTX_use_certificate
+	// alone does not do.
+	if (biocert != NULL) {
+		X509 *extra;
+		while ((extra = PEM_read_bio_X509(biocert, NULL, 0, NULL)) !=
+		    NULL) {
+			if (SSL_CTX_add_extra_chain_cert(cfg->ctx, extra) ==
+			    0) {
+				log_error("NNG-TLS-CFG-OWNCHAIN"
+				    "Failed to add chain certificate to SSL_CTX");
+				X509_free(extra);
+				rv = NNG_ECRYPTO;
+				goto error;
+			}
+			// ownership transferred to cfg->ctx on success
+		}
+	}
+
 	if (key_pkcs11) {
 		if ((rv = open_load_pkey_from_uri(cfg, key, &pkey)) != 0) {
 			goto error;

--- a/src/supplemental/tls/tls_test.c
+++ b/src/supplemental/tls/tls_test.c
@@ -229,6 +229,31 @@ test_tls_garbled_cert(void)
 }
 
 void
+test_tls_own_cert_trailing_garbage(void)
+{
+	nng_stream_listener *l;
+	nng_tls_config      *c1;
+	char                  certs[4096];
+
+	NUTS_ENABLE_LOG(NNG_LOG_INFO);
+
+	// valid leaf followed by a truncated trailing certificate (no END line)
+	snprintf(certs, sizeof(certs),
+	    "%s"
+	    "-----BEGIN CERTIFICATE-----\n"
+	    "MIIDdzCCAl8CFEzqJgxMn+OTdw7RjLtz8FlhrQ0HMA0GCSqGSIb3DQEBCwUAMHcx\n",
+	    nuts_server_crt);
+
+	NUTS_PASS(nng_stream_listener_alloc(&l, "tls+tcp://127.0.0.1:0"));
+	NUTS_PASS(nng_tls_config_alloc(&c1, NNG_TLS_MODE_SERVER));
+	NUTS_FAIL(nng_tls_config_own_cert(c1, certs, nuts_server_key, NULL),
+	    NNG_ECRYPTO);
+
+	nng_stream_listener_free(l);
+	nng_tls_config_free(c1);
+}
+
+void
 test_tls_psk(void)
 {
 	nng_stream_listener *l;
@@ -539,6 +564,7 @@ TEST_LIST = {
 	{ "tls large message", test_tls_large_message },
 	{ "tls mutual auth", test_tls_mutual_auth },
 	{ "tls garbled cert", test_tls_garbled_cert },
+	{ "tls own cert trailing garbage", test_tls_own_cert_trailing_garbage },
 	{ "tls psk", test_tls_psk },
 	{ "tls psk server identities", test_tls_psk_server_identities },
 	{ "tls psk bad identity", test_tls_psk_bad_identity },


### PR DESCRIPTION
open_config_own_cert() only loaded the first certificate found in certfile (the leaf) via SSL_CTX_use_certificate(); any intermediate CA certificates concatenated after it in the same file were parsed into the BIO and then silently discarded.

The server's outgoing chain would still often look complete, but only because OpenSSL falls back to auto-completing it from whatever is in the verify cert store -- which is populated by cacertfile, a setting whose documented purpose is verifying the *peer's* certificate, not supplying the server's own chain. This made the server's presented chain depend on the (unrelated) cacertfile/verify_peer configuration, and differ between listeners depending on incidental cacertfile content, e.g. a listener with a client-cert-verification-only CA file would accidentally get a complete chain while an otherwise-identical listener without cacertfile configured would present the leaf alone and fail client-side chain validation (verify error 20: unable to get local issuer certificate).

Fix: after loading the leaf certificate, read any remaining certificates out of the same certfile buffer and add them via SSL_CTX_add_extra_chain_cert(), so the server's chain is always fully determined by certfile alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - PEM-based TLS certificates now present the complete certificate chain to clients when additional certificates are included.
  - Errors encountered while loading the certificate chain are reported appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->