### PR TITLE
Add per-listener mount_point support

### DIFF
--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -1659,6 +1659,9 @@ NNG_DECL void  nng_msg_set_conn_param(nng_msg *msg, void *ptr);
 NNG_DECL const char    *conn_param_get_clientid(conn_param *cparam);
 NNG_DECL const uint8_t *conn_param_get_pro_name(conn_param *cparam);
 NNG_DECL const void *   conn_param_get_will_topic(conn_param *cparam);
+NNG_DECL const char    *conn_param_get_mount_point(conn_param *cparam);
+NNG_DECL void           conn_param_set_mount_point(
+              conn_param *cparam, const char *mount_point);
 NNG_DECL const void *   conn_param_get_will_msg(conn_param *cparam);
 NNG_DECL const uint8_t *conn_param_get_username(conn_param *cparam);
 NNG_DECL const uint8_t *conn_param_get_password(conn_param *cparam);

--- a/include/nng/protocol/mqtt/mqtt.h
+++ b/include/nng/protocol/mqtt/mqtt.h
@@ -18,6 +18,8 @@
 
 /* NNG OPTs */
 #define NANO_CONF "nano:conf"
+// per-listener MQTT topic mount_point prefix (char *, borrowed, not copied)
+#define NANO_MOUNT_POINT "nano:mount_point"
 
 
 /* Length defination */

--- a/include/nng/protocol/mqtt/mqtt_parser.h
+++ b/include/nng/protocol/mqtt/mqtt_parser.h
@@ -61,6 +61,11 @@ NNG_DECL int32_t conn_handler(uint8_t *packet, conn_param *conn_param, size_t ma
 NNG_DECL int     conn_param_alloc(conn_param **cparam);
 NNG_DECL void    conn_param_free(conn_param *cparam);
 NNG_DECL void    conn_param_clone(conn_param *cparam);
+// Stamp a per-listener mount_point onto a freshly negotiated conn_param and,
+// when a will message is present, rewrite its topic to the prefixed form.
+// no-op when mount_point is NULL. Only call once, right after conn_handler().
+NNG_DECL void    conn_param_apply_mount_point(
+    conn_param *cparam, const char *mount_point);
 NNG_DECL int     conn_param_ref(conn_param *cparam);
 NNG_DECL int     ws_msg_adaptor(uint8_t *packet, nng_msg *dst);
 

--- a/include/nng/supplemental/nanolib/conf.h
+++ b/include/nng/supplemental/nanolib/conf.h
@@ -86,6 +86,8 @@ struct conf_tls {
 	bool  verify_peer;
 	bool  set_fail; // fail_if_no_peer_cert
 	char *sni;
+	char *name; // listener name, only set for tls_list nodes
+	char *mount_point; // topic prefix applied/stripped for this listener
 };
 
 typedef struct conf_tls conf_tls;
@@ -103,6 +105,8 @@ typedef struct {
 	uint16_t keepcnt;
 	uint16_t sendtimeo;
 	uint16_t recvtimeo;
+	char    *name; // listener name, only set for tcp_list nodes
+	char    *mount_point; // topic prefix applied/stripped for this listener
 } conf_tcp;
 
 typedef struct {
@@ -224,6 +228,7 @@ struct conf_websocket {
 	bool  tls_enable;
 	char *url;     // "nmq-ws://addr:port/path"
 	char *tls_url; // "nmq-wss://addr:port/path"
+	char *mount_point; // topic prefix applied/stripped, shared by ws+wss
 };
 
 typedef struct conf_websocket conf_websocket;

--- a/src/core/message.h
+++ b/src/core/message.h
@@ -111,6 +111,8 @@ struct conn_param {
 	char              *tls_peer_cn;
 	// TLS client certificate subject, used by HTTP auth %d
 	char              *tls_subject;
+	// per-listener topic prefix, NULL when the listener is unmounted
+	char              *mount_point;
 	uint32_t           session_expiry_interval;
 	uint32_t           max_packet_size;
 	uint16_t           rx_max;

--- a/src/nng.c
+++ b/src/nng.c
@@ -2442,6 +2442,24 @@ conn_param_get_pro_name(conn_param *cparam)
 	return (const uint8_t *) cparam->pro_name.body;
 }
 
+const char *
+conn_param_get_mount_point(conn_param *cparam)
+{
+	return (const char *) cparam->mount_point;
+}
+
+void
+conn_param_set_mount_point(conn_param *cparam, const char *mount_point)
+{
+	if (cparam->mount_point) {
+		nng_strfree(cparam->mount_point);
+		cparam->mount_point = NULL;
+	}
+	if (mount_point != NULL) {
+		cparam->mount_point = nng_strdup(mount_point);
+	}
+}
+
 const void *
 conn_param_get_will_topic(conn_param *cparam)
 {

--- a/src/sp/protocol/mqtt/mqtt_parser.c
+++ b/src/sp/protocol/mqtt/mqtt_parser.c
@@ -885,6 +885,7 @@ conn_param_init(conn_param *cparam)
 	memset(cparam->server_port, '\0', 8);
 	cparam->tls_peer_cn = NULL;
 	cparam->tls_subject = NULL;
+	cparam->mount_point = NULL;
 
 	// MQTT_v5 Variable header
 	cparam->session_expiry_interval = 0;
@@ -952,6 +953,10 @@ conn_param_free(conn_param *cparam)
 		nng_strfree(cparam->tls_subject);
 		cparam->tls_subject = NULL;
 	}
+	if (cparam->mount_point) {
+		nng_strfree(cparam->mount_point);
+		cparam->mount_point = NULL;
+	}
 
 	property_free(cparam->properties);
 	property_free(cparam->will_properties);
@@ -978,6 +983,35 @@ conn_param_clone(conn_param *cparam)
 	}
 	nni_atomic_inc(&cparam->refcnt);
 	log_trace("%p is cloned!! %d", cparam, nni_atomic_get(&cparam->refcnt));
+}
+
+void
+conn_param_apply_mount_point(conn_param *cparam, const char *mount_point)
+{
+	size_t mp_len, new_len;
+	char  *body;
+
+	if (cparam == NULL || mount_point == NULL || mount_point[0] == '\0') {
+		return;
+	}
+	cparam->mount_point = nng_strdup(mount_point);
+
+	if (!cparam->will_flag || cparam->will_topic.body == NULL) {
+		return;
+	}
+	mp_len  = strlen(mount_point);
+	new_len = mp_len + 1 + cparam->will_topic.len;
+	if ((body = nng_alloc(new_len + 1)) == NULL) {
+		return;
+	}
+	memcpy(body, mount_point, mp_len);
+	body[mp_len] = '/';
+	memcpy(body + mp_len + 1, cparam->will_topic.body,
+	    cparam->will_topic.len);
+	body[new_len] = '\0';
+	nng_free(cparam->will_topic.body, cparam->will_topic.len);
+	cparam->will_topic.body = body;
+	cparam->will_topic.len  = (uint32_t) new_len;
 }
 
 /* Fowler/Noll/Vo (FNV) hash function, variant 1a */

--- a/src/sp/transport/mqtt/broker_tcp.c
+++ b/src/sp/transport/mqtt/broker_tcp.c
@@ -32,6 +32,7 @@ struct tcptran_pipe {
 	nng_stream *conn;
 	nni_pipe   *npipe; // for statitical
 	conf       *conf;
+	char       *mount_point; // borrowed from ep->mount_point, may be NULL
 	// uint16_t        peer;		//reserved for MQTT sdk version
 	size_t          rcvmax; // duplicate with conf->max_packet_size
 	size_t          gotrxhead;
@@ -70,6 +71,7 @@ struct tcptran_ep {
 	nng_url             *url;
 	nng_sockaddr         src;
 	conf                *conf;
+	char                *mount_point; // per-listener topic prefix, may be NULL
 	int                  refcnt; // active pipes
 	nni_aio             *useraio;
 	nni_aio             *connaio;
@@ -295,6 +297,7 @@ tcptran_ep_match(tcptran_ep *ep)
 	ep->useraio = NULL;
 	p->rcvmax   = ep->rcvmax;
 	p->conf     = ep->conf;
+	p->mount_point = ep->mount_point;
 	nni_aio_set_output(aio, 0, p);
 	// which triggers tcptran_ep_accept
 	nni_aio_finish(aio, 0, 0);
@@ -416,6 +419,8 @@ tcptran_pipe_nego_cb(void *arg)
 			nni_list_append(&ep->waitpipes, p);
 			// Match happens before accept_cb. Make pipe id ready
 			tcptran_ep_match(ep);
+			// ep_match just copied ep->mount_point into p->mount_point
+			conn_param_apply_mount_point(p->tcp_cparam, p->mount_point);
 			nni_mtx_unlock(&ep->mtx);
 			return;
 		} else {
@@ -2051,6 +2056,19 @@ tcptran_ep_set_conf(void *arg, const void *v, size_t sz, nni_opt_type t)
 }
 
 static int
+tcptran_ep_set_mount_point(void *arg, const void *v, size_t sz, nni_opt_type t)
+{
+	tcptran_ep *ep = arg;
+	NNI_ARG_UNUSED(sz);
+	NNI_ARG_UNUSED(t);
+
+	nni_mtx_lock(&ep->mtx);
+	ep->mount_point = (char *) v;
+	nni_mtx_unlock(&ep->mtx);
+	return 0;
+}
+
+static int
 tcptran_ep_get_recvmaxsz(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
 	tcptran_ep *ep = arg;
@@ -2219,6 +2237,10 @@ static const nni_option tcptran_ep_opts[] = {
 	{
 	    .o_name = NANO_CONF,
 	    .o_set  = tcptran_ep_set_conf,
+	},
+	{
+	    .o_name = NANO_MOUNT_POINT,
+	    .o_set  = tcptran_ep_set_mount_point,
 	},
 	// terminate list
 	{

--- a/src/sp/transport/mqtts/broker_tls.c
+++ b/src/sp/transport/mqtts/broker_tls.c
@@ -33,6 +33,7 @@ struct tlstran_pipe {
 	nng_stream *conn;
 	nni_pipe   *npipe; // for statitical
 	conf       *conf;
+	char       *mount_point; // borrowed from ep->mount_point, may be NULL
 	size_t          rcvmax; // duplicate with conf->max_packet_size
 	size_t          gotrxhead;
 	size_t          wantrxhead;
@@ -72,6 +73,7 @@ struct tlstran_ep {
 	nng_url             *url;
 	nng_sockaddr         src;
 	conf                *conf;
+	char                *mount_point; // per-listener topic prefix, may be NULL
 	nng_sockaddr         sa;
 	int                  refcnt; // active pipes
 	int                  authmode;
@@ -305,6 +307,7 @@ tlstran_ep_match(tlstran_ep *ep)
 	ep->useraio = NULL;
 	p->rcvmax   = ep->rcvmax;
 	p->conf     = ep->conf;
+	p->mount_point = ep->mount_point;
 	nni_aio_set_output(aio, 0, p);
 	nni_aio_finish(aio, 0, 0);
 }
@@ -412,6 +415,7 @@ tlstran_pipe_nego_cb(void *arg)
 			nni_list_append(&ep->waitpipes, p);
 			tlstran_ep_match(ep);
 			// connection packet handled successfully. clone it for protocol or app layer
+			conn_param_apply_mount_point(p->tcp_cparam, p->mount_point);
 			conn_param_clone(p->tcp_cparam);
 			// Connection is accepted.
 			p->pro_ver = p->tcp_cparam->pro_ver;
@@ -2109,6 +2113,19 @@ tlstran_ep_set_conf(void *arg, const void *v, size_t sz, nni_opt_type t)
 }
 
 static int
+tlstran_ep_set_mount_point(void *arg, const void *v, size_t sz, nni_opt_type t)
+{
+	tlstran_ep *ep = arg;
+	NNI_ARG_UNUSED(sz);
+	NNI_ARG_UNUSED(t);
+
+	nni_mtx_lock(&ep->mtx);
+	ep->mount_point = (char *) v;
+	nni_mtx_unlock(&ep->mtx);
+	return 0;
+}
+
+static int
 tlstran_ep_get_recvmaxsz(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
 	tlstran_ep *ep = arg;
@@ -2278,6 +2295,10 @@ static const nni_option tlstran_ep_opts[] = {
 	{
 	    .o_name = NANO_CONF,
 	    .o_set  = tlstran_ep_set_conf,
+	},
+	{
+	    .o_name = NANO_MOUNT_POINT,
+	    .o_set  = tlstran_ep_set_mount_point,
 	},
 	// terminate list
 	{

--- a/src/sp/transport/mqttws/nmq_websocket.c
+++ b/src/sp/transport/mqttws/nmq_websocket.c
@@ -73,6 +73,7 @@ ws_parse_remaining_length(const uint8_t *buf, size_t avail, uint8_t *pos,
 struct ws_listener {
 	uint16_t             peer; // remote protocol
 	conf                *conf;
+	char                *mount_point; // per-listener topic prefix, may be NULL
 	nni_list             aios;
 	nni_mtx              mtx;
 	nni_aio             *accaio;
@@ -92,6 +93,7 @@ struct ws_pipe {
 	nni_lmq     recvlmq;
 	nni_lmq     rslmq;	// Only for QoS msg ack cache
 	conf       *conf;
+	char       *mount_point; // borrowed from ws_listener->mount_point, may be NULL
 	nni_msg    *tmp_msg;	// Serving as recv buffer, convergence all msg from nng ws
 	nni_aio    *user_txaio;
 	nni_aio    *user_rxaio;
@@ -411,6 +413,7 @@ done:
 			goto skip;
 		}
 		log_trace("MQTT Clientid is %s", p->ws_param->clientid.body);
+		conn_param_apply_mount_point(p->ws_param, p->mount_point);
 		conn_param_clone(p->ws_param);
 		if (p->ws_param->pro_ver == MQTT_PROTOCOL_VERSION_v5) {
 			p->qsend_quota = p->ws_param->rx_max;
@@ -1707,6 +1710,7 @@ ws_pipe_start(ws_pipe *pipe, nng_stream *conn, ws_listener *l)
 	log_trace("ws_pipe_start!");
 	p->qrecv_quota = NANO_MAX_QOS_PACKET;
 	p->conf        = l->conf;
+	p->mount_point = l->mount_point;
 	nni_atomic_set_bool(&p->closed, false);
 	nng_stream_recv(p->ws, p->rxaio);
 }
@@ -1807,10 +1811,26 @@ wstran_ep_set_conf(void *arg, const void *v, size_t sz, nni_type t)
 	return 0;
 }
 
+static int
+wstran_ep_set_mount_point(void *arg, const void *v, size_t sz, nni_type t)
+{
+	ws_listener *l = arg;
+	NNI_ARG_UNUSED(sz);
+	NNI_ARG_UNUSED(t);
+	nni_mtx_lock(&l->mtx);
+	l->mount_point = (char *) v;
+	nni_mtx_unlock(&l->mtx);
+	return 0;
+}
+
 static const nni_option wstran_ep_opts[] = {
 	{
 	    .o_name = NANO_CONF,
 	    .o_set  = wstran_ep_set_conf,
+	},
+	{
+	    .o_name = NANO_MOUNT_POINT,
+	    .o_set  = wstran_ep_set_mount_point,
 	},
 	// terminate list
 	{

--- a/src/supplemental/nanolib/conf.c
+++ b/src/supplemental/nanolib/conf.c
@@ -810,6 +810,8 @@ conf_tls_init(conf_tls *tls)
 	tls->key_password = NULL;
 	tls->set_fail     = false;
 	tls->verify_peer  = false;
+	tls->name         = NULL;
+	tls->mount_point  = NULL;
 }
 
 void
@@ -846,6 +848,14 @@ conf_tls_destroy(conf_tls *tls)
 	if (tls->ca) {
 		free(tls->ca);
 		tls->ca = NULL;
+	}
+	if (tls->name) {
+		free(tls->name);
+		tls->name = NULL;
+	}
+	if (tls->mount_point) {
+		free(tls->mount_point);
+		tls->mount_point = NULL;
 	}
 }
 
@@ -4718,6 +4728,14 @@ conf_tcp_node_destroy(conf_tcp *node)
 		free(node->url);
 		node->url = NULL;
 	}
+	if (node->name) {
+		free(node->name);
+		node->name = NULL;
+	}
+	if (node->mount_point) {
+		free(node->mount_point);
+		node->mount_point = NULL;
+	}
 }
 
 static void
@@ -4873,6 +4891,7 @@ conf_fini(conf *nanomq_conf)
 	nng_strfree(nanomq_conf->hook_ipc_url);
 	nng_strfree(nanomq_conf->cmd_ipc_url);
 	nng_strfree(nanomq_conf->websocket.tls_url);
+	nng_strfree(nanomq_conf->websocket.mount_point);
 
 	conf_http_server_destroy(&nanomq_conf->http_server);
 

--- a/src/supplemental/nanolib/conf_ver2.c
+++ b/src/supplemental/nanolib/conf_ver2.c
@@ -58,6 +58,61 @@ static enum_map http_server_auth_type[] = {
 
 cJSON *hocon_get_obj(char *key, cJSON *jso);
 
+// mount_point must be non-empty, contain no '+'/'#', and not start with '$'
+// (leading '$' would make the mounted tree unreachable via '#' subscriptions,
+// see MQTT-3.1.1 4.7.2). Unset (NULL) is always valid.
+static bool
+mount_point_is_valid(const char *mp)
+{
+	if (mp == NULL) {
+		return true;
+	}
+	if (mp[0] == '\0' || mp[0] == '$') {
+		return false;
+	}
+	return strchr(mp, '+') == NULL && strchr(mp, '#') == NULL;
+}
+
+// Validate every configured mount_point before any listener is opened.
+// Exits non-zero naming the first offending listener (tcp/ssl/ws in that order).
+static void
+conf_mount_point_validate(conf *config)
+{
+	size_t i;
+
+	for (i = 0; i < config->tcp_list.count; i++) {
+		conf_tcp *node = config->tcp_list.nodes[i];
+		if (!mount_point_is_valid(node->mount_point)) {
+			log_error("Invalid mount_point '%s' on listener "
+			    "'%s': must be non-empty, must not contain '+' "
+			    "or '#', and must not start with '$'",
+			    node->mount_point ? node->mount_point : "",
+			    node->name ? node->name : "tcp");
+			exit(EXIT_FAILURE);
+		}
+	}
+	for (i = 0; i < config->tls_list.count; i++) {
+		conf_tls *node = config->tls_list.nodes[i];
+		if (!mount_point_is_valid(node->mount_point)) {
+			log_error("Invalid mount_point '%s' on listener "
+			    "'%s': must be non-empty, must not contain '+' "
+			    "or '#', and must not start with '$'",
+			    node->mount_point ? node->mount_point : "",
+			    node->name ? node->name : "ssl");
+			exit(EXIT_FAILURE);
+		}
+	}
+	if (!mount_point_is_valid(config->websocket.mount_point)) {
+		log_error("Invalid mount_point '%s' on listener 'ws': must "
+		    "be non-empty, must not contain '+' or '#', and must "
+		    "not start with '$'",
+		    config->websocket.mount_point
+		        ? config->websocket.mount_point
+		        : "");
+		exit(EXIT_FAILURE);
+	}
+}
+
 // Read json value into struct
 // use same struct fields and json keys
 #define hocon_read_str_base(structure, field, key, jso)                       \
@@ -405,6 +460,8 @@ conf_basic_parse_ver2(conf *config, cJSON *jso)
 			    node, url, "bind", "nmq-tcp://", tcp_node);
 			hocon_read_bool_base(node, enable, "enable", tcp_node);
 			if (node->url) {
+				node->name = nng_strdup(tcp_node->string);
+				hocon_read_str(node, mount_point, tcp_node);
 				cvector_push_back(
 				    config->tcp_list.nodes, node);
 			} else {
@@ -422,6 +479,7 @@ conf_basic_parse_ver2(conf *config, cJSON *jso)
 		} else {
 			hocon_read_address_base(websocket, url, "bind",
 			    "nmq-ws://", jso_websocket);
+			hocon_read_str(websocket, mount_point, jso_websocket);
 			websocket->enable = true;
 		}
 
@@ -432,6 +490,10 @@ conf_basic_parse_ver2(conf *config, cJSON *jso)
 			if (jso_websocket_tls != NULL) {
 				hocon_read_address_base(websocket, tls_url,
 				    "bind", "nmq-wss://", jso_websocket_tls);
+				if (websocket->mount_point == NULL) {
+					hocon_read_str(websocket, mount_point,
+					    jso_websocket_tls);
+				}
 			}
 			websocket->tls_enable = true;
 		}
@@ -539,6 +601,8 @@ conf_tls_parse_ver2(conf *config, cJSON *jso)
 		hocon_read_address_base(
 		    node, url, "bind", "tls+nmq-tcp://", node_item);
 		if (node->url) {
+			node->name = nng_strdup(node_item->string);
+			hocon_read_str(node, mount_point, node_item);
 			conf_tls_parse_ver2_base(node, node_item);
 			hocon_read_bool(node, verify_peer, node_item);
 			hocon_read_bool_base(
@@ -2139,6 +2203,7 @@ conf_parse_ver2(conf *config, bool is_reload)
 		conf_set_threads(config);
 		conf_sqlite_parse_ver2(config, jso);
 		conf_tls_parse_ver2(config, jso);
+		conf_mount_point_validate(config);
 #if defined(ENABLE_LOG)
 		conf_log_parse_ver2(config, jso);
 #endif


### PR DESCRIPTION
Add a per-listener mount_point string that flows: HOCON config ->
conf_tcp/conf_tls/conf_websocket struct field -> a new NANO_MOUNT_POINT nng_listener option (mirrors the existing NANO_CONF option) -> copied into each transport's endpoint (ep) struct -> copied into each new pipe (p->mount_point) at pipe-match time -> stamped onto the pipe's conn_param (cparam->mount_point, an owned copy) right after the CONNECT packet is parsed via the new conn_param_apply_mount_point().

This lets multiple tenants/apps share one broker's topic tree without collision: SUBSCRIBE/UNSUBSCRIBE filters and PUBLISH topics get the publishing/subscribing client's own mount_point prepended on ingress; PUBLISH delivery (and retained-message delivery on SUBSCRIBE) strip the recipient's own mount_point on egress. $SYS topics/filters always bypass both directions, and $share/<group>/ shared-subscription filters get the mount_point inserted after the group name.

Startup validation (conf_mount_point_validate()) rejects empty mount_points, leading $, or +/# wildcards.

This is the NNG-side (transport/config/conn_param plumbing) of the feature; the matching nanomq/ (broker application) call sites and topic-rewrite logic are on the identically-named branch drp3pp3r/listener-mount-point in the nanomq repo.

