### PR TITLE
Implement peer_cn/peer_subject for the OpenSSL TLS engine

### DIFF
--- a/src/supplemental/tls/openssl/openssl.c
+++ b/src/supplemental/tls/openssl/openssl.c
@@ -572,6 +572,71 @@ open_conn_verified(nng_tls_engine_conn *ec)
 	return (X509_V_OK == rv);
 }
 
+// SSL_get1_peer_certificate() replaces the deprecated SSL_get_peer_certificate()
+// in OpenSSL 3.0; both return a reference the caller must release with X509_free().
+static X509 *
+open_conn_get_peer_cert(nng_tls_engine_conn *ec)
+{
+#if OPENSSL_VERSION_MAJOR < 3
+	return (SSL_get_peer_certificate(ec->ssl));
+#else
+	return (SSL_get1_peer_certificate(ec->ssl));
+#endif
+}
+
+static char *
+open_conn_peer_cn(nng_tls_engine_conn *ec)
+{
+	X509 *cert = open_conn_get_peer_cert(ec);
+	if (cert == NULL) {
+		return (NULL);
+	}
+
+	char buf[256];
+	int  len = X509_NAME_get_text_by_NID(
+	    X509_get_subject_name(cert), NID_commonName, buf, sizeof(buf));
+	X509_free(cert);
+	if (len <= 0) {
+		return (NULL);
+	}
+
+	char *rv = malloc((size_t) len + 1);
+	if (rv == NULL) {
+		return (NULL);
+	}
+	memcpy(rv, buf, (size_t) len + 1);
+	return (rv);
+}
+
+static char *
+open_conn_peer_subject(nng_tls_engine_conn *ec)
+{
+	X509 *cert = open_conn_get_peer_cert(ec);
+	if (cert == NULL) {
+		return (NULL);
+	}
+
+	BIO *bio = BIO_new(BIO_s_mem());
+	if (bio == NULL) {
+		X509_free(cert);
+		return (NULL);
+	}
+
+	char *rv = NULL;
+	if (X509_NAME_print_ex(bio, X509_get_subject_name(cert), 0,
+	        XN_FLAG_RFC2253) > 0) {
+		char *data;
+		long  len = BIO_get_mem_data(bio, &data);
+		if (len > 0 && (rv = malloc((size_t) len + 1)) != NULL) {
+			memcpy(rv, data, (size_t) len);
+			rv[len] = '\0';
+		}
+	}
+	BIO_free(bio);
+	X509_free(cert);
+	return (rv);
+}
+
 /************************* SSL Configuration ***********************/
 
 static void
@@ -1197,14 +1262,16 @@ static nng_tls_engine_config_ops open_config_ops = {
 };
 
 static nng_tls_engine_conn_ops open_conn_ops = {
-	.size      = sizeof(nng_tls_engine_conn),
-	.init      = open_conn_init,
-	.fini      = open_conn_fini,
-	.close     = open_conn_close,
-	.recv      = open_conn_recv,
-	.send      = open_conn_send,
-	.handshake = open_conn_handshake,
-	.verified  = open_conn_verified,
+	.size         = sizeof(nng_tls_engine_conn),
+	.init         = open_conn_init,
+	.fini         = open_conn_fini,
+	.close        = open_conn_close,
+	.recv         = open_conn_recv,
+	.send         = open_conn_send,
+	.handshake    = open_conn_handshake,
+	.verified     = open_conn_verified,
+	.peer_cn      = open_conn_peer_cn,
+	.peer_subject = open_conn_peer_subject,
 };
 
 static nng_tls_engine open_engine = {


### PR DESCRIPTION
http_auth's %C (client certificate Common Name) and %d (client certificate Subject) placeholders in downstream nanomq were always substituted as empty, even with a verified client certificate presenting a Common Name.

Root cause: nanomq's conn_param already carries tls_peer_cn/ tls_subject, correctly populated via the generic
NNG_OPT_TLS_PEER_CN/NNG_OPT_TLS_PEER_SUBJECT pipe options -- which are routed through the active TLS engine's nng_tls_engine_conn_ops table (tls_common.c's tls_get_peer_cn()/tls_get_peer_subject() return NNG_ENOTSUP whenever ops.peer_cn/ops.peer_subject are NULL). This OpenSSL engine's open_conn_ops never implemented either callback -- unlike the mbedtls engine, which has working conn_peer_cn()/ conn_peer_subject() implementations.

Fix: implement open_conn_peer_cn()/open_conn_peer_subject() using the already-verified peer certificate (SSL_get_peer_certificate() on OpenSSL < 3, SSL_get1_peer_certificate() on OpenSSL >= 3), extracting the Common Name via the dedicated X509_NAME_get_text_by_NID() lookup and the full Subject DN via X509_NAME_print_ex() with RFC2253 formatting, and wire both into open_conn_ops.

